### PR TITLE
BA v12 - bugfixes

### DIFF
--- a/Imperium - Blood Angels.cat
+++ b/Imperium - Blood Angels.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="eb0f-c144-a282-8bdc" name="Imperium - Blood Angels" book="Index: Imperium 1" revision="11" battleScribeVersion="2.01" authorName="Crowbar90" gameSystemId="28ec-711c-d87f-3aeb" gameSystemRevision="1" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="eb0f-c144-a282-8bdc" name="Imperium - Blood Angels" book="Index: Imperium 1" revision="12" battleScribeVersion="2.01" authorName="Crowbar90" gameSystemId="28ec-711c-d87f-3aeb" gameSystemRevision="1" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <profiles/>
   <rules/>
   <infoLinks/>
@@ -8871,13 +8871,14 @@
           </constraints>
           <categoryLinks/>
         </entryLink>
-        <entryLink id="5d7e-1036-8ad7-d34d" name="New EntryLink" hidden="false" targetId="d74a-2fee-abea-1b42" type="selectionEntry">
+        <entryLink id="5d7e-1036-8ad7-d34d" name="Storm bolter" hidden="false" targetId="d74a-2fee-abea-1b42" type="selectionEntry">
           <profiles/>
           <rules/>
           <infoLinks/>
           <modifiers/>
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d9cb-9e16-c520-9093" type="max"/>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d9cb-9e16-c520-9093" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bcd3-e84f-d6f3-078e" type="min"/>
           </constraints>
           <categoryLinks/>
         </entryLink>
@@ -9877,43 +9878,7 @@
               </constraints>
               <categoryLinks/>
               <selectionEntries/>
-              <selectionEntryGroups>
-                <selectionEntryGroup id="c5b7-9bb7-8340-9086" name="Heavy weapon" hidden="false" collective="false">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                  <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ac36-ce40-a308-f20b" type="max"/>
-                    <constraint field="selections" scope="76e4-ef9b-a5fc-8864" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" id="b792-3840-7a82-c4c0" type="max"/>
-                  </constraints>
-                  <categoryLinks/>
-                  <selectionEntries/>
-                  <selectionEntryGroups/>
-                  <entryLinks>
-                    <entryLink id="6f30-0c3f-e63a-6d75" name="New EntryLink" hidden="false" targetId="290a-8ad2-2af9-5ebc" type="selectionEntry">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks/>
-                      <modifiers/>
-                      <constraints>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f20d-8b6d-0a7b-5a6d" type="max"/>
-                      </constraints>
-                      <categoryLinks/>
-                    </entryLink>
-                    <entryLink id="59ff-aa02-f585-9c40" name="New EntryLink" hidden="false" targetId="96f3-141e-f073-d314" type="selectionEntry">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks/>
-                      <modifiers/>
-                      <constraints>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8961-91b5-074e-0b87" type="max"/>
-                      </constraints>
-                      <categoryLinks/>
-                    </entryLink>
-                  </entryLinks>
-                </selectionEntryGroup>
-              </selectionEntryGroups>
+              <selectionEntryGroups/>
               <entryLinks>
                 <entryLink id="95a5-48b7-9422-e6a7" name="New EntryLink" hidden="false" targetId="8e23-a2e7-23c4-cac7" type="selectionEntry">
                   <profiles/>
@@ -9935,7 +9900,7 @@
                   </constraints>
                   <categoryLinks/>
                 </entryLink>
-                <entryLink id="ce15-fe41-7227-c024" name="New EntryLink" hidden="false" targetId="9ccd-823b-e317-5e31" type="selectionEntry">
+                <entryLink id="ce15-fe41-7227-c024" name="Astartes shotgun" hidden="false" targetId="9ccd-823b-e317-5e31" type="selectionEntry">
                   <profiles/>
                   <rules/>
                   <infoLinks/>
@@ -10442,74 +10407,468 @@
           <categoryLinks/>
           <selectionEntries/>
           <selectionEntryGroups>
-            <selectionEntryGroup id="b75a-9006-cb6b-b316" name="Weapons" hidden="false" collective="false" defaultSelectionEntryId="38d9-7fd6-c6e7-089e">
+            <selectionEntryGroup id="b75a-9006-cb6b-b316" name="Bolt pistol arm" hidden="false" collective="false" defaultSelectionEntryId="f96e-1853-0324-b999">
               <profiles/>
               <rules/>
               <infoLinks/>
-              <modifiers>
-                <modifier type="set" field="8d56-59be-4cd3-4cf6" value="1">
-                  <repeats/>
-                  <conditions>
-                    <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="38d9-7fd6-c6e7-089e" type="equalTo"/>
-                  </conditions>
-                  <conditionGroups/>
-                </modifier>
-              </modifiers>
+              <modifiers/>
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="563d-d37c-5f40-cde2" type="min"/>
-                <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="8d56-59be-4cd3-4cf6" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="8d56-59be-4cd3-4cf6" type="max"/>
               </constraints>
               <categoryLinks/>
