### PR TITLE
Added Sorcerer on Palanquin of Nurgle to Death Guard Army List and change Smoke Launchers to point to Smoke Launchers

### DIFF
--- a/Chaos - Death Guard.cat
+++ b/Chaos - Death Guard.cat
@@ -204,7 +204,7 @@
       <constraints/>
       <categoryLinks/>
     </entryLink>
-    <entryLink id="8122-270e-02ff-0560" name="New EntryLink" hidden="false" targetId="35e1-54d6-7565-dd03" type="selectionEntry">
+    <entryLink id="8122-270e-02ff-0560" name="Sorcerer with Jump Pack" hidden="false" targetId="35e1-54d6-7565-dd03" type="selectionEntry">
       <profiles/>
       <rules/>
       <infoLinks/>
@@ -212,7 +212,7 @@
       <constraints/>
       <categoryLinks/>
     </entryLink>
-    <entryLink id="a0bd-98c4-cba7-b313" name="New EntryLink" hidden="false" targetId="313d-d939-4be9-9e48" type="selectionEntry">
+    <entryLink id="a0bd-98c4-cba7-b313" name="Sorcerer in Terminator Armour" hidden="false" targetId="313d-d939-4be9-9e48" type="selectionEntry">
       <profiles/>
       <rules/>
       <infoLinks/>
@@ -293,6 +293,14 @@
       <categoryLinks/>
     </entryLink>
     <entryLink id="bdff-4064-28d5-ffcb" name="New EntryLink" hidden="false" targetId="64e4-21f2-e032-ad64" type="selectionEntry">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints/>
+      <categoryLinks/>
+    </entryLink>
+    <entryLink id="61c7-1c0e-a785-327e" name="Sorcerer on Palanquin of Nurgle" hidden="false" targetId="6a69-f097-e443-531d" type="selectionEntry">
       <profiles/>
       <rules/>
       <infoLinks/>
@@ -4006,7 +4014,7 @@
         </rule>
       </rules>
       <infoLinks>
-        <infoLink id="b394-4dae-b58d-112c" name="New InfoLink" hidden="false" targetId="6349-022a-cea9-524c" type="rule">
+        <infoLink id="b394-4dae-b58d-112c" name="Death to the False Emperor" hidden="false" targetId="6349-022a-cea9-524c" type="rule">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -4095,7 +4103,7 @@
           <selectionEntries/>
           <selectionEntryGroups/>
           <entryLinks>
-            <entryLink id="1d55-f458-b7d0-dac1" name="New EntryLink" hidden="false" targetId="07e7-1f9b-4c1c-aad9" type="selectionEntry">
+            <entryLink id="1d55-f458-b7d0-dac1" name="Force sword" hidden="false" targetId="07e7-1f9b-4c1c-aad9" type="selectionEntry">
               <profiles/>
               <rules/>
               <infoLinks/>
@@ -4105,7 +4113,7 @@
               </constraints>
               <categoryLinks/>
             </entryLink>
-            <entryLink id="038e-871d-be28-25a0" name="New EntryLink" hidden="false" targetId="4a0e-0f13-63c2-9aae" type="selectionEntry">
+            <entryLink id="038e-871d-be28-25a0" name="Force axe" hidden="false" targetId="4a0e-0f13-63c2-9aae" type="selectionEntry">
               <profiles/>
               <rules/>
               <infoLinks/>
@@ -4115,7 +4123,7 @@
               </constraints>
               <categoryLinks/>
             </entryLink>
-            <entryLink id="10eb-70c9-d19b-8967" name="New EntryLink" hidden="false" targetId="6f9a-c4fe-3132-d011" type="selectionEntry">
+            <entryLink id="10eb-70c9-d19b-8967" name="Force stave" hidden="false" targetId="6f9a-c4fe-3132-d011" type="selectionEntry">
               <profiles/>
               <rules/>
               <infoLinks/>
@@ -4176,7 +4184,7 @@
         </selectionEntryGroup>
       </selectionEntryGroups>
       <entryLinks>
-        <entryLink id="d983-4af4-8f95-a1e6" name="New EntryLink" hidden="false" targetId="cddf-945e-1335-e681" type="selectionEntry">
+        <entryLink id="d983-4af4-8f95-a1e6" name="Frag &amp; Krak grenades" hidden="false" targetId="cddf-945e-1335-e681" type="selectionEntry">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -6576,9 +6584,9 @@
         <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="19.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="6a69-f097-e443-531d" name="Sorcerer on Palanquin of Nurgle" page="" hidden="false" collective="false" type="model">
+    <selectionEntry id="6a69-f097-e443-531d" name="Sorcerer on Palanquin of Nurgle" book="Index: Chaos  -- FAQ 1.0" page="24" hidden="false" collective="false" type="model">
       <profiles>
-        <profile id="1b49-4914-edc7-d30a" name="Sorcerer on Palanquin of Nurgle" hidden="false" profileTypeId="800f-21d0-4387-c943" profileTypeName="Unit">
+        <profile id="1b49-4914-edc7-d30a" name="Sorcerer on Palanquin of Nurgle" book="Index: Chaos" page="24" hidden="false" profileTypeId="800f-21d0-4387-c943" profileTypeName="Unit">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -6595,7 +6603,7 @@
             <characteristic name="Save" characteristicTypeId="c0df-df94-abd7-e8d3" value="3+"/>
           </characteristics>
         </profile>
