### PR TITLE
bugfix:AM Set a default for a Company Commander's chainsword hand

### DIFF
--- a/Imperium - Astra Militarum.cat
+++ b/Imperium - Astra Militarum.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="53e9d88f-7463-8c27-fe67-e1a0d1ed0287" name="Imperium - Astra Militarum" revision="34" battleScribeVersion="2.01" authorName="Alphalas" authorContact="Gitter: @Alphalas, twitter: @kingoverlord" authorUrl="http://battlescribedata.appspot.com/#/repo/wh40k" gameSystemId="28ec-711c-d87f-3aeb" gameSystemRevision="1" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="53e9d88f-7463-8c27-fe67-e1a0d1ed0287" name="Imperium - Astra Militarum" revision="35" battleScribeVersion="2.01" authorName="Alphalas" authorContact="Gitter: @Alphalas, twitter: @kingoverlord" authorUrl="http://battlescribedata.appspot.com/#/repo/wh40k" gameSystemId="28ec-711c-d87f-3aeb" gameSystemRevision="1" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <profiles/>
   <rules/>
   <infoLinks/>
@@ -6920,7 +6920,7 @@
       <categoryLinks/>
       <selectionEntries/>
       <selectionEntryGroups>
-        <selectionEntryGroup id="6593-9d0a-53ce-5d6e" name="Chainsword" hidden="false" collective="false">
+        <selectionEntryGroup id="6593-9d0a-53ce-5d6e" name="Chainsword" hidden="false" collective="false" defaultSelectionEntryId="5eb7-4ef4-9213-c8a5">
           <profiles/>
           <rules/>
           <infoLinks/>


### PR DESCRIPTION
Changed default weapon in a Company Commander's chainsword hand from noting to a chainsword (like in the index).

This is to avoid the error: "Company Commander must have 1 more selections from Chainsword (minimum 1)" when adding a Company Commander