-              <selectionEntries>
-                <selectionEntry id="38d9-7fd6-c6e7-089e" name="Bolt pistol and special issue boltgun" hidden="false" collective="false" type="upgrade">
+              <selectionEntries/>
+              <selectionEntryGroups>
+                <selectionEntryGroup id="ae97-d943-3f82-11bd" name="Sergeant equipment" hidden="false" collective="false">
                   <profiles/>
                   <rules/>
                   <infoLinks/>
                   <modifiers/>
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3415-99aa-8386-83f0" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="980e-0d66-3685-0ff4" type="max"/>
                   </constraints>
                   <categoryLinks/>
                   <selectionEntries/>
-                  <selectionEntryGroups/>
-                  <entryLinks>
-                    <entryLink id="837f-67c3-d098-a02a" name="New EntryLink" hidden="false" targetId="0367-b42c-b6b4-0a58" type="selectionEntry">
+                  <selectionEntryGroups>
+                    <selectionEntryGroup id="6b00-fac4-d99b-3998" name="One-handed" hidden="false" collective="false">
                       <profiles/>
                       <rules/>
                       <infoLinks/>
                       <modifiers/>
                       <constraints>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5b03-a826-2b56-e4f4" type="min"/>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3c61-64c7-888a-f573" type="max"/>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6362-628c-de42-ee68" type="max"/>
                       </constraints>
                       <categoryLinks/>
-                    </entryLink>
-                    <entryLink id="5845-856e-f7bf-e9f0" name="New EntryLink" hidden="false" targetId="ac47-fbfd-4381-3191" type="selectionEntry">
+                      <selectionEntries/>
+                      <selectionEntryGroups/>
+                      <entryLinks>
+                        <entryLink id="60ac-44f6-d6b3-d7c0" name="Plasma pistol" hidden="false" targetId="b333-4c80-2f72-6b45" type="selectionEntry">
+                          <profiles/>
+                          <rules/>
+                          <infoLinks/>
+                          <modifiers/>
+                          <constraints>
+                            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e50f-0c41-48cf-4510" type="max"/>
+                          </constraints>
+                          <categoryLinks/>
+                        </entryLink>
+                        <entryLink id="e516-289c-f10f-626b" name="Hand flamer" hidden="false" targetId="3858-8a51-bdb4-a59e" type="selectionEntry">
+                          <profiles/>
+                          <rules/>
+                          <infoLinks/>
+                          <modifiers/>
+                          <constraints>
+                            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4ad0-130e-7cf3-6636" type="max"/>
+                          </constraints>
+                          <categoryLinks/>
+                        </entryLink>
+                        <entryLink id="c4db-99c0-6bd9-32b7" name="Inferno pistol" hidden="false" targetId="12fb-6600-667f-5922" type="selectionEntry">
+                          <profiles/>
+                          <rules/>
+                          <infoLinks/>
+                          <modifiers/>
+                          <constraints>
+                            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5a06-e440-2a5f-932d" type="max"/>
+                          </constraints>
+                          <categoryLinks/>
+                        </entryLink>
+                        <entryLink id="894f-c48f-7e1b-7a73" name="Power sword" hidden="false" targetId="c3d0-2567-35c6-3f29" type="selectionEntry">
+                          <profiles/>
+                          <rules/>
+                          <infoLinks/>
+                          <modifiers/>
+                          <constraints>
+                            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0b0a-09f4-dfa1-71f5" type="max"/>
+                          </constraints>
+                          <categoryLinks/>
+                        </entryLink>
+                        <entryLink id="b7c1-8229-f301-214d" name="Power axe" hidden="false" targetId="8d13-0f69-a808-e300" type="selectionEntry">
+                          <profiles/>
+                          <rules/>
+                          <infoLinks/>
+                          <modifiers/>
+                          <constraints>
+                            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="157f-84d3-cd2d-dfeb" type="max"/>
+                          </constraints>
+                          <categoryLinks/>
+                        </entryLink>
+                        <entryLink id="fa8b-49d2-ac7d-1862" name="Power maul" hidden="false" targetId="b22c-5019-c613-fb74" type="selectionEntry">
+                          <profiles/>
+                          <rules/>
+                          <infoLinks/>
+                          <modifiers/>
+                          <constraints>
+                            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="354a-1a79-bb4c-3d2a" type="max"/>
+                          </constraints>
+                          <categoryLinks/>
+                        </entryLink>
+                        <entryLink id="e14c-57a7-6bd4-028d" name="Lightning Claw" hidden="false" targetId="4fd6-1688-d86c-3510" type="selectionEntry">
+                          <profiles/>
+                          <rules/>
+                          <infoLinks/>
+                          <modifiers/>
+                          <constraints>
+                            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="267d-e5e7-999e-6fe0" type="max"/>
+                          </constraints>
+                          <categoryLinks/>
+                        </entryLink>
+                        <entryLink id="4d87-b7ed-8184-de38" name="Power fist" hidden="false" targetId="3102-2dd8-4f31-3af7" type="selectionEntry">
+                          <profiles/>
+                          <rules/>
+                          <infoLinks/>
+                          <modifiers/>
+                          <constraints>
+                            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0e7f-3694-680a-7bb0" type="max"/>
+                          </constraints>
+                          <categoryLinks/>
+                        </entryLink>
+                        <entryLink id="68b3-340d-d32f-c5c9" name="Grav-pistol" hidden="false" targetId="9f58-3b91-fa2e-32e2" type="selectionEntry">
+                          <profiles/>
+                          <rules/>
+                          <infoLinks/>
+                          <modifiers/>
+                          <constraints>
+                            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ddd0-7af8-ce3a-971d" type="max"/>
+                          </constraints>
+                          <categoryLinks/>
+                        </entryLink>
+                        <entryLink id="cea6-cccf-66b9-f02c" name="Chainsword" hidden="false" targetId="5f85-cddd-00b5-41f8" type="selectionEntry">
+                          <profiles/>
+                          <rules/>
+                          <infoLinks/>
+                          <modifiers/>
+                          <constraints>
+                            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bf54-476d-96fd-9758" type="max"/>
+                          </constraints>
+                          <categoryLinks/>
+                        </entryLink>
+                      </entryLinks>
+                    </selectionEntryGroup>
+                    <selectionEntryGroup id="1180-4624-9ac2-8b33" name="Two-handed" hidden="false" collective="false">
                       <profiles/>
                       <rules/>
                       <infoLinks/>
                       <modifiers/>
                       <constraints>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6970-d08b-642c-08e9" type="min"/>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4e60-30db-a095-6c93" type="max"/>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="de0a-3279-70a5-d9b4" type="max"/>
                       </constraints>
                       <categoryLinks/>
