### PR TITLE
Quad Heavy Bolter point adjustment.

### DIFF
--- a/Imperium - Inquisition.cat
+++ b/Imperium - Inquisition.cat
@@ -2997,7 +2997,7 @@
           <entryLinks/>
           <costs>
             <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="0.0"/>
-            <cost name="pts" costTypeId="points" value="72.0"/>
+            <cost name="pts" costTypeId="points" value="36.0"/>
           </costs>
         </selectionEntry>
       </selectionEntries>


### PR DESCRIPTION
Quad Heavy Bolter was 72pts should be 36pts.
Changed Quad Heavy Bolter to 36pts a piece.