### PR TITLE
Changed Bolt Pistol and Other from boltgun to Bolt Pistol

### DIFF
--- a/Chaos - Death Guard.cat
+++ b/Chaos - Death Guard.cat
@@ -2028,7 +2028,7 @@
                   <profiles/>
                   <rules/>
                   <infoLinks>
-                    <infoLink id="0674-f50a-d688-a617" hidden="false" targetId="3d4b-95ea-f860-dd22" type="profile">
+                    <infoLink id="0674-f50a-d688-a617" name="Bolt pistol" hidden="false" targetId="e6d5-677a-d8ed-f6a5" type="profile">
                       <profiles/>
                       <rules/>
                       <infoLinks/>


### PR DESCRIPTION
DeathGuard - Plague Marines - Plague Champion - Weapon Layout option Bolt Pistol and Other.

Changed Bolt Pistol and Other from boltgun to Bolt Pistol

DeathGuard Weapon Layout update, Fixes #680