-                    </entryLink>
-                  </entryLinks>
-                  <costs>
-                    <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="0.0"/>
-                    <cost name="pts" costTypeId="points" value="0.0"/>
-                  </costs>
-                </selectionEntry>
-              </selectionEntries>
-              <selectionEntryGroups/>
+                      <selectionEntries/>
+                      <selectionEntryGroups/>
+                      <entryLinks>
+                        <entryLink id="e7cf-dfb0-1d20-b5a4" name="Boltgun" hidden="false" targetId="8e23-a2e7-23c4-cac7" type="selectionEntry">
+                          <profiles/>
+                          <rules/>
+                          <infoLinks/>
+                          <modifiers/>
+                          <constraints>
+                            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a96e-eb40-f556-888a" type="max"/>
+                          </constraints>
+                          <categoryLinks/>
+                        </entryLink>
+                        <entryLink id="abaa-359d-2a72-cf22" name="Combi-flamer" hidden="false" targetId="a070-091c-f79c-7838" type="selectionEntry">
+                          <profiles/>
+                          <rules/>
+                          <infoLinks/>
+                          <modifiers/>
+                          <constraints>
+                            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a0b0-0e03-a8cc-d052" type="max"/>
+                          </constraints>
+                          <categoryLinks/>
+                        </entryLink>
+                        <entryLink id="affc-1024-b391-4868" name="New EntryLink" hidden="false" targetId="ce34-2e18-b818-b255" type="selectionEntry">
+                          <profiles/>
+                          <rules/>
+                          <infoLinks/>
+                          <modifiers/>
+                          <constraints>
+                            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ec29-c447-2fa1-cf45" type="max"/>
+                          </constraints>
+                          <categoryLinks/>
+                        </entryLink>
+                        <entryLink id="b8ea-ea2c-3c85-e604" name="Combi-plasma" hidden="false" targetId="1e2d-40cf-18d3-db7f" type="selectionEntry">
+                          <profiles/>
+                          <rules/>
+                          <infoLinks/>
+                          <modifiers/>
+                          <constraints>
+                            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="29fe-2620-3f9c-9c6a" type="max"/>
+                          </constraints>
+                          <categoryLinks/>
+                        </entryLink>
+                        <entryLink id="9d9d-d11b-0cb1-33b2" name="Combi-grav" hidden="false" targetId="a80a-0476-1ef9-e1cc" type="selectionEntry">
+                          <profiles/>
+                          <rules/>
+                          <infoLinks/>
+                          <modifiers/>
+                          <constraints>
+                            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c437-292c-bf73-e82f" type="max"/>
+                          </constraints>
+                          <categoryLinks/>
+                        </entryLink>
+                        <entryLink id="2dd7-9a0e-233e-1aa2" name="Storm bolter" hidden="false" targetId="d74a-2fee-abea-1b42" type="selectionEntry">
+                          <profiles/>
+                          <rules/>
+                          <infoLinks/>
+                          <modifiers/>
+                          <constraints>
+                            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="487d-d771-cc2b-55c1" type="max"/>
+                          </constraints>
+                          <categoryLinks/>
+                        </entryLink>
+                      </entryLinks>
+                    </selectionEntryGroup>
+                  </selectionEntryGroups>
+                  <entryLinks/>
+                </selectionEntryGroup>
+              </selectionEntryGroups>
               <entryLinks>