-        <profile id="bf7f-4b14-ed3a-da8d" name="Sorcerer" hidden="false" profileTypeId="bc97-dea9-9e88-bb7d" profileTypeName="Psyker">
+        <profile id="bf7f-4b14-ed3a-da8d" name="Sorcerer" book="Index: Chaos" page="24" hidden="false" profileTypeId="bc97-dea9-9e88-bb7d" profileTypeName="Psyker">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -6621,6 +6629,62 @@
       <constraints/>
       <categoryLinks>
         <categoryLink id="9c63-7e93-6f17-2562" name="New CategoryLink" hidden="false" targetId="5cf1-acf2-ca3b-c2e5" primary="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
+        <categoryLink id="69ac-1cec-fed9-8aa0" name="New CategoryLink" hidden="false" targetId="0fb6-fcaf-b180-5dda" primary="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
+        <categoryLink id="d0b6-4433-d196-fd8b" name="New CategoryLink" hidden="false" targetId="ca10-a5dd-f54f-0ed5" primary="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
+        <categoryLink id="a8b0-f8b6-30b8-3831" name="New CategoryLink" hidden="false" targetId="8308-6393-0ce1-4bf9" primary="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
+        <categoryLink id="4861-1439-a151-4040" name="New CategoryLink" hidden="false" targetId="ad01-caec-17d9-cb8d" primary="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
+        <categoryLink id="3451-fab6-311c-42fe" name="New CategoryLink" hidden="false" targetId="ef18-746a-369f-43a4" primary="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
+        <categoryLink id="d295-b7ae-4d04-9c48" name="New CategoryLink" hidden="false" targetId="0bc5-6451-5612-4a25" primary="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
+        <categoryLink id="1335-34ec-7bd7-82f1" name="New CategoryLink" hidden="false" targetId="848a6ff2-0def-4c72-8433-ff7da70e6bc7" primary="true">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
+        <categoryLink id="135d-45a6-2cab-a907" name="New CategoryLink" hidden="false" targetId="e691-aad7-d21c-1023" primary="false">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -6664,7 +6728,7 @@
         </selectionEntry>
       </selectionEntries>
       <selectionEntryGroups>
-        <selectionEntryGroup id="a939-d0b0-9b25-1ed1" name="Force sword options" hidden="false" collective="false">
+        <selectionEntryGroup id="a939-d0b0-9b25-1ed1" name="Force sword options" hidden="false" collective="false" defaultSelectionEntryId="7372-b5b8-afb4-6a4a">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -6677,7 +6741,7 @@
           <selectionEntries/>
           <selectionEntryGroups/>
           <entryLinks>
-            <entryLink id="7372-b5b8-afb4-6a4a" name="New EntryLink" hidden="false" targetId="07e7-1f9b-4c1c-aad9" type="selectionEntry">
+            <entryLink id="7372-b5b8-afb4-6a4a" name="Force sword" hidden="false" targetId="07e7-1f9b-4c1c-aad9" type="selectionEntry">
               <profiles/>
               <rules/>
               <infoLinks/>
@@ -6687,7 +6751,7 @@
               </constraints>
               <categoryLinks/>
             </entryLink>
-            <entryLink id="0f16-1feb-fbf9-0090" name="New EntryLink" hidden="false" targetId="4a0e-0f13-63c2-9aae" type="selectionEntry">
+            <entryLink id="0f16-1feb-fbf9-0090" name="Force axe" hidden="false" targetId="4a0e-0f13-63c2-9aae" type="selectionEntry">
               <profiles/>
               <rules/>
               <infoLinks/>
@@ -6697,7 +6761,7 @@
               </constraints>
               <categoryLinks/>
             </entryLink>
-            <entryLink id="4607-d3ee-ff1d-db18" name="New EntryLink" hidden="false" targetId="6f9a-c4fe-3132-d011" type="selectionEntry">
+            <entryLink id="4607-d3ee-ff1d-db18" name="Force stave" hidden="false" targetId="6f9a-c4fe-3132-d011" type="selectionEntry">
               <profiles/>
               <rules/>
               <infoLinks/>
@@ -6709,7 +6773,7 @@
             </entryLink>
           </entryLinks>
         </selectionEntryGroup>
-        <selectionEntryGroup id="1649-21f6-473a-26e1" name="Pistol options" hidden="false" collective="false">
+        <selectionEntryGroup id="1649-21f6-473a-26e1" name="Pistol options" hidden="false" collective="false" defaultSelectionEntryId="c753-0a99-9b07-2782">
           <profiles/>
           <rules/>
           <infoLinks/>

--- a/Chaos - Death Guard.cat
+++ b/Chaos - Death Guard.cat
@@ -4393,7 +4393,7 @@
       <profiles/>
       <rules/>
       <infoLinks>
-        <infoLink id="8666-4ddb-6bd0-fd99" name="New InfoLink" hidden="false" targetId="6644-7150-c910-865d" type="profile">
+        <infoLink id="8666-4ddb-6bd0-fd99" name="Smoke Launchers" hidden="false" targetId="c883-3078-1367-cc2c" type="profile">
           <profiles/>
           <rules/>
           <infoLinks/>

--- a/Chaos - Thousand Sons.cat
+++ b/Chaos - Thousand Sons.cat
@@ -4319,7 +4319,7 @@
       <profiles/>
       <rules/>
       <infoLinks>
-        <infoLink id="8666-4ddb-6bd0-fd99" name="New InfoLink" hidden="false" targetId="6644-7150-c910-865d" type="profile">
+        <infoLink id="8666-4ddb-6bd0-fd99" name="Smoke Launchers" hidden="false" targetId="c883-3078-1367-cc2c" type="profile">
           <profiles/>
           <rules/>
           <infoLinks/>


### PR DESCRIPTION
After starting fresh, I noticed V9 doesn't contain all the info needed to make Sorcerer on Palanquin of Nurgle available in the Death Guard List.  I've created the missing info.

This Fixes #703 and #704 they have been closed but should be re-opened and resolved.

See comment below -- also Fixes #762 and #763