### PR TITLE
Added Sorcerer on Palanquin of Nurgle to Death Guard Army List

### DIFF
--- a/Chaos - Death Guard.cat
+++ b/Chaos - Death Guard.cat
@@ -2028,7 +2028,7 @@
                   <profiles/>
                   <rules/>
                   <infoLinks>
-                    <infoLink id="0674-f50a-d688-a617" hidden="false" targetId="3d4b-95ea-f860-dd22" type="profile">
+                    <infoLink id="0674-f50a-d688-a617" name="Bolt pistol" hidden="false" targetId="e6d5-677a-d8ed-f6a5" type="profile">
                       <profiles/>
                       <rules/>
                       <infoLinks/>

--- a/Chaos - Death Guard.cat
+++ b/Chaos - Death Guard.cat
@@ -300,6 +300,14 @@
       <constraints/>
       <categoryLinks/>
     </entryLink>
+    <entryLink id="df1a-d99d-eb1b-7e04" name="Sorcerer on Palanquin of Nurgle" book="INDEX: CHAOS" page="24 &amp; INDEX: CHAOS FAQ 1" hidden="false" targetId="6a69-f097-e443-531d" type="selectionEntry">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints/>
+      <categoryLinks/>
+    </entryLink>
   </entryLinks>
   <sharedSelectionEntries>
     <selectionEntry id="598f-3cba-b8c5-e748" name="Chaos Lord" page="0" hidden="false" collective="false" type="model">
@@ -3988,7 +3996,7 @@
         </rule>
       </rules>
       <infoLinks>
-        <infoLink id="b394-4dae-b58d-112c" name="New InfoLink" hidden="false" targetId="6349-022a-cea9-524c" type="rule">
+        <infoLink id="b394-4dae-b58d-112c" name="Death to the False Emperor" hidden="false" targetId="6349-022a-cea9-524c" type="rule">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -4122,7 +4130,7 @@
           <selectionEntries/>
           <selectionEntryGroups/>
           <entryLinks>
-            <entryLink id="68f3-6e50-f517-84ce" name="New EntryLink" hidden="false" targetId="0334-f487-8229-0c1a" type="selectionEntry">
+            <entryLink id="68f3-6e50-f517-84ce" name="Bolt pistol" hidden="false" targetId="0334-f487-8229-0c1a" type="selectionEntry">
               <profiles/>
               <rules/>
               <infoLinks/>
@@ -4130,7 +4138,7 @@
               <constraints/>
               <categoryLinks/>
             </entryLink>
-            <entryLink id="af72-d69e-460a-8c3a" name="New EntryLink" hidden="false" targetId="ce84-10ca-568c-5c48" type="selectionEntryGroup">
+            <entryLink id="af72-d69e-460a-8c3a" name="Pistols" hidden="false" targetId="ce84-10ca-568c-5c48" type="selectionEntryGroup">
               <profiles/>
               <rules/>
               <infoLinks/>
@@ -4138,7 +4146,7 @@
               <constraints/>
               <categoryLinks/>
             </entryLink>
-            <entryLink id="0697-c0fb-e569-ce53" name="New EntryLink" hidden="false" targetId="5383-9a88-9883-e144" type="selectionEntryGroup">
+            <entryLink id="0697-c0fb-e569-ce53" name="Combi-weapons" hidden="false" targetId="5383-9a88-9883-e144" type="selectionEntryGroup">
               <profiles/>
               <rules/>
               <infoLinks/>
@@ -4146,7 +4154,7 @@
               <constraints/>
               <categoryLinks/>
             </entryLink>
-            <entryLink id="0a0e-1279-9de9-1e05" name="New EntryLink" hidden="false" targetId="becb-9ac2-cb36-95f7" type="selectionEntryGroup">
+            <entryLink id="0a0e-1279-9de9-1e05" name="Melee Weapons" hidden="false" targetId="becb-9ac2-cb36-95f7" type="selectionEntryGroup">
               <profiles/>
               <rules/>
               <infoLinks/>
@@ -4158,7 +4166,7 @@
         </selectionEntryGroup>
       </selectionEntryGroups>
       <entryLinks>