-                <entryLink id="8b0b-eadc-7128-b396" name="New EntryLink" hidden="false" targetId="5040-98cd-3b1c-47a2" type="selectionEntryGroup">
+                <entryLink id="f96e-1853-0324-b999" name="Bolt pistol" hidden="false" targetId="0367-b42c-b6b4-0a58" type="selectionEntry">
                   <profiles/>
                   <rules/>
                   <infoLinks/>
                   <modifiers/>
-                  <constraints/>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="35b3-c17f-81ee-5847" type="max"/>
+                  </constraints>
+                  <categoryLinks/>
+                </entryLink>
+              </entryLinks>
+            </selectionEntryGroup>
+            <selectionEntryGroup id="45a0-7f89-2b0b-13cf" name="Boltgun arm" hidden="false" collective="false" defaultSelectionEntryId="680a-a253-efea-9880">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7475-1f17-1384-90a4" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="24be-429e-5979-a727" type="max"/>
+              </constraints>
+              <categoryLinks/>
+              <selectionEntries/>
+              <selectionEntryGroups>
+                <selectionEntryGroup id="b38c-baf1-ef3d-9053" name="Sergeant equipment" hidden="false" collective="false">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a46e-24ea-e366-3e32" type="max"/>
+                  </constraints>
+                  <categoryLinks/>
+                  <selectionEntries/>
+                  <selectionEntryGroups>
+                    <selectionEntryGroup id="63e5-50c4-3dcf-62be" name="One-handed" hidden="false" collective="false">
+                      <profiles/>
+                      <rules/>
+                      <infoLinks/>
+                      <modifiers/>
+                      <constraints>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8e75-ffc7-7fdb-27b2" type="max"/>
+                      </constraints>
+                      <categoryLinks/>
+                      <selectionEntries/>
+                      <selectionEntryGroups/>
+                      <entryLinks>
+                        <entryLink id="af5f-f76c-1619-b800" name="Bolt pistol" hidden="false" targetId="bf86-1c1b-6871-da0b" type="selectionEntry">
+                          <profiles/>
+                          <rules/>
+                          <infoLinks/>
+                          <modifiers/>
+                          <constraints>
+                            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9532-c620-e802-7124" type="max"/>
+                          </constraints>
+                          <categoryLinks/>
+                        </entryLink>
+                        <entryLink id="1c0a-efa7-178a-d8f1" name="Plasma pistol" hidden="false" targetId="b333-4c80-2f72-6b45" type="selectionEntry">
+                          <profiles/>
+                          <rules/>
+                          <infoLinks/>
+                          <modifiers/>
+                          <constraints>
+                            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6b99-6498-230c-7a34" type="max"/>
+                          </constraints>
+                          <categoryLinks/>
+                        </entryLink>
+                        <entryLink id="c844-aa66-0d62-037d" name="Hand flamer" hidden="false" targetId="3858-8a51-bdb4-a59e" type="selectionEntry">
+                          <profiles/>
+                          <rules/>
+                          <infoLinks/>
+                          <modifiers/>
+                          <constraints>
+                            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9af5-2e4c-cb53-37c1" type="max"/>
+                          </constraints>
+                          <categoryLinks/>
+                        </entryLink>
+                        <entryLink id="4fd2-17b3-d1e9-755b" name="Inferno pistol" hidden="false" targetId="12fb-6600-667f-5922" type="selectionEntry">
+                          <profiles/>
+                          <rules/>
+                          <infoLinks/>
+                          <modifiers/>
+                          <constraints>
+                            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="cdda-a58c-717f-0fc2" type="max"/>
+                          </constraints>
+                          <categoryLinks/>
+                        </entryLink>
+                        <entryLink id="325f-cc46-3f26-e65b" name="Chainsword" hidden="false" targetId="5f85-cddd-00b5-41f8" type="selectionEntry">
+                          <profiles/>
+                          <rules/>
+                          <infoLinks/>
+                          <modifiers/>
+                          <constraints>
+                            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0df0-7335-28e7-77ff" type="max"/>
+                          </constraints>
+                          <categoryLinks/>
+                        </entryLink>
+                        <entryLink id="bcbf-575d-8d47-ff1c" name="Power sword" hidden="false" targetId="c3d0-2567-35c6-3f29" type="selectionEntry">
+                          <profiles/>
+                          <rules/>
+                          <infoLinks/>
+                          <modifiers/>
+                          <constraints>
+                            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5680-cfeb-ac05-71ee" type="max"/>
+                          </constraints>
+                          <categoryLinks/>
+                        </entryLink>
+                        <entryLink id="eee6-8336-d7cb-ffd7" name="Power axe" hidden="false" targetId="8d13-0f69-a808-e300" type="selectionEntry">
+                          <profiles/>
+                          <rules/>
+                          <infoLinks/>
+                          <modifiers/>
+                          <constraints>
+                            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="005d-8682-e6ff-8e2f" type="max"/>
+                          </constraints>
+                          <categoryLinks/>
+                        </entryLink>
+                        <entryLink id="b424-8944-1d55-f14f" name="Power maul" hidden="false" targetId="b22c-5019-c613-fb74" type="selectionEntry">
+                          <profiles/>
+                          <rules/>
+                          <infoLinks/>
+                          <modifiers/>
+                          <constraints>
+                            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="59a9-9d1b-a88c-17a9" type="max"/>
+                          </constraints>
+                          <categoryLinks/>
+                        </entryLink>
+                        <entryLink id="5c53-3add-2b1c-4cf4" name="Lightning Claw" hidden="false" targetId="4fd6-1688-d86c-3510" type="selectionEntry">
+                          <profiles/>
+                          <rules/>
+                          <infoLinks/>
+                          <modifiers/>
+                          <constraints>
+                            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b6f0-da85-650b-34c5" type="max"/>
+                          </constraints>
+                          <categoryLinks/>
+                        </entryLink>
+                        <entryLink id="943d-0074-a052-e4b8" name="Power fist" hidden="false" targetId="3102-2dd8-4f31-3af7" type="selectionEntry">
+                          <profiles/>
+                          <rules/>
+                          <infoLinks/>
+                          <modifiers/>
+                          <constraints>
+                            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c73f-3d29-dfd6-14bc" type="max"/>
+                          </constraints>
+                          <categoryLinks/>
+                        </entryLink>
+                        <entryLink id="6667-483d-3a75-e56d" name="Grav-pistol" hidden="false" targetId="9f58-3b91-fa2e-32e2" type="selectionEntry">
+                          <profiles/>
+                          <rules/>
+                          <infoLinks/>
+                          <modifiers/>
+                          <constraints>
+                            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0d8e-fc5f-ae40-93a8" type="max"/>
+                          </constraints>
+                          <categoryLinks/>
+                        </entryLink>
+                      </entryLinks>
+                    </selectionEntryGroup>
+                    <selectionEntryGroup id="f1d8-7075-94af-3781" name="Two-handed" hidden="false" collective="false">
+                      <profiles/>
+                      <rules/>
+                      <infoLinks/>
+                      <modifiers/>
+                      <constraints>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f076-aa45-3540-d0f4" type="max"/>
+                      </constraints>
+                      <categoryLinks/>
+                      <selectionEntries/>
+                      <selectionEntryGroups/>
+                      <entryLinks>
+                        <entryLink id="7ab5-3e5c-3a47-ab0b" name="Boltgun" hidden="false" targetId="8e23-a2e7-23c4-cac7" type="selectionEntry">
+                          <profiles/>
+                          <rules/>
+                          <infoLinks/>
+                          <modifiers/>
+                          <constraints>
+                            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5061-a432-13eb-fb90" type="max"/>
+                          </constraints>
+                          <categoryLinks/>
+                        </entryLink>
+                        <entryLink id="98da-2588-b6d4-adc9" name="Combi-flamer" hidden="false" targetId="a070-091c-f79c-7838" type="selectionEntry">
+                          <profiles/>
+                          <rules/>
+                          <infoLinks/>
+                          <modifiers/>
+                          <constraints>
+                            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="99c1-56c3-86e8-da41" type="max"/>
+                          </constraints>
+                          <categoryLinks/>
+                        </entryLink>
+                        <entryLink id="7628-7ed1-ae46-fe50" name="Combi-melta" hidden="false" targetId="ce34-2e18-b818-b255" type="selectionEntry">
+                          <profiles/>
+                          <rules/>
+                          <infoLinks/>
+                          <modifiers/>
+                          <constraints>
+                            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3c1c-223f-0481-3af9" type="max"/>
+                          </constraints>
+                          <categoryLinks/>
+                        </entryLink>
+                        <entryLink id="0183-505a-0379-6e4f" name="Combi-plasma" hidden="false" targetId="1e2d-40cf-18d3-db7f" type="selectionEntry">
+                          <profiles/>
+                          <rules/>
+                          <infoLinks/>
+                          <modifiers/>
+                          <constraints>
+                            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="91c2-1647-4a5d-2c37" type="max"/>
+                          </constraints>
+                          <categoryLinks/>
+                        </entryLink>
+                        <entryLink id="40d6-a9ed-d1e9-2853" name="Combi-grav" hidden="false" targetId="a80a-0476-1ef9-e1cc" type="selectionEntry">
+                          <profiles/>
+                          <rules/>
+                          <infoLinks/>
+                          <modifiers/>
+                          <constraints>
+                            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="cc70-1734-e1e9-642b" type="max"/>
+                          </constraints>
+                          <categoryLinks/>
+                        </entryLink>
+                        <entryLink id="09c3-16b8-81dd-fa98" name="Storm bolter" hidden="false" targetId="d74a-2fee-abea-1b42" type="selectionEntry">
+                          <profiles/>
+                          <rules/>
+                          <infoLinks/>
+                          <modifiers/>
+                          <constraints>
+                            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d16a-de81-f86f-bbcc" type="max"/>
+                          </constraints>
+                          <categoryLinks/>
+                        </entryLink>
+                      </entryLinks>
+                    </selectionEntryGroup>
+                  </selectionEntryGroups>
+                  <entryLinks/>
+                </selectionEntryGroup>
+              </selectionEntryGroups>
+              <entryLinks>
+                <entryLink id="680a-a253-efea-9880" name="Special issue boltgun" hidden="false" targetId="ac47-fbfd-4381-3191" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e14c-2a40-b233-dfd8" type="max"/>
+                  </constraints>
                   <categoryLinks/>
                 </entryLink>
               </entryLinks>
@@ -10527,7 +10886,7 @@
               </constraints>
               <categoryLinks/>
             </entryLink>
-            <entryLink id="5863-77ec-8d49-d429" name="New EntryLink" hidden="false" targetId="073b-2de5-765f-a4f2" type="selectionEntry">
+            <entryLink id="5863-77ec-8d49-d429" name="Krak grenade" hidden="false" targetId="073b-2de5-765f-a4f2" type="selectionEntry">
               <profiles/>
               <rules/>
               <infoLinks/>
@@ -11294,7 +11653,7 @@
       <profiles/>
       <rules/>
       <infoLinks>
-        <infoLink id="11cf-c764-bbe5-e835" name="New InfoLink" hidden="false" targetId="3c6f-1cf6-5985-bcf0" type="profile">
+        <infoLink id="11cf-c764-bbe5-e835" name="Techmarine" hidden="false" targetId="3c6f-1cf6-5985-bcf0" type="profile">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -11302,7 +11661,7 @@
             <modifier type="set" field="0bdf-a96e-9e38-7779" value="12&quot;">
               <repeats/>
               <conditions>
-                <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="08cf-46a8-1b7f-4b79" type="atLeast"/>
+                <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="b97e-89a9-af00-220f" type="atLeast"/>
               </conditions>
               <conditionGroups/>
             </modifier>