-        <entryLink id="d983-4af4-8f95-a1e6" name="New EntryLink" hidden="false" targetId="cddf-945e-1335-e681" type="selectionEntry">
+        <entryLink id="d983-4af4-8f95-a1e6" name="Frag &amp; Krak grenades" hidden="false" targetId="cddf-945e-1335-e681" type="selectionEntry">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -6558,7 +6566,7 @@
         <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="19.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="6a69-f097-e443-531d" name="Sorcerer on Palanquin of Nurgle" page="" hidden="false" collective="false" type="model">
+    <selectionEntry id="6a69-f097-e443-531d" name="Sorcerer on Palanquin of Nurgle" book="INDEX: CHAOS" page="24 &amp; INDEX: CHAOS FAQ 1" hidden="false" collective="false" type="model">
       <profiles>
         <profile id="1b49-4914-edc7-d30a" name="Sorcerer on Palanquin of Nurgle" hidden="false" profileTypeId="800f-21d0-4387-c943" profileTypeName="Unit">
           <profiles/>
@@ -6586,7 +6594,7 @@
             <characteristic name="Cast" characteristicTypeId="5afb-9914-904b-d3b3" value="2"/>
             <characteristic name="Deny" characteristicTypeId="b5ac-9c20-5d5a-6f9b" value="1"/>
             <characteristic name="Powers Known" characteristicTypeId="69d7-b45e-00a2-7e46" value="2 Dark Hereticus"/>
-            <characteristic name="Other" characteristicTypeId="c2e2-f115-0003-5d7b" value=""/>
+            <characteristic name="Other" characteristicTypeId="c2e2-f115-0003-5d7b" value="Smite"/>
           </characteristics>
         </profile>
       </profiles>
@@ -6603,6 +6611,62 @@
       <constraints/>
       <categoryLinks>
         <categoryLink id="9c63-7e93-6f17-2562" name="New CategoryLink" hidden="false" targetId="5cf1-acf2-ca3b-c2e5" primary="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
+        <categoryLink id="b2b8-9acc-774d-cede" name="New CategoryLink" hidden="false" targetId="ef18-746a-369f-43a4" primary="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
+        <categoryLink id="8cb3-c57d-69bd-3490" name="New CategoryLink" hidden="false" targetId="8308-6393-0ce1-4bf9" primary="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
+        <categoryLink id="4fde-b51f-0d9a-0f42" name="New CategoryLink" hidden="false" targetId="848a6ff2-0def-4c72-8433-ff7da70e6bc7" primary="true">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
+        <categoryLink id="79d5-3fb0-a7bb-983f" name="New CategoryLink" hidden="false" targetId="ca10-a5dd-f54f-0ed5" primary="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
+        <categoryLink id="8a81-129c-d60b-794c" name="New CategoryLink" hidden="false" targetId="0bc5-6451-5612-4a25" primary="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
+        <categoryLink id="a938-097a-2d2a-7270" name="New CategoryLink" hidden="false" targetId="0fb6-fcaf-b180-5dda" primary="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
+        <categoryLink id="b0e5-e967-ef84-b64c" name="New CategoryLink" hidden="false" targetId="ad01-caec-17d9-cb8d" primary="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
+        <categoryLink id="acc6-38e0-7894-8f43" name="New CategoryLink" hidden="false" targetId="e691-aad7-d21c-1023" primary="false">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -6646,7 +6710,7 @@
         </selectionEntry>
       </selectionEntries>
       <selectionEntryGroups>
-        <selectionEntryGroup id="a939-d0b0-9b25-1ed1" name="Force sword options" hidden="false" collective="false">
+        <selectionEntryGroup id="a939-d0b0-9b25-1ed1" name="Force sword options" hidden="false" collective="false" defaultSelectionEntryId="7372-b5b8-afb4-6a4a">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -6659,7 +6723,7 @@
           <selectionEntries/>
           <selectionEntryGroups/>
           <entryLinks>
-            <entryLink id="7372-b5b8-afb4-6a4a" name="New EntryLink" hidden="false" targetId="07e7-1f9b-4c1c-aad9" type="selectionEntry">
+            <entryLink id="7372-b5b8-afb4-6a4a" name="Force sword" hidden="false" targetId="07e7-1f9b-4c1c-aad9" type="selectionEntry">
               <profiles/>
               <rules/>
               <infoLinks/>