@@ -11374,59 +11733,7 @@
           <constraints/>
         </categoryLink>
       </categoryLinks>
-      <selectionEntries>
-        <selectionEntry id="68a3-8f7e-b746-920b" name="Servo-harness" hidden="false" collective="false" type="upgrade">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="dc0f-8eec-a828-7d9a" type="max"/>
-          </constraints>
-          <categoryLinks/>
-          <selectionEntries/>
-          <selectionEntryGroups/>
-          <entryLinks>
-            <entryLink id="c7da-0c8c-c8dd-ccc9" name="New EntryLink" hidden="false" targetId="fb0f-7f69-e952-07dc" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4e39-dd34-abc2-70b4" type="min"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0d28-2dda-e298-b504" type="max"/>
-              </constraints>
-              <categoryLinks/>
-            </entryLink>
-            <entryLink id="951c-442c-f6a7-b77a" name="New EntryLink" hidden="false" targetId="c3f2-5ecb-a2ae-a92f" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f329-5135-ba00-df5a" type="min"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e6ce-a81d-593b-b40b" type="max"/>
-              </constraints>
-              <categoryLinks/>
-            </entryLink>
-            <entryLink id="2c1e-2b00-e811-b666" name="New EntryLink" hidden="false" targetId="a255-3b4c-89e4-e6b3" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d808-1d42-91d9-da48" type="min"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="70e1-b7b3-c673-ca82" type="max"/>
-              </constraints>
-              <categoryLinks/>
-            </entryLink>
-          </entryLinks>
-          <costs>
-            <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="1.0"/>
-            <cost name="pts" costTypeId="points" value="0.0"/>
-          </costs>
-        </selectionEntry>
-      </selectionEntries>
+      <selectionEntries/>
       <selectionEntryGroups>
         <selectionEntryGroup id="2368-ef13-7851-fb0b" name="Ranged weapon" hidden="false" collective="false" defaultSelectionEntryId="56f8-df5b-ab9f-46dc">
           <profiles/>
@@ -11522,24 +11829,68 @@
           <profiles/>
           <rules/>
           <infoLinks/>
-          <modifiers>
-            <modifier type="set" field="hidden" value="true">
-              <repeats/>
-              <conditions>
-                <condition field="selections" scope="7588-23e3-1728-c3e2" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="08cf-46a8-1b7f-4b79" type="atLeast"/>
-              </conditions>
-              <conditionGroups/>
-            </modifier>
-          </modifiers>
+          <modifiers/>
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="456c-8a3b-8cb7-cf86" type="min"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8ca4-edf0-72da-942f" type="max"/>
           </constraints>
           <categoryLinks/>
-          <selectionEntries/>
+          <selectionEntries>
+            <selectionEntry id="cd85-2b9b-cc30-65aa" name="Servo-harness" hidden="false" collective="false" type="upgrade">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ef58-3342-1ca9-e5fd" type="max"/>
+              </constraints>
+              <categoryLinks/>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks>
+                <entryLink id="0be2-16ef-d653-72fb" name="New EntryLink" hidden="false" targetId="fb0f-7f69-e952-07dc" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="14e6-6229-33cb-8245" type="min"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="61c8-4d8e-a18b-cf45" type="max"/>
+                  </constraints>
+                  <categoryLinks/>
+                </entryLink>
+                <entryLink id="4d8d-7986-4940-9c28" name="New EntryLink" hidden="false" targetId="c3f2-5ecb-a2ae-a92f" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a914-3458-66cc-f4d6" type="min"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f488-48b5-8620-a4ba" type="max"/>
+                  </constraints>
+                  <categoryLinks/>
+                </entryLink>
+                <entryLink id="a476-0cb1-863f-779a" name="New EntryLink" hidden="false" targetId="a255-3b4c-89e4-e6b3" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9a83-4c14-6c56-6471" type="min"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4712-481c-e41f-4d23" type="max"/>
+                  </constraints>
+                  <categoryLinks/>
+                </entryLink>
+              </entryLinks>
+              <costs>
+                <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="1.0"/>
+                <cost name="pts" costTypeId="points" value="0.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
           <selectionEntryGroups/>
           <entryLinks>
-            <entryLink id="f4ae-b4f4-91ec-149b" name="New EntryLink" hidden="false" targetId="fb0f-7f69-e952-07dc" type="selectionEntry">
+            <entryLink id="f4ae-b4f4-91ec-149b" name="Servo-arm" hidden="false" targetId="fb0f-7f69-e952-07dc" type="selectionEntry">
               <profiles/>
               <rules/>
               <infoLinks/>
@@ -11553,17 +11904,25 @@
               <profiles/>
               <rules/>
               <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="76dc-81e2-6591-c2f8" type="max"/>
+              </constraints>
+              <categoryLinks/>
+            </entryLink>
+            <entryLink id="b97e-89a9-af00-220f" name="Jump Pack" hidden="false" targetId="8eda-5cb2-0c31-56da" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
               <modifiers>
-                <modifier type="set" field="hidden" value="true">
+                <modifier type="set" field="points" value="33">
                   <repeats/>
-                  <conditions>
-                    <condition field="selections" scope="7588-23e3-1728-c3e2" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="68a3-8f7e-b746-920b" type="equalTo"/>
-                  </conditions>
+                  <conditions/>
                   <conditionGroups/>
                 </modifier>
               </modifiers>
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="76dc-81e2-6591-c2f8" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f1be-6692-d590-ab41" type="max"/>
               </constraints>
               <categoryLinks/>
             </entryLink>
@@ -11571,22 +11930,6 @@
         </selectionEntryGroup>
       </selectionEntryGroups>
       <entryLinks>
-        <entryLink id="08cf-46a8-1b7f-4b79" name="Jump Pack" hidden="false" targetId="8eda-5cb2-0c31-56da" type="selectionEntry">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers>
-            <modifier type="set" field="points" value="33">
-              <repeats/>
-              <conditions/>
-              <conditionGroups/>
-            </modifier>
-          </modifiers>
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bdbd-1c64-7b27-c335" type="max"/>
-          </constraints>
-          <categoryLinks/>
-        </entryLink>
         <entryLink id="70bd-6958-d488-a8d9" name="New EntryLink" hidden="false" targetId="e897-c8fa-0976-e2d3" type="selectionEntry">
           <profiles/>
           <rules/>
@@ -11598,7 +11941,7 @@
           </constraints>
           <categoryLinks/>
         </entryLink>