@@ -6669,7 +6733,7 @@
               </constraints>
               <categoryLinks/>
             </entryLink>
-            <entryLink id="0f16-1feb-fbf9-0090" name="New EntryLink" hidden="false" targetId="4a0e-0f13-63c2-9aae" type="selectionEntry">
+            <entryLink id="0f16-1feb-fbf9-0090" name="Force axe" hidden="false" targetId="4a0e-0f13-63c2-9aae" type="selectionEntry">
               <profiles/>
               <rules/>
               <infoLinks/>
@@ -6679,7 +6743,7 @@
               </constraints>
               <categoryLinks/>
             </entryLink>
-            <entryLink id="4607-d3ee-ff1d-db18" name="New EntryLink" hidden="false" targetId="6f9a-c4fe-3132-d011" type="selectionEntry">
+            <entryLink id="4607-d3ee-ff1d-db18" name="Force stave" hidden="false" targetId="6f9a-c4fe-3132-d011" type="selectionEntry">
               <profiles/>
               <rules/>
               <infoLinks/>
@@ -6691,7 +6755,7 @@
             </entryLink>
           </entryLinks>
         </selectionEntryGroup>
-        <selectionEntryGroup id="1649-21f6-473a-26e1" name="Pistol options" hidden="false" collective="false">
+        <selectionEntryGroup id="1649-21f6-473a-26e1" name="Pistol options" hidden="false" collective="false" defaultSelectionEntryId="c753-0a99-9b07-2782">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -6704,7 +6768,7 @@
           <selectionEntries/>
           <selectionEntryGroups/>
           <entryLinks>
-            <entryLink id="c753-0a99-9b07-2782" name="New EntryLink" hidden="false" targetId="0334-f487-8229-0c1a" type="selectionEntry">
+            <entryLink id="c753-0a99-9b07-2782" name="Bolt pistol" hidden="false" targetId="0334-f487-8229-0c1a" type="selectionEntry">
               <profiles/>
               <rules/>
               <infoLinks/>
@@ -6712,7 +6776,7 @@
               <constraints/>
               <categoryLinks/>
             </entryLink>
-            <entryLink id="da00-c501-2ed1-b9e7" name="New EntryLink" hidden="false" targetId="ce84-10ca-568c-5c48" type="selectionEntryGroup">
+            <entryLink id="da00-c501-2ed1-b9e7" name="Pistols" hidden="false" targetId="ce84-10ca-568c-5c48" type="selectionEntryGroup">
               <profiles/>
               <rules/>
               <infoLinks/>
@@ -6720,7 +6784,7 @@
               <constraints/>
               <categoryLinks/>
             </entryLink>
-            <entryLink id="9714-931e-7afc-3bf4" name="New EntryLink" hidden="false" targetId="5383-9a88-9883-e144" type="selectionEntryGroup">
+            <entryLink id="9714-931e-7afc-3bf4" name="Combi-weapons" hidden="false" targetId="5383-9a88-9883-e144" type="selectionEntryGroup">
               <profiles/>
               <rules/>
               <infoLinks/>
@@ -6728,7 +6792,7 @@
               <constraints/>
               <categoryLinks/>
             </entryLink>
-            <entryLink id="b563-e41a-8620-cf3e" name="New EntryLink" hidden="false" targetId="becb-9ac2-cb36-95f7" type="selectionEntryGroup">
+            <entryLink id="b563-e41a-8620-cf3e" name="Melee Weapons" hidden="false" targetId="becb-9ac2-cb36-95f7" type="selectionEntryGroup">
               <profiles/>
               <rules/>
               <infoLinks/>
@@ -6740,7 +6804,7 @@
         </selectionEntryGroup>
       </selectionEntryGroups>
       <entryLinks>
-        <entryLink id="f231-44f2-afab-facb" name="New EntryLink" hidden="false" targetId="cddf-945e-1335-e681" type="selectionEntry">
+        <entryLink id="f231-44f2-afab-facb" name="Frag &amp; Krak grenades" hidden="false" targetId="cddf-945e-1335-e681" type="selectionEntry">
           <profiles/>
           <rules/>
           <infoLinks/>


### PR DESCRIPTION
As of FAQ 1 - Sorcerer on Palanquin of Nurgle is now in the Death Guard Army List -- Issue #703 