-        <entryLink id="0fb0-1a09-76b8-79d4" name="New EntryLink" hidden="false" targetId="073b-2de5-765f-a4f2" type="selectionEntry">
+        <entryLink id="0fb0-1a09-76b8-79d4" name="Krak grenade" hidden="false" targetId="073b-2de5-765f-a4f2" type="selectionEntry">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -13888,6 +14231,13 @@
           <modifiers/>
           <constraints/>
         </categoryLink>
+        <categoryLink id="4d00-8b8d-3ea9-2286" name="New CategoryLink" hidden="false" targetId="94e1-25fe-8b2d-64dd" primary="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="5877-417f-ce5b-b5a9" name="Blood Song" hidden="false" collective="false" type="upgrade">
@@ -14089,6 +14439,13 @@
           <constraints/>
         </categoryLink>
         <categoryLink id="8283-85ec-0bed-21d0" name="New CategoryLink" hidden="false" targetId="b011-7906-1d21-91b1" primary="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
+        <categoryLink id="b4c9-c29d-5a2d-54c5" name="New CategoryLink" hidden="false" targetId="94e1-25fe-8b2d-64dd" primary="false">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -15925,7 +16282,7 @@
           <selectionEntries/>
           <selectionEntryGroups/>
           <entryLinks>
-            <entryLink id="5664-aa73-1e40-cb57" name="New EntryLink" hidden="false" targetId="3416-2170-2d36-e76e" type="selectionEntry">
+            <entryLink id="5664-aa73-1e40-cb57" name="Angelus boltgun" hidden="false" targetId="3416-2170-2d36-e76e" type="selectionEntry">
               <profiles/>
               <rules/>
               <infoLinks/>
@@ -15935,7 +16292,7 @@
               </constraints>
               <categoryLinks/>
             </entryLink>
-            <entryLink id="48e8-1ee8-ec8c-489d" name="New EntryLink" hidden="false" targetId="12fb-6600-667f-5922" type="selectionEntry">
+            <entryLink id="48e8-1ee8-ec8c-489d" name="Inferno pistol" hidden="false" targetId="12fb-6600-667f-5922" type="selectionEntry">
               <profiles/>
               <rules/>
               <infoLinks/>
@@ -15945,7 +16302,7 @@
               </constraints>
               <categoryLinks/>
             </entryLink>
-            <entryLink id="8109-a7a8-d3cd-368c" name="New EntryLink" hidden="false" targetId="d83e-4dc3-0722-4206" type="selectionEntry">
+            <entryLink id="8109-a7a8-d3cd-368c" name="Plasma pistol" hidden="false" targetId="b333-4c80-2f72-6b45" type="selectionEntry">
               <profiles/>
               <rules/>
               <infoLinks/>
@@ -15970,7 +16327,7 @@
           <selectionEntries/>
           <selectionEntryGroups/>
           <entryLinks>
-            <entryLink id="04ad-3aa7-d54d-7844" name="New EntryLink" hidden="false" targetId="c6b0-3f26-775c-7232" type="selectionEntry">
+            <entryLink id="04ad-3aa7-d54d-7844" name="Encarmine axe" hidden="false" targetId="c6b0-3f26-775c-7232" type="selectionEntry">
               <profiles/>
               <rules/>
               <infoLinks/>
@@ -15980,7 +16337,7 @@
               </constraints>
               <categoryLinks/>
             </entryLink>
-            <entryLink id="6316-f3eb-1aba-c022" name="New EntryLink" hidden="false" targetId="537e-2cf9-80d7-1f5d" type="selectionEntry">
+            <entryLink id="6316-f3eb-1aba-c022" name="Encarmine sword" hidden="false" targetId="537e-2cf9-80d7-1f5d" type="selectionEntry">
               <profiles/>
               <rules/>
               <infoLinks/>
@@ -15990,7 +16347,7 @@
               </constraints>
               <categoryLinks/>
             </entryLink>
-            <entryLink id="ce66-ad9c-2481-c00f" name="New EntryLink" hidden="false" targetId="3102-2dd8-4f31-3af7" type="selectionEntry">
+            <entryLink id="ce66-ad9c-2481-c00f" name="Power fist" hidden="false" targetId="3102-2dd8-4f31-3af7" type="selectionEntry">
               <profiles/>
               <rules/>
               <infoLinks/>


### PR DESCRIPTION
Both versions of Tycho now have the keyword Tycho.
Removed collective gear from Sanguinary Ancient. Fixes #686.
Techmarine servo-arm options reworked. Fixes #687.
Rhino now has its defaul storm bolter. Fixes #690.
Scout Sergeant doesn't have access to heavy weapons anymore. Fixes #691.
Sternguard Veteran Sergeant options reworked. Fixes #689.