### PR TITLE
Chaos updates

### DIFF
--- a/Chaos - Chaos Space Marines.cat
+++ b/Chaos - Chaos Space Marines.cat
@@ -1288,7 +1288,15 @@
               <profiles/>
               <rules/>
               <infoLinks/>
-              <modifiers/>
+              <modifiers>
+                <modifier type="set" field="13fc-b29b-31f2-ab9f" value="3">
+                  <repeats/>
+                  <conditions>
+                    <condition field="selections" scope="1c33-1745-41e1-1d76" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="81a1-634f-6fb3-1eb1" type="equalTo"/>
+                  </conditions>
+                  <conditionGroups/>
+                </modifier>
+              </modifiers>
               <characteristics>
                 <characteristic name="M" characteristicTypeId="0bdf-a96e-9e38-7779" value="6&quot;"/>
                 <characteristic name="WS" characteristicTypeId="e7f0-1278-0250-df0c" value="4+"/>
@@ -1446,10 +1454,29 @@
               <entryLinks/>
               <costs>
                 <cost name="pts" costTypeId="points" value="5.0"/>
+                <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="6298-60d3-c71c-ede1" name="Chaos Cultist w/ autopistol and brutal assault weapon" hidden="false" collective="false" type="model">
-              <profiles/>
+              <profiles>
+                <profile id="4cb2-a66f-860c-2b64" name="Chaos Cultist w/ Brutal assault weapon" hidden="false" profileTypeId="800f-21d0-4387-c943" profileTypeName="Unit">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <characteristics>
+                    <characteristic name="M" characteristicTypeId="0bdf-a96e-9e38-7779" value="6&quot;"/>
+                    <characteristic name="WS" characteristicTypeId="e7f0-1278-0250-df0c" value="4+"/>
+                    <characteristic name="BS" characteristicTypeId="381b-eb28-74c3-df5f" value="4+"/>
+                    <characteristic name="S" characteristicTypeId="2218-aa3c-265f-2939" value="3"/>
+                    <characteristic name="T" characteristicTypeId="9c9f-9774-a358-3a39" value="3"/>
+                    <characteristic name="W" characteristicTypeId="f330-5e6e-4110-0978" value="1"/>
+                    <characteristic name="A" characteristicTypeId="13fc-b29b-31f2-ab9f" value="2"/>
+                    <characteristic name="Ld" characteristicTypeId="00ca-f8b8-876d-b705" value="5"/>
+                    <characteristic name="Save" characteristicTypeId="c0df-df94-abd7-e8d3" value="6+"/>
+                  </characteristics>
+                </profile>
+              </profiles>
               <rules/>
               <infoLinks/>
               <modifiers/>
@@ -1476,7 +1503,10 @@
                   <selectionEntries/>
                   <selectionEntryGroups/>
                   <entryLinks/>
-                  <costs/>
+                  <costs>
+                    <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="0.0"/>
+                    <cost name="pts" costTypeId="points" value="0.0"/>
+                  </costs>
                 </selectionEntry>
               </selectionEntries>
               <selectionEntryGroups/>
@@ -16180,7 +16210,10 @@ D3   Bonus
       <selectionEntries/>
       <selectionEntryGroups/>
       <entryLinks/>
-      <costs/>
+      <costs>
+        <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="0.0"/>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
     </selectionEntry>
   </sharedSelectionEntries>
   <sharedSelectionEntryGroups>
@@ -17498,7 +17531,7 @@ D3   Bonus
         <characteristic name="S" characteristicTypeId="59b1-319e-ec13-d466" value="User"/>
         <characteristic name="AP" characteristicTypeId="75aa-a838-b675-6484" value="0"/>
         <characteristic name="D" characteristicTypeId="ae8a-3137-d65b-4ca7" value="1"/>
-        <characteristic name="Abilities" characteristicTypeId="837d-5e63-aeb7-1410" value="Each time the bearer fights, it can make 1 additional attack with this weapon."/>
+        <characteristic name="Abilities" characteristicTypeId="837d-5e63-aeb7-1410" value="Each time the bearer fights, it can make 1 additional attack with this weapon. This extra attack is included in its profile."/>
       </characteristics>
     </profile>
   </sharedProfiles>

--- a/Chaos - Chaos Space Marines.cat
+++ b/Chaos - Chaos Space Marines.cat
@@ -4,7 +4,20 @@
   <rules/>
   <infoLinks/>
   <costTypes/>
-  <profileTypes/>
+  <profileTypes>
+    <profileType id="ecda-13fc-b1ec-ed87" name="Enhanced Warriors">
+      <characteristicTypes>
+        <characteristicType id="e2e5-58a5-2283-3403" name="D3 Roll"/>
+        <characteristicType id="619a-9465-4a11-cd9e" name="Effect"/>
+      </characteristicTypes>
+    </profileType>
+    <profileType id="ab9e-0e23-5699-9d71" name="Mutated beyond reason">
+      <characteristicTypes>
+        <characteristicType id="7e36-5885-a0e4-79c0" name="D3 Roll"/>
+        <characteristicType id="7911-8c44-6fa5-a910" name="Result"/>
+      </characteristicTypes>
+    </profileType>
+  </profileTypes>
   <categoryEntries>
     <categoryEntry id="848a6ff2-0def-4c72-8433-ff7da70e6bc7" name="HQ" hidden="false">
       <profiles/>
@@ -49,13 +62,6 @@
       <constraints/>
     </categoryEntry>
     <categoryEntry id="d713cda3-5d0f-40d8-b621-69233263ec2a" name="Fortification" hidden="false">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <constraints/>
-    </categoryEntry>
-    <categoryEntry id="717b-8863-9d25-5e2a" name="Chaos" hidden="false">
       <profiles/>
       <rules/>
       <infoLinks/>
@@ -167,14 +173,14 @@
       <modifiers/>
       <constraints/>
     </categoryEntry>
-    <categoryEntry id="b2b6-8e4a-9c74-cc37" name="(Legion)" hidden="false">
+    <categoryEntry id="b2b6-8e4a-9c74-cc37" name="&lt;Legion&gt;" hidden="false">
       <profiles/>
       <rules/>
       <infoLinks/>
       <modifiers/>
       <constraints/>
     </categoryEntry>
-    <categoryEntry id="a61a-08c8-c7f7-9f78" name="(Mark of Chaos)" hidden="false">
+    <categoryEntry id="a61a-08c8-c7f7-9f78" name="&lt;Mark of Chaos&gt;" hidden="false">
       <profiles/>
       <rules/>
       <infoLinks/>
@@ -711,7 +717,7 @@
       <constraints/>
       <categoryLinks/>
     </entryLink>
-    <entryLink id="f43c-d68b-3d42-e8ee" name="New EntryLink" hidden="false" targetId="d990-6016-2e27-d72f" type="selectionEntry">
+    <entryLink id="f43c-d68b-3d42-e8ee" name="Khorne Berzerkers" hidden="false" targetId="d990-6016-2e27-d72f" type="selectionEntry">
       <profiles/>
       <rules/>
       <infoLinks/>
@@ -766,7 +772,7 @@
       <constraints/>
       <categoryLinks/>
     </entryLink>
-    <entryLink id="65d2-4d61-d7fc-f838" name="New EntryLink" hidden="false" targetId="5cae-15dc-4a5d-0b9b" type="selectionEntry">
+    <entryLink id="65d2-4d61-d7fc-f838" name="Helbrute" hidden="false" targetId="5cae-15dc-4a5d-0b9b" type="selectionEntry">
       <profiles/>
       <rules/>
       <infoLinks/>
@@ -920,7 +926,7 @@
       <constraints/>
       <categoryLinks/>
     </entryLink>
-    <entryLink id="5d60-16a5-e284-5b01" name="New EntryLink" hidden="false" targetId="04e3-0faf-a637-97f9" type="selectionEntry">
+    <entryLink id="5d60-16a5-e284-5b01" name="Cypher" hidden="false" targetId="04e3-0faf-a637-97f9" type="selectionEntry">
       <profiles/>
       <rules/>
       <infoLinks/>
@@ -936,7 +942,7 @@
       <constraints/>
       <categoryLinks/>
     </entryLink>
-    <entryLink id="ed30-3ce1-b203-4f61" name="New EntryLink" hidden="false" targetId="d3e7-290d-f3e8-6a14" type="selectionEntry">
+    <entryLink id="ed30-3ce1-b203-4f61" name="Lucius the Eternal" hidden="false" targetId="d3e7-290d-f3e8-6a14" type="selectionEntry">
       <profiles/>
       <rules/>
       <infoLinks/>
@@ -981,38 +987,43 @@
             <characteristic name="Save" characteristicTypeId="c0df-df94-abd7-e8d3" value="2+"/>
           </characteristics>
         </profile>
+        <profile id="d0a6-b5f9-be43-522d" name="Dark Destiny" hidden="false" profileTypeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" profileTypeName="Abilities">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Description" characteristicTypeId="21befb24-fc85-4f52-a745-64b2e48f8228" value="Abaddon the Despoiler has a 4+ invulnerable save. In addition, all damage suffered by Abaddon the Despoiler is halved (rounding up)."/>
+          </characteristics>
+        </profile>
+        <profile id="c621-6a0e-8fd2-bf4a" name="Lord of the Black Legion" hidden="false" profileTypeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" profileTypeName="Abilities">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Description" characteristicTypeId="21befb24-fc85-4f52-a745-64b2e48f8228" value="You can re-roll any failed hit rolls for friendly BLACK LEGION units that are within 6&quot; of Abaddon the Despoiler."/>
+          </characteristics>
+        </profile>
+        <profile id="7337-3435-3d29-0797" name="Mark of Chaos Ascendant" hidden="false" profileTypeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" profileTypeName="Abilities">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Description" characteristicTypeId="21befb24-fc85-4f52-a745-64b2e48f8228" value="Friendly HERETIC ASTARTES units automatically pass Morale tests whilst they are within 12&quot; of Abaddon the Despoiler."/>
+          </characteristics>
+        </profile>
       </profiles>
-      <rules>
-        <rule id="7d54-b53b-ea67-8a57" name="Mark of Chaos Ascendant" hidden="false">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <description>Friendly Heretic Astartes units automatically pass Morale tests whilst they are within 12&quot; of Abaddon the Despoiler. </description>
-        </rule>
-        <rule id="8501-e3cd-d0c3-961b" name="Dark Destiny" hidden="false">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <description>Abaddon the Despoiler has a 4++. In additiona, all damage suffered by Abaddon the Despoiler is halved (rounded</description>
-        </rule>
-        <rule id="b3f0-ea4a-b7cd-c3b4" name="Lord of the Black Legion" hidden="false">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <description>You can re-roll any failed hit rolls for friendly Black Legion units that are within 6&quot; of Abaddon the Despoiler.</description>
-        </rule>
-      </rules>
+      <rules/>
       <infoLinks>
-        <infoLink id="e685-41fa-bce4-2e85" name="New InfoLink" hidden="false" targetId="6349-022a-cea9-524c" type="rule">
+        <infoLink id="e685-41fa-bce4-2e85" name="Death to the False Emperor" hidden="false" targetId="37a4-1d84-4ef0-c4f6" type="profile">
           <profiles/>
           <rules/>
           <infoLinks/>
           <modifiers/>
         </infoLink>
-        <infoLink id="797f-330b-d419-07e4" name="New InfoLink" hidden="false" targetId="ae9c-d115-d4a9-ba02" type="rule">
+        <infoLink id="797f-330b-d419-07e4" name="Teleport Strike" hidden="false" targetId="ae9c-d115-d4a9-ba02" type="rule">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -1060,13 +1071,6 @@
           <constraints/>
         </categoryLink>
         <categoryLink id="2221-2977-a03e-0edd" name="New CategoryLink" hidden="false" targetId="ca10-a5dd-f54f-0ed5" primary="false">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints/>
-        </categoryLink>
-        <categoryLink id="cd41-804e-ef1f-2a06" name="New CategoryLink" hidden="false" targetId="717b-8863-9d25-5e2a" primary="false">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -1122,6 +1126,13 @@
           <modifiers/>
           <constraints/>
         </categoryLink>
+        <categoryLink id="210a-a888-29d6-b484" name="New CategoryLink" hidden="false" targetId="5cf1-acf2-ca3b-c2e5" primary="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="1a9d-dbb3-33f3-fb0d" name="Drach&apos;nyen" hidden="false" collective="false" type="upgrade">
@@ -1137,7 +1148,7 @@
                 <characteristic name="S" characteristicTypeId="59b1-319e-ec13-d466" value="+1"/>
                 <characteristic name="AP" characteristicTypeId="75aa-a838-b675-6484" value="-3"/>
                 <characteristic name="D" characteristicTypeId="ae8a-3137-d65b-4ca7" value="D3"/>
-                <characteristic name="Abilities" characteristicTypeId="837d-5e63-aeb7-1410" value="Roll a D6 each time Abaddon the Despoiler fights. On a 1 he suffers a MW and cannot use this weapon further during this phase. On a 2+ he can make that many additional attacks with this weapon."/>
+                <characteristic name="Abilities" characteristicTypeId="837d-5e63-aeb7-1410" value="Roll a D6 each time Abaddon the Despoiler fights. On a 1 he suffers a mortal wound and cannot use this weapon further during this phase. On a 2+ he can make that many additional attacks with this weapon."/>
               </characteristics>
             </profile>
           </profiles>
@@ -1259,13 +1270,6 @@
           <modifiers/>
           <constraints/>
         </categoryLink>
-        <categoryLink id="c0ab-8c39-9311-f0fd" name="New CategoryLink" hidden="false" targetId="717b-8863-9d25-5e2a" primary="false">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints/>
-        </categoryLink>
         <categoryLink id="803d-fb75-f2ff-b095" name="New CategoryLink" hidden="false" targetId="ca10-a5dd-f54f-0ed5" primary="false">
           <profiles/>
           <rules/>
@@ -1274,6 +1278,13 @@
           <constraints/>
         </categoryLink>
         <categoryLink id="e18b-a952-545c-8c08" name="New CategoryLink" hidden="false" targetId="3d52-fccf-10c0-3fae" primary="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
+        <categoryLink id="2d39-3392-2c8a-fde4" name="New CategoryLink" hidden="false" targetId="5cf1-acf2-ca3b-c2e5" primary="false">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -1661,7 +1672,7 @@
           <infoLinks/>
           <modifiers/>
           <characteristics>
-            <characteristic name="Capacity" characteristicTypeId="15aa-1916-a38b-d223" value="This model can transport 10 (Legion) Infantry models (each Terminator and Jump Pack model takes up the space of two other models, and each Cult of Destruction model takes up the space of three other models)."/>
+            <characteristic name="Capacity" characteristicTypeId="15aa-1916-a38b-d223" value="This model can transport 10 &lt;LEGION&gt; INFANTRY models (each TERMINATOR and JUMP PACK model takes up the space of two other models, and each CULT OF DESTRUCTION model takes up the space of three other models)."/>
           </characteristics>
         </profile>
       </profiles>
@@ -1675,7 +1686,7 @@
         </rule>
       </rules>
       <infoLinks>
-        <infoLink id="dde5-7b3e-b575-fee1" name="New InfoLink" hidden="false" targetId="b4eb-f3f5-d439-1834" type="rule">
+        <infoLink id="dde5-7b3e-b575-fee1" name="Daemonic Machine Spirit" hidden="false" targetId="9676-5c4d-7ae8-461b" type="profile">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -1713,7 +1724,7 @@
           <modifiers/>
           <constraints/>
         </categoryLink>
-        <categoryLink id="8915-498e-2c97-92df" name="New CategoryLink" hidden="false" targetId="717b-8863-9d25-5e2a" primary="false">
+        <categoryLink id="5fa6-b56c-5946-8706" name="New CategoryLink" hidden="false" targetId="5cf1-acf2-ca3b-c2e5" primary="false">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -1750,7 +1761,7 @@
       </selectionEntries>
       <selectionEntryGroups/>
       <entryLinks>
-        <entryLink id="6cb3-ba32-f3e0-994b" name="New EntryLink" hidden="false" targetId="09d8-7790-ed3f-4d6d" type="selectionEntry">
+        <entryLink id="6cb3-ba32-f3e0-994b" name="Twin heavy bolter" hidden="false" targetId="09d8-7790-ed3f-4d6d" type="selectionEntry">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -1780,7 +1791,7 @@
           </constraints>
           <categoryLinks/>
         </entryLink>
-        <entryLink id="8137-a3b1-907d-704e" name="New EntryLink" hidden="false" targetId="45e8-d3d1-105b-90a3" type="selectionEntryGroup">
+        <entryLink id="8137-a3b1-907d-704e" name="Mark of Chaos" hidden="false" targetId="45e8-d3d1-105b-90a3" type="selectionEntryGroup">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -1788,7 +1799,7 @@
           <constraints/>
           <categoryLinks/>
         </entryLink>
-        <entryLink id="0ac2-6864-7700-b1f1" name="New EntryLink" hidden="false" targetId="5383-9a88-9883-e144" type="selectionEntryGroup">
+        <entryLink id="0ac2-6864-7700-b1f1" name="Combi-weapons" hidden="false" targetId="5383-9a88-9883-e144" type="selectionEntryGroup">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -1824,19 +1835,19 @@
       </profiles>
       <rules/>
       <infoLinks>
-        <infoLink id="a271-ad31-2800-23e0" name="New InfoLink" hidden="false" targetId="6349-022a-cea9-524c" type="rule">
+        <infoLink id="a271-ad31-2800-23e0" name="Death to the False Emperor" hidden="false" targetId="37a4-1d84-4ef0-c4f6" type="profile">
           <profiles/>
           <rules/>
           <infoLinks/>
           <modifiers/>
         </infoLink>
-        <infoLink id="4da1-37f8-a2e0-faf8" name="New InfoLink" hidden="false" targetId="94d8-b556-103a-36ec" type="rule">
+        <infoLink id="4da1-37f8-a2e0-faf8" name="Sigil of Corruption" hidden="false" targetId="c237-7aca-a961-6c59" type="profile">
           <profiles/>
           <rules/>
           <infoLinks/>
           <modifiers/>
         </infoLink>
-        <infoLink id="6a3d-307f-ee7b-0a4d" name="New InfoLink" hidden="false" targetId="8ce7-b46b-12bd-dbb8" type="rule">
+        <infoLink id="6a3d-307f-ee7b-0a4d" name="Lord of Chaos" hidden="false" targetId="69a2-f63e-3d27-5c09" type="profile">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -1847,13 +1858,6 @@
       <constraints/>
       <categoryLinks>
         <categoryLink id="5fc1-46d1-60bd-bf52" name="New CategoryLink" hidden="false" targetId="848a6ff2-0def-4c72-8433-ff7da70e6bc7" primary="true">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints/>
-        </categoryLink>
-        <categoryLink id="6e0c-38d5-538f-44e6" name="New CategoryLink" hidden="false" targetId="717b-8863-9d25-5e2a" primary="false">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -1896,6 +1900,13 @@
           <constraints/>
         </categoryLink>
         <categoryLink id="d7a3-8151-7626-0937" name="New CategoryLink" hidden="false" targetId="a61a-08c8-c7f7-9f78" primary="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
+        <categoryLink id="00a8-ba91-4772-59d4" name="New CategoryLink" hidden="false" targetId="5cf1-acf2-ca3b-c2e5" primary="false">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -2117,7 +2128,7 @@
       </profiles>
       <rules/>
       <infoLinks>
-        <infoLink id="113f-c728-f886-9d6d" name="New InfoLink" hidden="false" targetId="3541-94a7-a138-358b" type="rule">
+        <infoLink id="113f-c728-f886-9d6d" name="Explodes" hidden="false" targetId="9446-1148-da70-4028" type="profile">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -2141,7 +2152,7 @@
           <modifiers/>
           <constraints/>
         </categoryLink>
-        <categoryLink id="87d8-f5ae-fc60-14bc" name="New CategoryLink" hidden="false" targetId="717b-8863-9d25-5e2a" primary="false">
+        <categoryLink id="87d8-f5ae-fc60-14bc" name="New CategoryLink" hidden="false" targetId="5cf1-acf2-ca3b-c2e5" primary="false">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -2327,16 +2338,40 @@
       </costs>
     </selectionEntry>
     <selectionEntry id="8a3b-80c7-0cf3-e044" name="Chaos Terminators" page="0" hidden="false" collective="false" type="unit">
-      <profiles/>
+      <profiles>
+        <profile id="d79b-2e76-7321-e45b" name="Chaos Terminator" hidden="false" profileTypeId="800f-21d0-4387-c943" profileTypeName="Unit">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="M" characteristicTypeId="0bdf-a96e-9e38-7779" value="5&quot;"/>
+            <characteristic name="WS" characteristicTypeId="e7f0-1278-0250-df0c" value="3+"/>
+            <characteristic name="BS" characteristicTypeId="381b-eb28-74c3-df5f" value="3+"/>
+            <characteristic name="S" characteristicTypeId="2218-aa3c-265f-2939" value="4"/>
+            <characteristic name="T" characteristicTypeId="9c9f-9774-a358-3a39" value="4"/>
+            <characteristic name="W" characteristicTypeId="f330-5e6e-4110-0978" value="2"/>
+            <characteristic name="A" characteristicTypeId="13fc-b29b-31f2-ab9f" value="2"/>
+            <characteristic name="Ld" characteristicTypeId="00ca-f8b8-876d-b705" value="8"/>
+            <characteristic name="Save" characteristicTypeId="c0df-df94-abd7-e8d3" value="2+"/>
+          </characteristics>
+        </profile>
+      </profiles>
       <rules/>
       <infoLinks>
-        <infoLink id="2835-d046-8ce7-775d" name="New InfoLink" hidden="false" targetId="6349-022a-cea9-524c" type="rule">
+        <infoLink id="2835-d046-8ce7-775d" name="Death to the False Emperor" hidden="false" targetId="37a4-1d84-4ef0-c4f6" type="profile">
           <profiles/>
           <rules/>
           <infoLinks/>
           <modifiers/>
         </infoLink>
         <infoLink id="eba0-a7bc-2c3a-d807" name="New InfoLink" hidden="false" targetId="ae9c-d115-d4a9-ba02" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="7646-3052-fb3b-bc96" name="Terminator Armour" hidden="false" targetId="aa2e-f0e5-04d3-aae3" type="profile">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -2368,7 +2403,7 @@
           <modifiers/>
           <constraints/>
         </categoryLink>
-        <categoryLink id="0110-8780-03ce-38f1" name="New CategoryLink" hidden="false" targetId="717b-8863-9d25-5e2a" primary="false">
+        <categoryLink id="0110-8780-03ce-38f1" name="New CategoryLink" hidden="false" targetId="5cf1-acf2-ca3b-c2e5" primary="false">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -2397,63 +2432,148 @@
           <constraints/>
         </categoryLink>
       </categoryLinks>
-      <selectionEntries/>
+      <selectionEntries>
+        <selectionEntry id="d2c0-5ffd-5cb4-6158" name="Chaos Terminator Champion" hidden="false" collective="false" type="model">
+          <profiles>
+            <profile id="9a5d-681c-a5ff-2f22" name="Chaos Terminator Champion" hidden="false" profileTypeId="800f-21d0-4387-c943" profileTypeName="Unit">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <characteristics>
+                <characteristic name="M" characteristicTypeId="0bdf-a96e-9e38-7779" value="5&quot;"/>
+                <characteristic name="WS" characteristicTypeId="e7f0-1278-0250-df0c" value="3+"/>
+                <characteristic name="BS" characteristicTypeId="381b-eb28-74c3-df5f" value="3+"/>
+                <characteristic name="S" characteristicTypeId="2218-aa3c-265f-2939" value="4"/>
+                <characteristic name="T" characteristicTypeId="9c9f-9774-a358-3a39" value="4"/>
+                <characteristic name="W" characteristicTypeId="f330-5e6e-4110-0978" value="2"/>
+                <characteristic name="A" characteristicTypeId="13fc-b29b-31f2-ab9f" value="3"/>
+                <characteristic name="Ld" characteristicTypeId="00ca-f8b8-876d-b705" value="9"/>
+                <characteristic name="Save" characteristicTypeId="c0df-df94-abd7-e8d3" value="2+"/>
+              </characteristics>
+            </profile>
+          </profiles>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a214-5746-efb4-5dcc" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="cbb5-9a40-ffbc-db6d" type="min"/>
+          </constraints>
+          <categoryLinks/>
+          <selectionEntries/>
+          <selectionEntryGroups>
+            <selectionEntryGroup id="346a-8e3e-4a06-99e5" name="Combi-bolter options" hidden="false" collective="false" defaultSelectionEntryId="3930-0a97-f483-d940">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="c758-c9a0-bc73-65dd" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="1710-dbca-b114-b4a8" type="max"/>
+              </constraints>
+              <categoryLinks/>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks>
+                <entryLink id="c18e-0644-0b5f-23ba" name="Combi-weapons" hidden="false" targetId="5383-9a88-9883-e144" type="selectionEntryGroup">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                  <categoryLinks/>
+                </entryLink>
+                <entryLink id="3930-0a97-f483-d940" name="Combi-bolter" hidden="false" targetId="082c-9397-0c1c-dd36" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="cc21-f572-5042-d151" type="max"/>
+                  </constraints>
+                  <categoryLinks/>
+                </entryLink>
+              </entryLinks>
+            </selectionEntryGroup>
+            <selectionEntryGroup id="b31e-be55-227a-2d38" name="Power axe options" hidden="false" collective="false" defaultSelectionEntryId="ff06-ae85-ca99-113f">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="7016-b568-7c24-5358" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="5374-854b-35ca-867d" type="max"/>
+              </constraints>
+              <categoryLinks/>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks>
+                <entryLink id="ff06-ae85-ca99-113f" name="Power axe" hidden="false" targetId="3292-34e6-f679-d5b9" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3420-92a8-b906-ebfd" type="max"/>
+                  </constraints>
+                  <categoryLinks/>
+                </entryLink>
+                <entryLink id="41a2-a605-c04b-bbbd" name="Terminator Melee Weapons" hidden="false" targetId="2607-d554-732e-c0b0" type="selectionEntryGroup">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6abb-344f-738a-6caa" type="max"/>
+                  </constraints>
+                  <categoryLinks/>
+                </entryLink>
+              </entryLinks>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="31.0"/>
+            <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="0.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
       <selectionEntryGroups>
-        <selectionEntryGroup id="05eb-15d3-8dd3-01ea" name="Unit size: 5-10 Models" hidden="false" collective="false">
+        <selectionEntryGroup id="46af-d032-70d6-777c" name="Chaos Terminator" hidden="false" collective="false" defaultSelectionEntryId="97bd-ee10-9c11-10b5">
           <profiles/>
           <rules/>
           <infoLinks/>
           <modifiers/>
           <constraints>
-            <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="713b-4649-781c-0bb2" type="min"/>
-            <constraint field="selections" scope="parent" value="10.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="09c9-d557-ae70-59eb" type="max"/>
+            <constraint field="selections" scope="parent" value="9.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ef10-e34d-ae48-9e06" type="max"/>
+            <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="375e-7532-fe6d-cef7" type="min"/>
           </constraints>
           <categoryLinks/>
           <selectionEntries>
-            <selectionEntry id="8613-270c-cfb3-6601" name="Chaos Terminator" page="0" hidden="false" collective="false" type="model">
-              <profiles>
-                <profile id="afc7-9563-155e-b3d9" name="Chaos Terminator" hidden="false" profileTypeId="800f-21d0-4387-c943" profileTypeName="Unit">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                  <characteristics>
-                    <characteristic name="M" characteristicTypeId="0bdf-a96e-9e38-7779" value="5&quot;"/>
-                    <characteristic name="WS" characteristicTypeId="e7f0-1278-0250-df0c" value="3+"/>
-                    <characteristic name="BS" characteristicTypeId="381b-eb28-74c3-df5f" value="3+"/>
-                    <characteristic name="S" characteristicTypeId="2218-aa3c-265f-2939" value="4"/>
-                    <characteristic name="T" characteristicTypeId="9c9f-9774-a358-3a39" value="4"/>
-                    <characteristic name="W" characteristicTypeId="f330-5e6e-4110-0978" value="2"/>
-                    <characteristic name="A" characteristicTypeId="13fc-b29b-31f2-ab9f" value="2"/>
-                    <characteristic name="Ld" characteristicTypeId="00ca-f8b8-876d-b705" value="8"/>
-                    <characteristic name="Save" characteristicTypeId="c0df-df94-abd7-e8d3" value="2+"/>
-                  </characteristics>
-                </profile>
-              </profiles>
+            <selectionEntry id="97bd-ee10-9c11-10b5" name="Terminator" hidden="false" collective="false" type="upgrade">
+              <profiles/>
               <rules/>
               <infoLinks/>
               <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="fab8-2328-6cf1-6c43" type="min"/>
-                <constraint field="selections" scope="parent" value="9.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="0a5e-f5a3-d02f-1298" type="max"/>
-              </constraints>
+              <constraints/>
               <categoryLinks/>
               <selectionEntries/>
               <selectionEntryGroups>
-                <selectionEntryGroup id="6cf0-e6f1-67ee-45bf" name="Power axe options" hidden="false" collective="false" defaultSelectionEntryId="db3f-0053-5c36-0b19">
+                <selectionEntryGroup id="660f-a33f-012b-0b9d" name="Combi-bolter options" hidden="false" collective="false" defaultSelectionEntryId="add7-0894-df42-4485">
                   <profiles/>
                   <rules/>
                   <infoLinks/>
                   <modifiers/>
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="362e-b5e9-d922-4ace" type="min"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="d676-2d75-6adf-1c39" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="d2e9-c0f1-8aa7-4646" type="min"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="f6ab-2382-3869-23fd" type="max"/>
                   </constraints>
                   <categoryLinks/>
                   <selectionEntries/>
                   <selectionEntryGroups/>
                   <entryLinks>
-                    <entryLink id="db3f-0053-5c36-0b19" name="New EntryLink" hidden="false" targetId="3292-34e6-f679-d5b9" type="selectionEntry">
+                    <entryLink id="4e00-1cb8-074e-7fac" name="Combi-weapons" hidden="false" targetId="5383-9a88-9883-e144" type="selectionEntryGroup">
                       <profiles/>
                       <rules/>
                       <infoLinks/>
@@ -2461,115 +2581,48 @@
                       <constraints/>
                       <categoryLinks/>
                     </entryLink>
-                    <entryLink id="adac-3c63-2f76-7f6c" name="New EntryLink" hidden="false" targetId="2607-d554-732e-c0b0" type="selectionEntryGroup">
+                    <entryLink id="add7-0894-df42-4485" name="Combi-bolter" hidden="false" targetId="082c-9397-0c1c-dd36" type="selectionEntry">
                       <profiles/>
                       <rules/>
                       <infoLinks/>
                       <modifiers/>
-                      <constraints/>
+                      <constraints>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="67e7-3ec6-995d-2b73" type="max"/>
+                      </constraints>
                       <categoryLinks/>
                     </entryLink>
                   </entryLinks>
                 </selectionEntryGroup>
-                <selectionEntryGroup id="cf71-335a-d177-feae" name="Combi-bolter options" hidden="false" collective="false" defaultSelectionEntryId="3326-bc2d-64cd-eb68">
+                <selectionEntryGroup id="c37f-04b9-90e9-c3ea" name="Power axe options" hidden="false" collective="false" defaultSelectionEntryId="3484-3995-d078-3fb5">
                   <profiles/>
                   <rules/>
                   <infoLinks/>
                   <modifiers/>
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="9c63-73c0-bdd7-2332" type="min"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="d1f4-3bd3-5456-4545" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="5645-738c-31c4-491a" type="min"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="950d-36f9-b043-0520" type="max"/>
                   </constraints>
                   <categoryLinks/>
                   <selectionEntries/>
                   <selectionEntryGroups/>
                   <entryLinks>
-                    <entryLink id="1605-e09e-1f9d-a285" name="New EntryLink" hidden="false" targetId="5383-9a88-9883-e144" type="selectionEntryGroup">
+                    <entryLink id="3484-3995-d078-3fb5" name="Power axe" hidden="false" targetId="3292-34e6-f679-d5b9" type="selectionEntry">
                       <profiles/>
                       <rules/>
                       <infoLinks/>
                       <modifiers/>
-                      <constraints/>
-                      <categoryLinks/>
-                    </entryLink>
-                    <entryLink id="709b-6ffd-5973-3d6f" name="New EntryLink" hidden="false" targetId="18bc-b335-29c2-2ae2" type="selectionEntry">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks/>
-                      <modifiers>
-                        <modifier type="increment" field="16b6-d5c5-947f-2ec0" value="1">
-                          <repeats>
-                            <repeat field="selections" scope="8a3b-80c7-0cf3-e044" value="5.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="model" repeats="1" roundUp="false"/>
-                          </repeats>
-                          <conditions/>
-                          <conditionGroups/>
-                        </modifier>
-                        <modifier type="set" field="hidden" value="true">
-                          <repeats/>
-                          <conditions>
-                            <condition field="selections" scope="8a3b-80c7-0cf3-e044" value="5.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="model" type="lessThan"/>
-                          </conditions>
-                          <conditionGroups/>
-                        </modifier>
-                      </modifiers>
                       <constraints>
-                        <constraint field="selections" scope="8613-270c-cfb3-6601" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="16b6-d5c5-947f-2ec0" type="max"/>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9dde-066c-b49c-169f" type="max"/>
                       </constraints>
                       <categoryLinks/>
                     </entryLink>
-                    <entryLink id="6122-0801-e549-614b" name="New EntryLink" hidden="false" targetId="5ab4-1ee7-95ad-7e15" type="selectionEntry">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks/>
-                      <modifiers>
-                        <modifier type="increment" field="5fb7-ab40-a152-8902" value="1">
-                          <repeats>
-                            <repeat field="selections" scope="8a3b-80c7-0cf3-e044" value="5.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="model" repeats="1" roundUp="false"/>
-                          </repeats>
-                          <conditions/>
-                          <conditionGroups/>
-                        </modifier>
-                        <modifier type="set" field="hidden" value="true">
-                          <repeats/>
-                          <conditions>
-                            <condition field="selections" scope="8a3b-80c7-0cf3-e044" value="5.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="model" type="lessThan"/>
-                          </conditions>
-                          <conditionGroups/>
-                        </modifier>
-                      </modifiers>
-                      <constraints>
-                        <constraint field="selections" scope="8613-270c-cfb3-6601" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="5fb7-ab40-a152-8902" type="max"/>
-                      </constraints>
-                      <categoryLinks/>
-                    </entryLink>
-                    <entryLink id="3326-bc2d-64cd-eb68" name="New EntryLink" hidden="false" targetId="082c-9397-0c1c-dd36" type="selectionEntry">
+                    <entryLink id="987b-b25f-315f-ce27" name="Terminator Melee Weapons" hidden="false" targetId="2607-d554-732e-c0b0" type="selectionEntryGroup">
                       <profiles/>
                       <rules/>
                       <infoLinks/>
                       <modifiers/>
-                      <constraints/>
-                      <categoryLinks/>
-                    </entryLink>
-                    <entryLink id="159d-9168-9d35-ba28" name="Lightning claw" hidden="false" targetId="0d37-6229-c7e7-54a7" type="selectionEntry">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks/>
-                      <modifiers>
-                        <modifier type="set" field="hidden" value="true">
-                          <repeats/>
-                          <conditions>
-                            <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e833-e504-c446-48e6" type="equalTo"/>
-                          </conditions>
-                          <conditionGroups/>
-                        </modifier>
-                        <modifier type="set" field="points" value="4">
-                          <repeats/>
-                          <conditions/>
-                          <conditionGroups/>
-                        </modifier>
-                      </modifiers>
                       <constraints>
-                        <constraint field="selections" scope="8613-270c-cfb3-6601" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="36f6-da1f-f6fb-65cf" type="max"/>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3632-44e2-a2b4-d8fe" type="max"/>
                       </constraints>
                       <categoryLinks/>
                     </entryLink>
@@ -2582,123 +2635,101 @@
                 <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="0.0"/>
               </costs>
             </selectionEntry>
-            <selectionEntry id="271c-24a1-4048-db9c" name="Terminator Champion" page="0" hidden="false" collective="false" type="model">
-              <profiles>
-                <profile id="3252-4a4b-27e9-c072" name="Terminator Champion" page="0" hidden="false" profileTypeId="800f-21d0-4387-c943" profileTypeName="Unit">
+            <selectionEntry id="4e3f-1db3-5eba-1a28" name="Terminator w/ Lightning Claws" hidden="false" collective="false" type="model">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+              <categoryLinks/>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks>
+                <entryLink id="642b-7dfc-770d-6865" name="Lightning Claw (Pair)" hidden="false" targetId="7603-6241-ab8b-4603" type="selectionEntry">
                   <profiles/>
                   <rules/>
                   <infoLinks/>
                   <modifiers/>
-                  <characteristics>
-                    <characteristic name="M" characteristicTypeId="0bdf-a96e-9e38-7779" value="5&quot;"/>
-                    <characteristic name="WS" characteristicTypeId="e7f0-1278-0250-df0c" value="3+"/>
-                    <characteristic name="BS" characteristicTypeId="381b-eb28-74c3-df5f" value="3+"/>
-                    <characteristic name="S" characteristicTypeId="2218-aa3c-265f-2939" value="4"/>
-                    <characteristic name="T" characteristicTypeId="9c9f-9774-a358-3a39" value="4"/>
-                    <characteristic name="W" characteristicTypeId="f330-5e6e-4110-0978" value="2"/>
-                    <characteristic name="A" characteristicTypeId="13fc-b29b-31f2-ab9f" value="3"/>
-                    <characteristic name="Ld" characteristicTypeId="00ca-f8b8-876d-b705" value="9"/>
-                    <characteristic name="Save" characteristicTypeId="c0df-df94-abd7-e8d3" value="2+"/>
-                  </characteristics>
-                </profile>
-              </profiles>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4ba7-1ad8-cde5-6ca3" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3574-5a21-0914-8cc1" type="min"/>
+                  </constraints>
+                  <categoryLinks/>
+                </entryLink>
+              </entryLinks>
+              <costs>
+                <cost name="pts" costTypeId="points" value="31.0"/>
+                <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="50e5-a7e8-686b-ef1d" name="Terminator w/ Heavy Weapon" hidden="false" collective="false" type="model">
+              <profiles/>
               <rules/>
               <infoLinks/>
-              <modifiers/>
+              <modifiers>
+                <modifier type="increment" field="348b-53c4-39df-f2ff" value="1">
+                  <repeats/>
+                  <conditions>
+                    <condition field="selections" scope="8a3b-80c7-0cf3-e044" value="5.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="model" type="greaterThan"/>
+                  </conditions>
+                  <conditionGroups/>
+                </modifier>
+              </modifiers>
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="3764-330a-4d1c-f4df" type="min"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="dc8c-fe77-dd70-7dd8" type="max"/>
+                <constraint field="selections" scope="8a3b-80c7-0cf3-e044" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="348b-53c4-39df-f2ff" type="max"/>
               </constraints>
               <categoryLinks/>
               <selectionEntries/>
               <selectionEntryGroups>
-                <selectionEntryGroup id="36c3-ecdf-714a-bece" name="Power axe options" hidden="false" collective="false" defaultSelectionEntryId="d76e-0ce2-fd5e-6e53">
+                <selectionEntryGroup id="b9ef-0a42-7d5d-69c5" name="Weapon option" hidden="false" collective="false">
                   <profiles/>
                   <rules/>
                   <infoLinks/>
                   <modifiers/>
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="5d52-59a1-d316-7c30" type="min"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="bcd2-d4f3-64ca-5b7f" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b182-b109-fa1f-fa1c" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="91c2-b278-b4c9-9ae4" type="min"/>
                   </constraints>
                   <categoryLinks/>
                   <selectionEntries/>
                   <selectionEntryGroups/>
                   <entryLinks>
-                    <entryLink id="d76e-0ce2-fd5e-6e53" name="New EntryLink" hidden="false" targetId="3292-34e6-f679-d5b9" type="selectionEntry">
+                    <entryLink id="4c39-c058-7ab8-d746" name="Heavy flamer" hidden="false" targetId="18bc-b335-29c2-2ae2" type="selectionEntry">
                       <profiles/>
                       <rules/>
                       <infoLinks/>
                       <modifiers/>
-                      <constraints/>
-                      <categoryLinks/>
-                    </entryLink>
-                    <entryLink id="0fec-d7b9-1fd2-99a7" name="New EntryLink" hidden="false" targetId="2607-d554-732e-c0b0" type="selectionEntryGroup">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks/>
-                      <modifiers/>
-                      <constraints/>
-                      <categoryLinks/>
-                    </entryLink>
-                  </entryLinks>
-                </selectionEntryGroup>
-                <selectionEntryGroup id="e29a-b1aa-4a74-b068" name="Combi-bolter options" hidden="false" collective="false" defaultSelectionEntryId="cf5d-7d19-183c-6979">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                  <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="0477-77f1-ac22-e0c7" type="min"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="2e3e-6f64-cf99-bcf0" type="max"/>
-                  </constraints>
-                  <categoryLinks/>
-                  <selectionEntries/>
-                  <selectionEntryGroups/>
-                  <entryLinks>
-                    <entryLink id="f78f-ec88-64fe-903d" name="New EntryLink" hidden="false" targetId="5383-9a88-9883-e144" type="selectionEntryGroup">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks/>
-                      <modifiers/>
-                      <constraints/>
-                      <categoryLinks/>
-                    </entryLink>
-                    <entryLink id="7cd0-dcfc-e986-72cd" name="New EntryLink" hidden="false" targetId="0d37-6229-c7e7-54a7" type="selectionEntry">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks/>
-                      <modifiers>
-                        <modifier type="set" field="hidden" value="true">
-                          <repeats/>
-                          <conditions>
-                            <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e833-e504-c446-48e6" type="equalTo"/>
-                          </conditions>
-                          <conditionGroups/>
-                        </modifier>
-                        <modifier type="set" field="points" value="4">
-                          <repeats/>
-                          <conditions/>
-                          <conditionGroups/>
-                        </modifier>
-                      </modifiers>
                       <constraints>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="9faf-1347-c863-da9f" type="max"/>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="57cf-365a-0537-087f" type="max"/>
                       </constraints>
                       <categoryLinks/>
                     </entryLink>
-                    <entryLink id="cf5d-7d19-183c-6979" name="New EntryLink" hidden="false" targetId="082c-9397-0c1c-dd36" type="selectionEntry">
+                    <entryLink id="ab4e-6d53-0d33-749f" name="Reaper autocannon" hidden="false" targetId="5ab4-1ee7-95ad-7e15" type="selectionEntry">
                       <profiles/>
                       <rules/>
                       <infoLinks/>
                       <modifiers/>
-                      <constraints/>
+                      <constraints>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fdc0-9cf2-3896-1304" type="max"/>
+                      </constraints>
                       <categoryLinks/>
                     </entryLink>
                   </entryLinks>
                 </selectionEntryGroup>
               </selectionEntryGroups>
-              <entryLinks/>
+              <entryLinks>
+                <entryLink id="79f2-3b10-e658-b123" name="Power axe" hidden="false" targetId="3292-34e6-f679-d5b9" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ede6-6b8a-340c-98c0" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b7c6-b719-51cb-f001" type="min"/>
+                  </constraints>
+                  <categoryLinks/>
+                </entryLink>
+              </entryLinks>
               <costs>
                 <cost name="pts" costTypeId="points" value="31.0"/>
                 <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="0.0"/>
@@ -2710,7 +2741,7 @@
         </selectionEntryGroup>
       </selectionEntryGroups>
       <entryLinks>
-        <entryLink id="8e5b-0087-a187-f98a" name="New EntryLink" hidden="false" targetId="f995-21ce-bbe7-f8fe" type="selectionEntryGroup">
+        <entryLink id="8e5b-0087-a187-f98a" name="Mark of Chaos with Icons" hidden="false" targetId="f995-21ce-bbe7-f8fe" type="selectionEntryGroup">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -2794,7 +2825,7 @@
       </profiles>
       <rules/>
       <infoLinks>
-        <infoLink id="ba49-f4e3-1c2d-e149" name="New InfoLink" hidden="false" targetId="3541-94a7-a138-358b" type="rule">
+        <infoLink id="ba49-f4e3-1c2d-e149" name="Explodes" hidden="false" targetId="9446-1148-da70-4028" type="profile">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -2825,7 +2856,7 @@
           <modifiers/>
           <constraints/>
         </categoryLink>
-        <categoryLink id="1c9f-aeb4-804b-b65b" name="New CategoryLink" hidden="false" targetId="717b-8863-9d25-5e2a" primary="false">
+        <categoryLink id="1c9f-aeb4-804b-b65b" name="New CategoryLink" hidden="false" targetId="5cf1-acf2-ca3b-c2e5" primary="false">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -2931,7 +2962,15 @@
           <profiles/>
           <rules/>
           <infoLinks/>
-          <modifiers/>
+          <modifiers>
+            <modifier type="increment" field="13fc-b29b-31f2-ab9f" value="1">
+              <repeats/>
+              <conditions>
+                <condition field="selections" scope="c5a2-5d3b-99c9-7b99" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="d237-8733-7cdc-f0f1" type="equalTo"/>
+              </conditions>
+              <conditionGroups/>
+            </modifier>
+          </modifiers>
           <characteristics>
             <characteristic name="M" characteristicTypeId="0bdf-a96e-9e38-7779" value="8&quot;"/>
             <characteristic name="WS" characteristicTypeId="e7f0-1278-0250-df0c" value="2+"/>
@@ -2952,42 +2991,20 @@
           <characteristics>
             <characteristic name="Cast" characteristicTypeId="5afb-9914-904b-d3b3" value="1"/>
             <characteristic name="Deny" characteristicTypeId="b5ac-9c20-5d5a-6f9b" value="1"/>
-            <characteristic name="Powers Known" characteristicTypeId="69d7-b45e-00a2-7e46" value="1 Dark Hereticus"/>
+            <characteristic name="Powers Known" characteristicTypeId="69d7-b45e-00a2-7e46" value="Smite and one power from the Dark Hereticus discipline"/>
             <characteristic name="Other" characteristicTypeId="c2e2-f115-0003-5d7b" value=""/>
           </characteristics>
         </profile>
       </profiles>
-      <rules>
-        <rule id="43c7-4c6e-0253-c59d" name="Daemonic Allegiance" hidden="false">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <description>When you include a Daemon Prince in your army, you must choose which of the four Chaos Gods it owes its allegiance to: Khorne, Tzeentch, Nurgle, or Slaanesh. It then gains the appropriate keyword.</description>
-        </rule>
-        <rule id="0e00-be0f-ee90-f822" name="Prince of Chaos" hidden="false">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <description>You can re-roll hit rolls of 1 made for friendly (Legion) units within 6&quot; of this model. This ability also affects friendly Daemon units within 6&quot;, but only if they owe their allegiance to the same Chaos God e.g., Khorne Daemon units are only affected by Khorne Daemon Princes.</description>
-        </rule>
-        <rule id="122f-76fa-13ff-8763" name="Might over Magic" hidden="false">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <description>A Daemon Prince of Khorne increases its Attacks characteristic by 1.</description>
-        </rule>
-      </rules>
+      <rules/>
       <infoLinks>
-        <infoLink id="2c65-43c6-922d-0004" name="New InfoLink" hidden="false" targetId="6349-022a-cea9-524c" type="rule">
+        <infoLink id="2c65-43c6-922d-0004" name="Death to the False Emperor" hidden="false" targetId="37a4-1d84-4ef0-c4f6" type="profile">
           <profiles/>
           <rules/>
           <infoLinks/>
           <modifiers/>
         </infoLink>
-        <infoLink id="a861-3c9c-1034-761d" name="New InfoLink" hidden="false" targetId="2946-510b-88fb-5c9c" type="rule">
+        <infoLink id="a861-3c9c-1034-761d" name="Daemonic" hidden="false" targetId="94f5-82c3-bb66-ac0c" type="profile">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -3004,7 +3021,7 @@
           <modifiers/>
           <constraints/>
         </categoryLink>
-        <categoryLink id="0d5a-d049-541d-fff4" name="New CategoryLink" hidden="false" targetId="717b-8863-9d25-5e2a" primary="false">
+        <categoryLink id="0d5a-d049-541d-fff4" name="New CategoryLink" hidden="false" targetId="5cf1-acf2-ca3b-c2e5" primary="false">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -3094,6 +3111,358 @@
             </entryLink>
           </entryLinks>
         </selectionEntryGroup>
+        <selectionEntryGroup id="9086-75e4-9304-184b" name="Daemonic Allegiance" hidden="false" collective="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b2c8-8184-7266-5d2d" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="724b-eac7-9c38-d0b5" type="min"/>
+          </constraints>
+          <categoryLinks/>
+          <selectionEntries>
+            <selectionEntry id="d237-8733-7cdc-f0f1" name="Khorne" hidden="false" collective="false" type="upgrade">
+              <profiles>
+                <profile id="e922-8c24-4564-44f9" name="Prince of Chaos" hidden="false" profileTypeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" profileTypeName="Abilities">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <characteristics>
+                    <characteristic name="Description" characteristicTypeId="21befb24-fc85-4f52-a745-64b2e48f8228" value="You can re-roll hit rolls of 1 made for friendly KHORNE DAEMON units within 6&quot;."/>
+                  </characteristics>
+                </profile>
+              </profiles>
+              <rules/>
+              <infoLinks>
+                <infoLink id="6598-bde0-a2d7-9aa0" name="Unstoppable Ferocity" hidden="false" targetId="0d99-a301-149f-4537" type="profile">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                </infoLink>
+                <infoLink id="b52f-dffd-875d-c140" name="Might over Magic" hidden="false" targetId="95ad-c89a-501a-6c76" type="profile">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                </infoLink>
+              </infoLinks>
+              <modifiers/>
+              <constraints/>
+              <categoryLinks>
+                <categoryLink id="faba-dc13-96d0-6da0" name="New CategoryLink" hidden="false" targetId="dfc5-aa04-9546-1b4c" primary="false">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </categoryLink>
+              </categoryLinks>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks/>
+              <costs>
+                <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="0.0"/>
+                <cost name="pts" costTypeId="points" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="2cdb-c110-dfc0-ae79" name="Nurgle" hidden="false" collective="false" type="upgrade">
+              <profiles>
+                <profile id="f87c-92bc-434a-a639" name="Psyker" hidden="false" profileTypeId="bc97-dea9-9e88-bb7d" profileTypeName="Psyker">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <characteristics>
+                    <characteristic name="Cast" characteristicTypeId="5afb-9914-904b-d3b3" value="1"/>
+                    <characteristic name="Deny" characteristicTypeId="b5ac-9c20-5d5a-6f9b" value="1"/>
+                    <characteristic name="Powers Known" characteristicTypeId="69d7-b45e-00a2-7e46" value="Smite and one power from the Nurgle discipline"/>
+                    <characteristic name="Other" characteristicTypeId="c2e2-f115-0003-5d7b"/>
+                  </characteristics>
+                </profile>
+                <profile id="9fba-da82-3049-13b4" name="Prince of Chaos" hidden="false" profileTypeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" profileTypeName="Abilities">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <characteristics>
+                    <characteristic name="Description" characteristicTypeId="21befb24-fc85-4f52-a745-64b2e48f8228" value="You can re-roll hit rolls of 1 made for friendly NURGLE DAEMON units within 6&quot;."/>
+                  </characteristics>
+                </profile>
+              </profiles>
+              <rules/>
+              <infoLinks>
+                <infoLink id="5f1a-88b9-3cdd-aa8c" name="Disgustingly Resilient" hidden="false" targetId="649e-7454-0be4-7a71" type="profile">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                </infoLink>
+              </infoLinks>
+              <modifiers/>
+              <constraints/>
+              <categoryLinks>
+                <categoryLink id="952a-3c5f-4322-d3bb" name="New CategoryLink" hidden="false" targetId="0fb6-fcaf-b180-5dda" primary="false">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </categoryLink>
+                <categoryLink id="3df5-bf30-3680-48c9" name="New CategoryLink" hidden="false" targetId="e691-aad7-d21c-1023" primary="false">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </categoryLink>
+              </categoryLinks>
+              <selectionEntries>
+                <selectionEntry id="6072-f901-2584-1f64" name="Smite" hidden="false" collective="false" type="upgrade">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks>
+                    <infoLink id="fa23-e003-33fe-7130" name="Smite" hidden="false" targetId="5821-6c45-8572-7e0e" type="profile">
+                      <profiles/>
+                      <rules/>
+                      <infoLinks/>
+                      <modifiers/>
+                    </infoLink>
+                  </infoLinks>
+                  <modifiers/>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4156-cfdf-a928-6361" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d273-100d-09ba-1cd1" type="min"/>
+                  </constraints>
+                  <categoryLinks/>
+                  <selectionEntries/>
+                  <selectionEntryGroups/>
+                  <entryLinks/>
+                  <costs>
+                    <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="0.0"/>
+                    <cost name="pts" costTypeId="points" value="0.0"/>
+                  </costs>
+                </selectionEntry>
+              </selectionEntries>
+              <selectionEntryGroups/>
+              <entryLinks>
+                <entryLink id="6d57-467e-245a-4e90" name="Dark Hereticus discipline" hidden="false" targetId="0246-3399-3b88-44aa" type="selectionEntryGroup">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="46a9-bed5-b431-8c18" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="eb18-345c-f7b0-6c05" type="min"/>
+                  </constraints>
+                  <categoryLinks/>
+                </entryLink>
+              </entryLinks>
+              <costs>
+                <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="0.0"/>
+                <cost name="pts" costTypeId="points" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="2922-95ed-34df-8a9a" name="Slaanesh" hidden="false" collective="false" type="upgrade">
+              <profiles>
+                <profile id="1eaf-b327-77bc-325e" name="Psyker" hidden="false" profileTypeId="bc97-dea9-9e88-bb7d" profileTypeName="Psyker">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <characteristics>
+                    <characteristic name="Cast" characteristicTypeId="5afb-9914-904b-d3b3" value="1"/>
+                    <characteristic name="Deny" characteristicTypeId="b5ac-9c20-5d5a-6f9b" value="1"/>
+                    <characteristic name="Powers Known" characteristicTypeId="69d7-b45e-00a2-7e46" value="Smite and one power from the Slaanesh discipline"/>
+                    <characteristic name="Other" characteristicTypeId="c2e2-f115-0003-5d7b"/>
+                  </characteristics>
+                </profile>
+                <profile id="2b26-1a31-ed76-efbf" name="Prince of Chaos" hidden="false" profileTypeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" profileTypeName="Abilities">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <characteristics>
+                    <characteristic name="Description" characteristicTypeId="21befb24-fc85-4f52-a745-64b2e48f8228" value="You can re-roll hit rolls of 1 made for friendly SLAANESH DAEMON units within 6&quot;."/>
+                  </characteristics>
+                </profile>
+              </profiles>
+              <rules/>
+              <infoLinks>
+                <infoLink id="42c9-9895-9835-5817" name="Quicksilver Swiftness" hidden="false" targetId="b623-8135-5aa4-d13e" type="profile">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                </infoLink>
+              </infoLinks>
+              <modifiers/>
+              <constraints/>
+              <categoryLinks>
+                <categoryLink id="a58e-c98d-e590-2621" name="New CategoryLink" hidden="false" targetId="1da2-76db-f76f-6b6c" primary="false">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </categoryLink>
+                <categoryLink id="cfe9-1ba4-1d63-b2e7" name="New CategoryLink" hidden="false" targetId="e691-aad7-d21c-1023" primary="false">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </categoryLink>
+              </categoryLinks>
+              <selectionEntries>
+                <selectionEntry id="389d-8012-023e-1dd8" name="Smite" hidden="false" collective="false" type="upgrade">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks>
+                    <infoLink id="0032-0b2b-27e8-e664" name="Smite" hidden="false" targetId="5821-6c45-8572-7e0e" type="profile">
+                      <profiles/>
+                      <rules/>
+                      <infoLinks/>
+                      <modifiers/>
+                    </infoLink>
+                  </infoLinks>
+                  <modifiers/>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9f12-b76b-fa31-aff5" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3386-07eb-a617-ac71" type="min"/>
+                  </constraints>
+                  <categoryLinks/>
+                  <selectionEntries/>
+                  <selectionEntryGroups/>
+                  <entryLinks/>
+                  <costs>
+                    <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="0.0"/>
+                    <cost name="pts" costTypeId="points" value="0.0"/>
+                  </costs>
+                </selectionEntry>
+              </selectionEntries>
+              <selectionEntryGroups/>
+              <entryLinks>
+                <entryLink id="b9e2-c40b-bc4c-23f4" name="Dark Hereticus discipline" hidden="false" targetId="0246-3399-3b88-44aa" type="selectionEntryGroup">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f4de-889c-9577-903e" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6b26-8ba3-11e5-39e9" type="min"/>
+                  </constraints>
+                  <categoryLinks/>
+                </entryLink>
+              </entryLinks>
+              <costs>
+                <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="0.0"/>
+                <cost name="pts" costTypeId="points" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="c727-0a9c-0634-8acd" name="Tzeentch" hidden="false" collective="false" type="upgrade">
+              <profiles>
+                <profile id="5025-50a9-810c-d692" name="Psyker" hidden="false" profileTypeId="bc97-dea9-9e88-bb7d" profileTypeName="Psyker">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <characteristics>
+                    <characteristic name="Cast" characteristicTypeId="5afb-9914-904b-d3b3" value="1"/>
+                    <characteristic name="Deny" characteristicTypeId="b5ac-9c20-5d5a-6f9b" value="1"/>
+                    <characteristic name="Powers Known" characteristicTypeId="69d7-b45e-00a2-7e46" value="Smite and one power from the Tzeentch discipline"/>
+                    <characteristic name="Other" characteristicTypeId="c2e2-f115-0003-5d7b"/>
+                  </characteristics>
+                </profile>
+                <profile id="ad13-b63c-8187-0e50" name="Prince of Chaos" hidden="false" profileTypeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" profileTypeName="Abilities">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <characteristics>
+                    <characteristic name="Description" characteristicTypeId="21befb24-fc85-4f52-a745-64b2e48f8228" value="You can re-roll hit rolls of 1 made for friendly TZEENTCH DAEMON units within 6&quot;."/>
+                  </characteristics>
+                </profile>
+              </profiles>
+              <rules/>
+              <infoLinks>
+                <infoLink id="cb7b-1716-d684-30bd" name="Ephemeral Form" hidden="false" targetId="cb03-ddea-2ac5-9879" type="profile">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                </infoLink>
+              </infoLinks>
+              <modifiers/>
+              <constraints/>
+              <categoryLinks>
+                <categoryLink id="94a1-e9db-cb61-b3d5" name="New CategoryLink" hidden="false" targetId="012f-abfc-397b-3519" primary="false">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </categoryLink>
+                <categoryLink id="19dd-d698-4a63-298d" name="New CategoryLink" hidden="false" targetId="e691-aad7-d21c-1023" primary="false">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </categoryLink>
+              </categoryLinks>
+              <selectionEntries>
+                <selectionEntry id="6c4f-9337-f6e6-ed09" name="Smite" hidden="false" collective="false" type="upgrade">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks>
+                    <infoLink id="5ce8-26d4-e579-4b99" name="Smite" hidden="false" targetId="5821-6c45-8572-7e0e" type="profile">
+                      <profiles/>
+                      <rules/>
+                      <infoLinks/>
+                      <modifiers/>
+                    </infoLink>
+                  </infoLinks>
+                  <modifiers/>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ad30-fab7-6c79-d210" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a101-528f-a8e9-c6f1" type="min"/>
+                  </constraints>
+                  <categoryLinks/>
+                  <selectionEntries/>
+                  <selectionEntryGroups/>
+                  <entryLinks/>
+                  <costs>
+                    <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="0.0"/>
+                    <cost name="pts" costTypeId="points" value="0.0"/>
+                  </costs>
+                </selectionEntry>
+              </selectionEntries>
+              <selectionEntryGroups/>
+              <entryLinks>
+                <entryLink id="9265-a892-cf6f-61b7" name="Dark Hereticus discipline" hidden="false" targetId="0246-3399-3b88-44aa" type="selectionEntryGroup">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e435-c6c4-fca2-a279" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0bb2-580b-a8a9-507d" type="min"/>
+                  </constraints>
+                  <categoryLinks/>
+                </entryLink>
+              </entryLinks>
+              <costs>
+                <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="0.0"/>
+                <cost name="pts" costTypeId="points" value="0.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+          <selectionEntryGroups/>
+          <entryLinks/>
+        </selectionEntryGroup>
       </selectionEntryGroups>
       <entryLinks>
         <entryLink id="c884-fb3b-a6b9-fb68" name="New EntryLink" hidden="false" targetId="ab5a-b591-31e2-e0d0" type="selectionEntry">
@@ -3114,17 +3483,6 @@
           <modifiers/>
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f03d-8095-182f-bf4b" type="max"/>
-          </constraints>
-          <categoryLinks/>
-        </entryLink>
-        <entryLink id="0815-6225-1cbb-4df4" name="New EntryLink" hidden="false" targetId="45e8-d3d1-105b-90a3" type="selectionEntryGroup">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="579f-b3f0-2008-ce51" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a8ec-af52-f017-fd12" type="min"/>
           </constraints>
           <categoryLinks/>
         </entryLink>
@@ -3159,7 +3517,7 @@
           <infoLinks/>
           <modifiers/>
           <characteristics>
-            <characteristic name="Description" characteristicTypeId="21befb24-fc85-4f52-a745-64b2e48f8228" value="You can re-roll failed hit rolls in the Fight phase for friendly (Legion) units that are within 6&quot; of a Dark Apostle."/>
+            <characteristic name="Description" characteristicTypeId="21befb24-fc85-4f52-a745-64b2e48f8228" value="You can re-roll failed hit rolls in the Fight phase for friendly &lt;LEGION&gt; units that are within 6&quot; of a Dark Apostle."/>
           </characteristics>
         </profile>
         <profile id="5b7c-9678-aab9-717a" name="Demagogue" hidden="false" profileTypeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" profileTypeName="Abilities">
@@ -3168,19 +3526,19 @@
           <infoLinks/>
           <modifiers/>
           <characteristics>
-            <characteristic name="Description" characteristicTypeId="21befb24-fc85-4f52-a745-64b2e48f8228" value="All friendly (Legion) units that are within 6&quot; of a Dark Apostle in the Morale phase can use his Ld instead of their own."/>
+            <characteristic name="Description" characteristicTypeId="21befb24-fc85-4f52-a745-64b2e48f8228" value="All friendly &lt;LEGION&gt; units that are within 6&quot; of a Dark Apostle in the Morale phase can use his Leadership instead of their own."/>
           </characteristics>
         </profile>
       </profiles>
       <rules/>
       <infoLinks>
-        <infoLink id="86f7-7948-366c-cd43" name="New InfoLink" hidden="false" targetId="6349-022a-cea9-524c" type="rule">
+        <infoLink id="86f7-7948-366c-cd43" name="Death to the False Emperor" hidden="false" targetId="37a4-1d84-4ef0-c4f6" type="profile">
           <profiles/>
           <rules/>
           <infoLinks/>
           <modifiers/>
         </infoLink>
-        <infoLink id="2767-fdd5-92ad-a0f4" name="New InfoLink" hidden="false" targetId="94d8-b556-103a-36ec" type="rule">
+        <infoLink id="2767-fdd5-92ad-a0f4" name="Sigil of Corruption" hidden="false" targetId="c237-7aca-a961-6c59" type="profile">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -3197,7 +3555,7 @@
           <modifiers/>
           <constraints/>
         </categoryLink>
-        <categoryLink id="1fcc-b7e9-5a57-0a2e" name="New CategoryLink" hidden="false" targetId="717b-8863-9d25-5e2a" primary="false">
+        <categoryLink id="1fcc-b7e9-5a57-0a2e" name="New CategoryLink" hidden="false" targetId="5cf1-acf2-ca3b-c2e5" primary="false">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -3384,19 +3742,19 @@
       </profiles>
       <rules/>
       <infoLinks>
-        <infoLink id="5ab5-00ee-f312-6033" name="New InfoLink" hidden="false" targetId="3541-94a7-a138-358b" type="rule">
+        <infoLink id="5ab5-00ee-f312-6033" name="Explodes" hidden="false" targetId="9446-1148-da70-4028" type="profile">
           <profiles/>
           <rules/>
           <infoLinks/>
           <modifiers/>
         </infoLink>
-        <infoLink id="c736-96a1-f303-347b" name="New InfoLink" hidden="false" targetId="2946-510b-88fb-5c9c" type="rule">
+        <infoLink id="c736-96a1-f303-347b" name="Daemonic" hidden="false" targetId="94f5-82c3-bb66-ac0c" type="profile">
           <profiles/>
           <rules/>
           <infoLinks/>
           <modifiers/>
         </infoLink>
-        <infoLink id="7890-822a-4a71-8c31" name="New InfoLink" hidden="false" targetId="afd3-a04b-c770-90c1" type="rule">
+        <infoLink id="7890-822a-4a71-8c31" name="Infernal Regeneration" hidden="false" targetId="a46b-e84f-ab7b-a4e4" type="profile">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -3427,7 +3785,7 @@
           <modifiers/>
           <constraints/>
         </categoryLink>
-        <categoryLink id="3dd6-d756-d56c-d999" name="New CategoryLink" hidden="false" targetId="717b-8863-9d25-5e2a" primary="false">
+        <categoryLink id="3dd6-d756-d56c-d999" name="New CategoryLink" hidden="false" targetId="5cf1-acf2-ca3b-c2e5" primary="false">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -3708,30 +4066,58 @@
             <characteristic name="Save" characteristicTypeId="c0df-df94-abd7-e8d3" value="3+"/>
           </characteristics>
         </profile>
+        <profile id="b217-38db-3f0f-b3f2" name="The Chirurgeon" hidden="false" profileTypeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" profileTypeName="Abilities">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Description" characteristicTypeId="21befb24-fc85-4f52-a745-64b2e48f8228" value="At the beginning of each of your turns, Fabius Bile heals D3 wounds."/>
+          </characteristics>
+        </profile>
+        <profile id="4805-e90a-695b-00d2" name="Enhanced Warriors" hidden="false" profileTypeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" profileTypeName="Abilities">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Description" characteristicTypeId="21befb24-fc85-4f52-a745-64b2e48f8228" value="Fabius Bile can enhance one unit of HERETIC ASTARTES INFANTRY (but not CHARACTERS, they refuse the dubious honour of Bile&apos;s gifts) that is within 1&quot; of him at the end of any Movement phase. Roll a D6 for each model in the unit; the unit suffers 1 mortal wound for each roll of 6 (only the strong survive Bile&apos;s experimental cocktails). Then roll a D3 and refer to the table below to see what bonus the survivors gain for the rest of the battle. A unit can only be enhanced once per game.  D3   Bonus 1    Swollen Musculature: +1 S 2    Calcific Growths: +1 T 3    Berserk Rage: +1 A"/>
+          </characteristics>
+        </profile>
+        <profile id="e74a-22a1-3f58-e7b1" name="Enhanced Warriors 1" hidden="false" profileTypeId="ecda-13fc-b1ec-ed87" profileTypeName="Enhanced Warriors">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="D3 Roll" characteristicTypeId="e2e5-58a5-2283-3403" value="1"/>
+            <characteristic name="Effect" characteristicTypeId="619a-9465-4a11-cd9e" value="Swollen Musculature: +1 Strength"/>
+          </characteristics>
+        </profile>
+        <profile id="30f0-4a60-2881-8280" name="Enhanced Warriors 2" hidden="false" profileTypeId="ecda-13fc-b1ec-ed87" profileTypeName="Enhanced Warriors">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="D3 Roll" characteristicTypeId="e2e5-58a5-2283-3403" value="2"/>
+            <characteristic name="Effect" characteristicTypeId="619a-9465-4a11-cd9e" value="Calcific Growth: +1 Toughness"/>
+          </characteristics>
+        </profile>
+        <profile id="fd46-11c8-9f50-0ef9" name="Enhanced Warriors 3" hidden="false" profileTypeId="ecda-13fc-b1ec-ed87" profileTypeName="Enhanced Warriors">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="D3 Roll" characteristicTypeId="e2e5-58a5-2283-3403" value="3"/>
+            <characteristic name="Effect" characteristicTypeId="619a-9465-4a11-cd9e" value="Berserk Rage: +1 Attacks"/>
+          </characteristics>
+        </profile>
       </profiles>
-      <rules>
-        <rule id="c149-9768-be0b-98f0" name="The Chirugeon" hidden="false">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <description>At the beginning of each of your turns, Fabius Bile heals D3 wounds.</description>
-        </rule>
-        <rule id="061c-e73f-2197-a362" name="Enhanced Warriors" hidden="false">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <description>Fabius Bile can enhance one unit of Heretic Astartes Infantry (but no tCharacters, they refuse the dubious honour of Bile&apos;s gifts) that is within 1&quot; of him at the end of any Movement phase. Roll a D6 for each model in the unit; the unit suffers 1 MW for each roll of 6 (only the strong survive Bile&apos;s experimental cocktails). Then roll a D3 and refer to the table below to see what bonus the survivors gain for the rest of the battle. A unit can only be enhanced once per game.
-
-D3   Bonus
-1    Swolen Musculature: +1 S
-2    Calcific Growths: +1 T
-3    Berserk Rage: +1 A</description>
-        </rule>
-      </rules>
+      <rules/>
       <infoLinks>
-        <infoLink id="8238-1cde-01e9-ca9f" name="New InfoLink" hidden="false" targetId="6349-022a-cea9-524c" type="rule">
+        <infoLink id="8238-1cde-01e9-ca9f" name="Death to the False Emperor" hidden="false" targetId="37a4-1d84-4ef0-c4f6" type="profile">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -3764,7 +4150,7 @@ D3   Bonus
           <modifiers/>
           <constraints/>
         </categoryLink>
-        <categoryLink id="3c5d-8486-8847-d77e" name="New CategoryLink" hidden="false" targetId="717b-8863-9d25-5e2a" primary="false">
+        <categoryLink id="3c5d-8486-8847-d77e" name="New CategoryLink" hidden="false" targetId="5cf1-acf2-ca3b-c2e5" primary="false">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -3943,19 +4329,19 @@ D3   Bonus
       </profiles>
       <rules/>
       <infoLinks>
-        <infoLink id="b5dc-a119-b616-0f03" name="New InfoLink" hidden="false" targetId="3541-94a7-a138-358b" type="rule">
+        <infoLink id="b5dc-a119-b616-0f03" name="Explodes" hidden="false" targetId="9446-1148-da70-4028" type="profile">
           <profiles/>
           <rules/>
           <infoLinks/>
           <modifiers/>
         </infoLink>
-        <infoLink id="71ef-5e6a-edd6-0f09" name="New InfoLink" hidden="false" targetId="afd3-a04b-c770-90c1" type="rule">
+        <infoLink id="71ef-5e6a-edd6-0f09" name="Infernal Regeneration" hidden="false" targetId="a46b-e84f-ab7b-a4e4" type="profile">
           <profiles/>
           <rules/>
           <infoLinks/>
           <modifiers/>
         </infoLink>
-        <infoLink id="1320-b6d4-ec4d-1cf7" name="New InfoLink" hidden="false" targetId="2946-510b-88fb-5c9c" type="rule">
+        <infoLink id="1320-b6d4-ec4d-1cf7" name="Daemonic" hidden="false" targetId="94f5-82c3-bb66-ac0c" type="profile">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -3972,7 +4358,7 @@ D3   Bonus
           <modifiers/>
           <constraints/>
         </categoryLink>
-        <categoryLink id="298e-af21-8821-49df" name="New CategoryLink" hidden="false" targetId="717b-8863-9d25-5e2a" primary="false">
+        <categoryLink id="298e-af21-8821-49df" name="New CategoryLink" hidden="false" targetId="5cf1-acf2-ca3b-c2e5" primary="false">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -4066,24 +4452,16 @@ D3   Bonus
               </costs>
             </selectionEntry>
             <selectionEntry id="398b-d0b5-cd98-2f2a" name="2x Ectoplasma cannons" hidden="false" collective="false" type="upgrade">
-              <profiles>
-                <profile id="a83e-568a-eae2-4039" name="Ectoplasma cannon" hidden="false" profileTypeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" profileTypeName="Weapon">
+              <profiles/>
+              <rules/>
+              <infoLinks>
+                <infoLink id="1dfd-1a9e-7e9e-55b7" name="Ectoplasma cannon" hidden="false" targetId="ba8c-82d5-79c0-d0d9" type="profile">
                   <profiles/>
                   <rules/>
                   <infoLinks/>
                   <modifiers/>
-                  <characteristics>
-                    <characteristic name="Range" characteristicTypeId="6fa97fa8-ea74-4a27-a0fb-bc4e5f367464" value="24&quot;"/>
-                    <characteristic name="Type" characteristicTypeId="077c342f-d7b9-45c6-b8af-88e97cafd3a2" value="Heavy D3"/>
-                    <characteristic name="S" characteristicTypeId="59b1-319e-ec13-d466" value="7"/>
-                    <characteristic name="AP" characteristicTypeId="75aa-a838-b675-6484" value="-3"/>
-                    <characteristic name="D" characteristicTypeId="ae8a-3137-d65b-4ca7" value="D3"/>
-                    <characteristic name="Abilities" characteristicTypeId="837d-5e63-aeb7-1410" value="-"/>
-                  </characteristics>
-                </profile>
-              </profiles>
-              <rules/>
-              <infoLinks/>
+                </infoLink>
+              </infoLinks>
               <modifiers/>
               <constraints/>
               <categoryLinks/>
@@ -4141,24 +4519,16 @@ D3   Bonus
               </costs>
             </selectionEntry>
             <selectionEntry id="1157-5eec-dab9-13c6" name="Ectoplasma cannon" hidden="false" collective="false" type="upgrade">
-              <profiles>
-                <profile id="54bb-700f-5d2a-97dc" name="Ectoplasma cannon" hidden="false" profileTypeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" profileTypeName="Weapon">
+              <profiles/>
+              <rules/>
+              <infoLinks>
+                <infoLink id="aee9-d1ae-1459-8529" name="Ectoplasma cannon" hidden="false" targetId="ba8c-82d5-79c0-d0d9" type="profile">
                   <profiles/>
                   <rules/>
                   <infoLinks/>
                   <modifiers/>
-                  <characteristics>
-                    <characteristic name="Range" characteristicTypeId="6fa97fa8-ea74-4a27-a0fb-bc4e5f367464" value="24&quot;"/>
-                    <characteristic name="Type" characteristicTypeId="077c342f-d7b9-45c6-b8af-88e97cafd3a2" value="Heavy D3"/>
-                    <characteristic name="S" characteristicTypeId="59b1-319e-ec13-d466" value="7"/>
-                    <characteristic name="AP" characteristicTypeId="75aa-a838-b675-6484" value="-3"/>
-                    <characteristic name="D" characteristicTypeId="ae8a-3137-d65b-4ca7" value="D3"/>
-                    <characteristic name="Abilities" characteristicTypeId="837d-5e63-aeb7-1410" value="-"/>
-                  </characteristics>
-                </profile>
-              </profiles>
-              <rules/>
-              <infoLinks/>
+                </infoLink>
+              </infoLinks>
               <modifiers/>
               <constraints/>
               <categoryLinks/>
@@ -4249,23 +4619,21 @@ D3   Bonus
           </characteristics>
         </profile>
       </profiles>
-      <rules>
-        <rule id="5188-7ffc-8376-eeb4" name="Crash and Burn" hidden="false">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <description>if this model is reduced to 0 wounds, roll a D6 before removing the model from the battlefield; on a 6 it crashes in a fiery explosion and each unit within 6&quot; suffers D3 MW.</description>
-        </rule>
-      </rules>
+      <rules/>
       <infoLinks>
-        <infoLink id="fc94-8f49-944c-df76" name="New InfoLink" hidden="false" targetId="2946-510b-88fb-5c9c" type="rule">
+        <infoLink id="fc94-8f49-944c-df76" name="Daemonic" hidden="false" targetId="94f5-82c3-bb66-ac0c" type="profile">
           <profiles/>
           <rules/>
           <infoLinks/>
           <modifiers/>
         </infoLink>
-        <infoLink id="0edd-ba98-a3b9-a06a" name="New InfoLink" hidden="false" targetId="afd3-a04b-c770-90c1" type="rule">
+        <infoLink id="0edd-ba98-a3b9-a06a" name="Infernal Regeneration" hidden="false" targetId="a46b-e84f-ab7b-a4e4" type="profile">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="8214-585c-4188-51ed" name="Crash and Burn" hidden="false" targetId="2dba-f58f-2639-301e" type="profile">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -4324,7 +4692,7 @@ D3   Bonus
           <modifiers/>
           <constraints/>
         </categoryLink>
-        <categoryLink id="1c1f-0d54-39d1-031a" name="New CategoryLink" hidden="false" targetId="717b-8863-9d25-5e2a" primary="false">
+        <categoryLink id="1c1f-0d54-39d1-031a" name="New CategoryLink" hidden="false" targetId="5cf1-acf2-ca3b-c2e5" primary="false">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -4353,7 +4721,7 @@ D3   Bonus
                 <characteristic name="S" characteristicTypeId="59b1-319e-ec13-d466" value="User"/>
                 <characteristic name="AP" characteristicTypeId="75aa-a838-b675-6484" value="-1"/>
                 <characteristic name="D" characteristicTypeId="ae8a-3137-d65b-4ca7" value="D3"/>
-                <characteristic name="Abilities" characteristicTypeId="837d-5e63-aeb7-1410" value="When attacking models that can Fly, you may add 1 to this weapon&apos;s hit roll."/>
+                <characteristic name="Abilities" characteristicTypeId="837d-5e63-aeb7-1410" value="When attacking models that can FLY, you may add 1 to this weapon&apos;s hit roll."/>
               </characteristics>
             </profile>
           </profiles>
@@ -4390,7 +4758,7 @@ D3   Bonus
               <profiles/>
               <rules/>
               <infoLinks>
-                <infoLink id="33ba-fe70-afd6-3bb7" hidden="false" targetId="3351-60e7-b298-81aa" type="profile">
+                <infoLink id="33ba-fe70-afd6-3bb7" name="Hades autocannon" hidden="false" targetId="3351-60e7-b298-81aa" type="profile">
                   <profiles/>
                   <rules/>
                   <infoLinks/>
@@ -4436,7 +4804,7 @@ D3   Bonus
         </selectionEntryGroup>
       </selectionEntryGroups>
       <entryLinks>
-        <entryLink id="5733-8873-73bb-d74f" name="New EntryLink" hidden="false" targetId="45e8-d3d1-105b-90a3" type="selectionEntryGroup">
+        <entryLink id="5733-8873-73bb-d74f" name="Mark of Chaos" hidden="false" targetId="45e8-d3d1-105b-90a3" type="selectionEntryGroup">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -4498,31 +4866,34 @@ D3   Bonus
             <characteristic name="Other" characteristicTypeId="c2e2-f115-0003-5d7b" value=""/>
           </characteristics>
         </profile>
+        <profile id="2654-57d3-2b61-5ecf" name="Lord of the Red Corsairs" hidden="false" profileTypeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" profileTypeName="Abilities">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Description" characteristicTypeId="21befb24-fc85-4f52-a745-64b2e48f8228" value="Friendly RED CORSAIRS units automatically pass Morale tests whilst they are within 6&quot; of Huron Blackheart."/>
+          </characteristics>
+        </profile>
+        <profile id="dd1f-3ded-29d7-550e" name="The Hamadrya" hidden="false" profileTypeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" profileTypeName="Abilities">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Description" characteristicTypeId="21befb24-fc85-4f52-a745-64b2e48f8228" value="After Huron Blackheart has manifested a psychic power, his Hamadrya can lend him additional power if it is still alive. When it does so, Huron Blackheart can immediately attempt to manifest an adiditional psychic power. "/>
+          </characteristics>
+        </profile>
       </profiles>
-      <rules>
-        <rule id="b4f0-88a5-8dea-b93e" name="The Hamadrya" hidden="false">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <description>After Huron Blackheart has manifested a psychic power, his Hamadrya can lend him additional power if it is still alive. When it does so, Huron Blackheart can immediately attempt to manifest an adiditional psychic power. </description>
-        </rule>
-        <rule id="dce2-afc5-8ed0-bd73" name="Lord of the Red Corsairs" hidden="false">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <description>Friendly Red Corsairs units automatically pass Morale tests whilst they are within 6&quot; of Huron Blackheart.</description>
-        </rule>
-      </rules>
+      <rules/>
       <infoLinks>
-        <infoLink id="22a0-1c59-9db2-fe37" name="New InfoLink" hidden="false" targetId="94d8-b556-103a-36ec" type="rule">
+        <infoLink id="22a0-1c59-9db2-fe37" name="Sigil of Corruption" hidden="false" targetId="c237-7aca-a961-6c59" type="profile">
           <profiles/>
           <rules/>
           <infoLinks/>
           <modifiers/>
         </infoLink>
-        <infoLink id="c07d-7c47-1471-a006" name="New InfoLink" hidden="false" targetId="6349-022a-cea9-524c" type="rule">
+        <infoLink id="c07d-7c47-1471-a006" name="Death to the False Emperor" hidden="false" targetId="37a4-1d84-4ef0-c4f6" type="profile">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -4555,7 +4926,7 @@ D3   Bonus
           <modifiers/>
           <constraints/>
         </categoryLink>
-        <categoryLink id="d9d3-16e4-1224-4a3f" name="New CategoryLink" hidden="false" targetId="717b-8863-9d25-5e2a" primary="false">
+        <categoryLink id="d9d3-16e4-1224-4a3f" name="New CategoryLink" hidden="false" targetId="5cf1-acf2-ca3b-c2e5" primary="false">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -4698,7 +5069,7 @@ D3   Bonus
           <infoLinks/>
           <modifiers/>
           <characteristics>
-            <characteristic name="M" characteristicTypeId="0bdf-a96e-9e38-7779" value="6"/>
+            <characteristic name="M" characteristicTypeId="0bdf-a96e-9e38-7779" value="6&quot;"/>
             <characteristic name="WS" characteristicTypeId="e7f0-1278-0250-df0c" value="2+"/>
             <characteristic name="BS" characteristicTypeId="381b-eb28-74c3-df5f" value="2+"/>
             <characteristic name="S" characteristicTypeId="2218-aa3c-265f-2939" value="5"/>
@@ -4709,37 +5080,40 @@ D3   Bonus
             <characteristic name="Save" characteristicTypeId="c0df-df94-abd7-e8d3" value="3+"/>
           </characteristics>
         </profile>
+        <profile id="3912-374f-5b26-6572" name="Kill! Maim! Burn!" hidden="false" profileTypeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" profileTypeName="Abilities">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Description" characteristicTypeId="21befb24-fc85-4f52-a745-64b2e48f8228" value="You can re-roll failed hit rolls made for friendly World Eaters units within 1&quot; of Kharn the Betrayer."/>
+          </characteristics>
+        </profile>
+        <profile id="9a72-df9f-afb2-ed1f" name="The Betrayer" hidden="false" profileTypeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" profileTypeName="Abilities">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Description" characteristicTypeId="21befb24-fc85-4f52-a745-64b2e48f8228" value="You cannot re-roll or modify hit rolls of 1 made for Kharn the Betrayer in the Fight phase. Instead, those attacks automatically hit a friendly unit within 1&quot;. Randomly determine which unit is hit if there is more than one. If there are no friendly units within 1&quot; of Kharn, the hits are discarded."/>
+          </characteristics>
+        </profile>
       </profiles>
-      <rules>
-        <rule id="901f-e6c6-0c0d-edac" name="The Betrayer" hidden="false">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <description>You cannot re-roll or modify hit rolls of 1 made for Kharn the Betrayer in the Fight phase. Instead, those attacks automatically hit a friendly unit within 1&quot;. Randomly determine which unit is hit if there is more than one. If there are no firendly units within 1&quot; of Kharn, the hits are discarded.</description>
-        </rule>
-        <rule id="6505-9a51-fe00-599f" name="Kill! Maim! Burn!" hidden="false">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <description>You can re-roll failed hit rolls made for friendly World Eaters units within 1&quot; of Kharn the Betrayer.</description>
-        </rule>
-      </rules>
+      <rules/>
       <infoLinks>
-        <infoLink id="15ea-b6c2-cfb5-5c0e" name="New InfoLink" hidden="false" targetId="6349-022a-cea9-524c" type="rule">
+        <infoLink id="15ea-b6c2-cfb5-5c0e" name="Death to the False Emperor" hidden="false" targetId="37a4-1d84-4ef0-c4f6" type="profile">
           <profiles/>
           <rules/>
           <infoLinks/>
           <modifiers/>
         </infoLink>
-        <infoLink id="b533-f85f-3175-9fcd" name="New InfoLink" hidden="false" targetId="728f-90eb-c466-9e70" type="rule">
+        <infoLink id="b533-f85f-3175-9fcd" name="Blood for the Blood God" hidden="false" targetId="b0a9-4ba4-c487-01b9" type="profile">
           <profiles/>
           <rules/>
           <infoLinks/>
           <modifiers/>
         </infoLink>
-        <infoLink id="0b3d-6a70-6b3c-41ad" name="New InfoLink" hidden="false" targetId="94d8-b556-103a-36ec" type="rule">
+        <infoLink id="0b3d-6a70-6b3c-41ad" name="Sigil of Corruption" hidden="false" targetId="c237-7aca-a961-6c59" type="profile">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -4779,7 +5153,7 @@ D3   Bonus
           <modifiers/>
           <constraints/>
         </categoryLink>
-        <categoryLink id="aa31-818c-a27d-90c8" name="New CategoryLink" hidden="false" targetId="717b-8863-9d25-5e2a" primary="false">
+        <categoryLink id="aa31-818c-a27d-90c8" name="New CategoryLink" hidden="false" targetId="5cf1-acf2-ca3b-c2e5" primary="false">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -4841,7 +5215,7 @@ D3   Bonus
                 <characteristic name="S" characteristicTypeId="59b1-319e-ec13-d466" value="8"/>
                 <characteristic name="AP" characteristicTypeId="75aa-a838-b675-6484" value="-3"/>
                 <characteristic name="D" characteristicTypeId="ae8a-3137-d65b-4ca7" value="2"/>
-                <characteristic name="Abilities" characteristicTypeId="837d-5e63-aeb7-1410" value="Each time you roll a hit roll of 1 when firing this weapon, the bearer suffers a MW."/>
+                <characteristic name="Abilities" characteristicTypeId="837d-5e63-aeb7-1410" value="Each time you roll a hit roll of 1 when firing this weapon, the bearer suffers a mortal wound."/>
               </characteristics>
             </profile>
           </profiles>
@@ -4883,19 +5257,33 @@ D3   Bonus
     </selectionEntry>
     <selectionEntry id="d990-6016-2e27-d72f" name="Khorne Berzerkers" page="" hidden="false" collective="false" type="unit">
       <profiles>
-        <profile id="c540-e7d4-351e-bca9" name="Blood for the Blood God" book="" hidden="false" profileTypeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" profileTypeName="Abilities">
+        <profile id="656a-109f-8357-055e" name="Khorne Berzerker" hidden="false" profileTypeId="800f-21d0-4387-c943" profileTypeName="Unit">
           <profiles/>
           <rules/>
           <infoLinks/>
           <modifiers/>
           <characteristics>
-            <characteristic name="Description" characteristicTypeId="21befb24-fc85-4f52-a745-64b2e48f8228" value="This unit can fight twice in each Fight phase, instead of only one."/>
+            <characteristic name="M" characteristicTypeId="0bdf-a96e-9e38-7779" value="6&quot;"/>
+            <characteristic name="WS" characteristicTypeId="e7f0-1278-0250-df0c" value="3+"/>
+            <characteristic name="BS" characteristicTypeId="381b-eb28-74c3-df5f" value="3+"/>
+            <characteristic name="S" characteristicTypeId="2218-aa3c-265f-2939" value="5"/>
+            <characteristic name="T" characteristicTypeId="9c9f-9774-a358-3a39" value="4"/>
+            <characteristic name="W" characteristicTypeId="f330-5e6e-4110-0978" value="1"/>
+            <characteristic name="A" characteristicTypeId="13fc-b29b-31f2-ab9f" value="2"/>
+            <characteristic name="Ld" characteristicTypeId="00ca-f8b8-876d-b705" value="7"/>
+            <characteristic name="Save" characteristicTypeId="c0df-df94-abd7-e8d3" value="3+"/>
           </characteristics>
         </profile>
       </profiles>
       <rules/>
       <infoLinks>
-        <infoLink id="4f75-f57b-a616-4f00" name="New InfoLink" hidden="false" targetId="6349-022a-cea9-524c" type="rule">
+        <infoLink id="4f75-f57b-a616-4f00" name="Death to the False Emperor" hidden="false" targetId="37a4-1d84-4ef0-c4f6" type="profile">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="bd8b-3583-77ae-48ff" name="Blood for the Blood God" hidden="false" targetId="b0a9-4ba4-c487-01b9" type="profile">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -4932,7 +5320,7 @@ D3   Bonus
       </modifiers>
       <constraints/>
       <categoryLinks>
-        <categoryLink id="3c22-d57d-d88d-6da7" name="New CategoryLink" hidden="false" targetId="717b-8863-9d25-5e2a" primary="false">
+        <categoryLink id="3c22-d57d-d88d-6da7" name="New CategoryLink" hidden="false" targetId="5cf1-acf2-ca3b-c2e5" primary="false">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -4962,76 +5350,6 @@ D3   Bonus
         </categoryLink>
       </categoryLinks>
       <selectionEntries>
-        <selectionEntry id="b4f9-bfd3-3700-6ddb" name="Khorne Berzerker" hidden="false" collective="false" type="model">
-          <profiles>
-            <profile id="55a3-b8d3-c55d-65c5" name="Khorne Berzerker" hidden="false" profileTypeId="800f-21d0-4387-c943" profileTypeName="Unit">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <characteristics>
-                <characteristic name="M" characteristicTypeId="0bdf-a96e-9e38-7779" value="6&quot;"/>
-                <characteristic name="WS" characteristicTypeId="e7f0-1278-0250-df0c" value="3+"/>
-                <characteristic name="BS" characteristicTypeId="381b-eb28-74c3-df5f" value="3+"/>
-                <characteristic name="S" characteristicTypeId="2218-aa3c-265f-2939" value="5"/>
-                <characteristic name="T" characteristicTypeId="9c9f-9774-a358-3a39" value="4"/>
-                <characteristic name="W" characteristicTypeId="f330-5e6e-4110-0978" value="1"/>
-                <characteristic name="A" characteristicTypeId="13fc-b29b-31f2-ab9f" value="2"/>
-                <characteristic name="Ld" characteristicTypeId="00ca-f8b8-876d-b705" value="7"/>
-                <characteristic name="Save" characteristicTypeId="c0df-df94-abd7-e8d3" value="3+"/>
-              </characteristics>
-            </profile>
-          </profiles>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints>
-            <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ad5d-453a-58e8-2942" type="min"/>
-            <constraint field="selections" scope="parent" value="19.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6a4e-d4d9-a21b-9577" type="max"/>
-          </constraints>
-          <categoryLinks/>
-          <selectionEntries/>
-          <selectionEntryGroups/>
-          <entryLinks>
-            <entryLink id="53ec-ddd5-5e10-f96d" name="Frag &amp; Krak grenades" hidden="false" targetId="cddf-945e-1335-e681" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6f97-538c-f5a6-6087" type="max"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5986-3a01-3340-6a76" type="min"/>
-              </constraints>
-              <categoryLinks/>
-            </entryLink>
-            <entryLink id="1f95-255f-1ddc-e90c" name="Bolt pistol" hidden="false" targetId="37d3-7098-d596-9948" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c824-7efc-55a1-0184" type="max"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="29bb-3dfd-f0f7-46d2" type="min"/>
-              </constraints>
-              <categoryLinks/>
-            </entryLink>
-            <entryLink id="ae81-750a-71f1-d91f" name="Chainsword" hidden="false" targetId="704f-026f-22fd-89d5" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="da2d-1d2f-0fe4-dce7" type="max"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4eb2-94a0-e6fb-fd3a" type="min"/>
-              </constraints>
-              <categoryLinks/>
-            </entryLink>
-          </entryLinks>
-          <costs>
-            <cost name="pts" costTypeId="points" value="16.0"/>
-            <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="0.0"/>
-          </costs>
-        </selectionEntry>
         <selectionEntry id="8713-bf56-1ba2-fdb2" name="Berzerker Champion" hidden="false" collective="false" type="model">
           <profiles>
             <profile id="fee3-a817-87b4-dea2" name="Berzerker Champion" hidden="false" profileTypeId="800f-21d0-4387-c943" profileTypeName="Unit">
@@ -5074,7 +5392,7 @@ D3   Bonus
               </constraints>
               <categoryLinks/>
             </entryLink>
-            <entryLink id="c387-417b-d5e1-a257" name="New EntryLink" hidden="false" targetId="1912-576e-6a2b-5c6e" type="selectionEntryGroup">
+            <entryLink id="c387-417b-d5e1-a257" name="Champion Equipment" hidden="false" targetId="ad90-3560-ea09-82ef" type="selectionEntryGroup">
               <profiles/>
               <rules/>
               <infoLinks/>
@@ -5088,77 +5406,207 @@ D3   Bonus
             <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="0.0"/>
           </costs>
         </selectionEntry>
-        <selectionEntry id="79da-fe9c-634a-e1f3" name="Swap bolt pistol or chainsword for chainaxe" hidden="false" collective="false" type="upgrade">
+      </selectionEntries>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="d164-433b-f095-94a7" name="Khorne Berserkers" hidden="false" collective="false" defaultSelectionEntryId="cc27-df20-5665-a2c1">
           <profiles/>
           <rules/>
-          <infoLinks>
-            <infoLink id="0b65-7843-6c86-bc2d" name="New InfoLink" hidden="false" targetId="fc56-4e98-3cdc-3659" type="profile">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-            </infoLink>
-          </infoLinks>
-          <modifiers>
-            <modifier type="increment" field="a549-f6b3-f9f9-deb6" value="1">
-              <repeats>
-                <repeat field="selections" scope="d990-6016-2e27-d72f" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b4f9-bfd3-3700-6ddb" repeats="1" roundUp="false"/>
-              </repeats>
-              <conditions/>
-              <conditionGroups/>
-            </modifier>
-          </modifiers>
-          <constraints>
-            <constraint field="selections" scope="d990-6016-2e27-d72f" value="0.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="a549-f6b3-f9f9-deb6" type="max"/>
-          </constraints>
-          <categoryLinks/>
-          <selectionEntries/>
-          <selectionEntryGroups/>
-          <entryLinks/>
-          <costs>
-            <cost name="pts" costTypeId="points" value="1.0"/>
-            <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="0.0"/>
-          </costs>
-        </selectionEntry>
-        <selectionEntry id="3eee-20b7-2b11-8fc7" name="Swap bolt pistol for plasma pistol" hidden="false" collective="false" type="upgrade">
-          <profiles/>
-          <rules/>
-          <infoLinks>
-            <infoLink id="bc03-d740-a577-b04b" name="New InfoLink" hidden="false" targetId="5779-2931-fe17-2b27" type="profile">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-            </infoLink>
-            <infoLink id="b5ec-3c7f-4f0c-f586" name="New InfoLink" hidden="false" targetId="ff12-161a-ca85-339f" type="profile">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-            </infoLink>
-          </infoLinks>
+          <infoLinks/>
           <modifiers/>
           <constraints>
-            <constraint field="selections" scope="d990-6016-2e27-d72f" value="2.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="4bda-a936-50ba-7f2f" type="max"/>
+            <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f366-1993-a535-c592" type="min"/>
+            <constraint field="selections" scope="parent" value="19.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="869a-6db7-5fa7-ada3" type="max"/>
           </constraints>
           <categoryLinks/>
-          <selectionEntries/>
+          <selectionEntries>
+            <selectionEntry id="cc27-df20-5665-a2c1" name="Berzerker w/ chainsword" hidden="false" collective="false" type="model">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+              <categoryLinks/>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks>
+                <entryLink id="8119-78f1-a0b9-214d" name="Frag &amp; Krak grenades" hidden="false" targetId="cddf-945e-1335-e681" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="dd63-323b-6924-7f1e" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="cbfb-60b5-feb4-de31" type="min"/>
+                  </constraints>
+                  <categoryLinks/>
+                </entryLink>
+                <entryLink id="73b0-6481-88e5-72d4" name="Bolt pistol" hidden="false" targetId="37d3-7098-d596-9948" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7d82-1397-cc8e-5901" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b249-b570-2007-252a" type="min"/>
+                  </constraints>
+                  <categoryLinks/>
+                </entryLink>
+                <entryLink id="c72f-ffae-16e3-ff71" name="Chainsword" hidden="false" targetId="704f-026f-22fd-89d5" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7945-83f3-d75b-8cfa" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ba5e-7f94-6100-d816" type="min"/>
+                  </constraints>
+                  <categoryLinks/>
+                </entryLink>
+              </entryLinks>
+              <costs>
+                <cost name="pts" costTypeId="points" value="16.0"/>
+                <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="6df9-c70b-1065-6fa2" name="Berserker w/ Chain axe" hidden="false" collective="false" type="model">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+              <categoryLinks/>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks>
+                <entryLink id="a16f-a5c6-1558-9eb1" name="Bolt pistol" hidden="false" targetId="37d3-7098-d596-9948" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="efff-8ef0-4c9c-912d" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="df38-b9d5-59bb-8750" type="min"/>
+                  </constraints>
+                  <categoryLinks/>
+                </entryLink>
+                <entryLink id="038b-9455-0cdc-9292" name="Frag &amp; Krak grenades" hidden="false" targetId="cddf-945e-1335-e681" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0d13-f40b-1b03-514d" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f2e8-3b8b-2f79-7525" type="min"/>
+                  </constraints>
+                  <categoryLinks/>
+                </entryLink>
+                <entryLink id="1cea-2874-1353-b170" name="Chainaxe" hidden="false" targetId="69a9-e421-f588-79bc" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0a28-99a4-7691-bca9" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5976-f9e6-ab96-3397" type="min"/>
+                  </constraints>
+                  <categoryLinks/>
+                </entryLink>
+              </entryLinks>
+              <costs>
+                <cost name="pts" costTypeId="points" value="16.0"/>
+                <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="db90-1a14-c826-6789" name="Berserker w/ plasma pistol" hidden="false" collective="false" type="upgrade">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="d990-6016-2e27-d72f" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8e67-9374-da43-1d9d" type="max"/>
+              </constraints>
+              <categoryLinks/>
+              <selectionEntries/>
+              <selectionEntryGroups>
+                <selectionEntryGroup id="946c-3680-08a4-a300" name="Melee option" hidden="false" collective="false" defaultSelectionEntryId="14fc-aed9-87b3-8b94">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1376-fcc5-0b58-dc24" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bd17-217a-43fc-8df6" type="min"/>
+                  </constraints>
+                  <categoryLinks/>
+                  <selectionEntries/>
+                  <selectionEntryGroups/>
+                  <entryLinks>
+                    <entryLink id="ad1d-4b48-8dce-57fb" name="Chainaxe" hidden="false" targetId="262d-dbbf-8474-791c" type="selectionEntry">
+                      <profiles/>
+                      <rules/>
+                      <infoLinks/>
+                      <modifiers/>
+                      <constraints>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="247e-13e0-0e90-c0fc" type="max"/>
+                      </constraints>
+                      <categoryLinks/>
+                    </entryLink>
+                    <entryLink id="14fc-aed9-87b3-8b94" name="Chainsword" hidden="false" targetId="0dd1-2e2b-7dd1-5495" type="selectionEntry">
+                      <profiles/>
+                      <rules/>
+                      <infoLinks/>
+                      <modifiers/>
+                      <constraints>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="755c-5603-1855-3e32" type="max"/>
+                      </constraints>
+                      <categoryLinks/>
+                    </entryLink>
+                  </entryLinks>
+                </selectionEntryGroup>
+              </selectionEntryGroups>
+              <entryLinks>
+                <entryLink id="e995-fd13-1013-d2e4" name="Frag &amp; Krak grenades" hidden="false" targetId="cddf-945e-1335-e681" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b754-d471-a7b8-0ddd" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="73d5-c5db-483d-9170" type="min"/>
+                  </constraints>
+                  <categoryLinks/>
+                </entryLink>
+                <entryLink id="c427-8cb6-23c3-2407" name="Plasma pistol" hidden="false" targetId="83be-1ba9-c326-4760" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c15b-7e35-6b3a-e354" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a05b-ce3a-9957-6d7d" type="min"/>
+                  </constraints>
+                  <categoryLinks/>
+                </entryLink>
+              </entryLinks>
+              <costs>
+                <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="0.0"/>
+                <cost name="pts" costTypeId="points" value="0.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
           <selectionEntryGroups/>
           <entryLinks/>
-          <costs>
-            <cost name="pts" costTypeId="points" value="7.0"/>
-            <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="0.0"/>
-          </costs>
-        </selectionEntry>
-      </selectionEntries>
-      <selectionEntryGroups/>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
       <entryLinks>
         <entryLink id="6235-10eb-15c4-f5c0" name="Icon of Wrath" hidden="false" targetId="4925-fdaf-aee3-c408" type="selectionEntry">
           <profiles/>
           <rules/>
           <infoLinks/>
           <modifiers/>
-          <constraints/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="00b1-0700-a489-8b71" type="max"/>
+          </constraints>
           <categoryLinks/>
         </entryLink>
       </entryLinks>
@@ -5240,27 +5688,28 @@ D3   Bonus
           <infoLinks/>
           <modifiers/>
           <characteristics>
-            <characteristic name="Description" characteristicTypeId="21befb24-fc85-4f52-a745-64b2e48f8228" value="A Khorne Lord of Skulls can shoot if there are enemy models within 1&quot; of it, as long as all of the enemy models have the Infantry keyword. In this case it can shoot the enemy unit that is within 1&quot; of it, or any other visible enemy unit that is within range and more than 1&quot; away from any friendly models. In addition, a Khorne Lord of Skulls can move and fire Heavy weapons without suffering the penalty to its hit rolls. Finally, a Khorne Lord of Skulls only gains a bonus to its save in cover if at least half of the model is obscured from the firer."/>
+            <characteristic name="Description" characteristicTypeId="21befb24-fc85-4f52-a745-64b2e48f8228" value="A Khorne Lord of Skulls can shoot if there are enemy models within 1&quot; of it, as long as all of the enemy models have the INFANTRY keyword. In this case it can shoot the enemy unit that is within 1&quot; of it, or any other visible enemy unit that is within range and more than 1&quot; away from any friendly models. In addition, a Khorne Lord of Skulls can move and fire Heavy weapons without suffering the penalty to its hit rolls. Finally, a Khorne Lord of Skulls only gains a bonus to its save in cover if at least half of the model is obscured from the firer."/>
           </characteristics>
         </profile>
-      </profiles>
-      <rules>
-        <rule id="96e0-a433-db00-bce8" name="Explodes" hidden="false">
+        <profile id="27f6-92fe-840d-91f8" name="Explodes" hidden="false" profileTypeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" profileTypeName="Abilities">
           <profiles/>
           <rules/>
           <infoLinks/>
           <modifiers/>
-          <description>If this model is reduced to 0 wounds, roll a D6 before removing the model from the battlefield and before any embarked models disembark; on a 6 it explodes, and each unit within 2D6&quot; suffers D6 MW.</description>
-        </rule>
-      </rules>
+          <characteristics>
+            <characteristic name="Description" characteristicTypeId="21befb24-fc85-4f52-a745-64b2e48f8228" value="If this model is reduced to 0 wounds, roll a D6 before removing the model from the battlefield and before any embarked models disembark; on a 6 it explodes, and each unit within 2D6&quot; suffers D6 mortal wounds."/>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules/>
       <infoLinks>
-        <infoLink id="a7cb-93fd-d8ff-77c9" name="New InfoLink" hidden="false" targetId="afd3-a04b-c770-90c1" type="rule">
+        <infoLink id="a7cb-93fd-d8ff-77c9" name="Infernal Regeneration" hidden="false" targetId="a46b-e84f-ab7b-a4e4" type="profile">
           <profiles/>
           <rules/>
           <infoLinks/>
           <modifiers/>
         </infoLink>
-        <infoLink id="542a-8376-36b7-db1a" name="New InfoLink" hidden="false" targetId="2946-510b-88fb-5c9c" type="rule">
+        <infoLink id="542a-8376-36b7-db1a" name="Daemonic" hidden="false" targetId="94f5-82c3-bb66-ac0c" type="profile">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -5297,7 +5746,7 @@ D3   Bonus
           <modifiers/>
           <constraints/>
         </categoryLink>
-        <categoryLink id="4ceb-f19d-db1f-ce11" name="New CategoryLink" hidden="false" targetId="717b-8863-9d25-5e2a" primary="false">
+        <categoryLink id="4ceb-f19d-db1f-ce11" name="New CategoryLink" hidden="false" targetId="5cf1-acf2-ca3b-c2e5" primary="false">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -5652,7 +6101,7 @@ D3   Bonus
           <infoLinks/>
           <modifiers/>
           <characteristics>
-            <characteristic name="Description" characteristicTypeId="21befb24-fc85-4f52-a745-64b2e48f8228" value="Lucius the Eternal has a 5++ save. Whenever you make a successful saving throw for Lucius in the Fight phase, roll a D6. On a roll of 4+, the unit that made the attack suffers a MW after all of its attacks have been made."/>
+            <characteristic name="Description" characteristicTypeId="21befb24-fc85-4f52-a745-64b2e48f8228" value="Lucius the Eternal has a 5+ invulnerable save. Whenever you make a successful saving throw for Lucius in the Fight phase, roll a D6. On a roll of 4+, the unit that made the attack suffers a mortal wound after all of its attacks have been made."/>
           </characteristics>
         </profile>
         <profile id="0012-7e7a-f5a7-5891" name="Duellist&apos;s Pride" hidden="false" profileTypeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" profileTypeName="Abilities">
@@ -5667,7 +6116,7 @@ D3   Bonus
       </profiles>
       <rules/>
       <infoLinks>
-        <infoLink id="4ed7-cdfc-ebfc-c428" name="Death to the False Emperor" hidden="false" targetId="6349-022a-cea9-524c" type="rule">
+        <infoLink id="4ed7-cdfc-ebfc-c428" name="Death to the False Emperor" hidden="false" targetId="37a4-1d84-4ef0-c4f6" type="profile">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -5686,7 +6135,7 @@ D3   Bonus
           <modifiers/>
           <constraints/>
         </categoryLink>
-        <categoryLink id="4c76-0d91-b13b-fba6" name="New CategoryLink" hidden="false" targetId="717b-8863-9d25-5e2a" primary="false">
+        <categoryLink id="4c76-0d91-b13b-fba6" name="New CategoryLink" hidden="false" targetId="5cf1-acf2-ca3b-c2e5" primary="false">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -5803,39 +6252,6 @@ D3   Bonus
             <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="0.0"/>
           </costs>
         </selectionEntry>
-        <selectionEntry id="5389-35d9-cacc-e0c0" name="Doom siren" hidden="false" collective="false" type="upgrade">
-          <profiles>
-            <profile id="2f8b-cac1-4833-c229" name="Doom siren" hidden="false" profileTypeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" profileTypeName="Weapon">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <characteristics>
-                <characteristic name="Range" characteristicTypeId="6fa97fa8-ea74-4a27-a0fb-bc4e5f367464" value="8&quot;"/>
-                <characteristic name="Type" characteristicTypeId="077c342f-d7b9-45c6-b8af-88e97cafd3a2" value="Assault D3"/>
-                <characteristic name="S" characteristicTypeId="59b1-319e-ec13-d466" value="5"/>
-                <characteristic name="AP" characteristicTypeId="75aa-a838-b675-6484" value="-2"/>
-                <characteristic name="D" characteristicTypeId="ae8a-3137-d65b-4ca7" value="1"/>
-                <characteristic name="Abilities" characteristicTypeId="837d-5e63-aeb7-1410" value="This weapon automatically htis its target. Units targeted by this weapon do not gain any bonus to their saving throws for being in cover."/>
-              </characteristics>
-            </profile>
-          </profiles>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b575-d939-b7b2-6f66" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5db0-ab11-29c0-5203" type="min"/>
-          </constraints>
-          <categoryLinks/>
-          <selectionEntries/>
-          <selectionEntryGroups/>
-          <entryLinks/>
-          <costs>
-            <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="0.0"/>
-            <cost name="pts" costTypeId="points" value="0.0"/>
-          </costs>
-        </selectionEntry>
       </selectionEntries>
       <selectionEntryGroups/>
       <entryLinks>
@@ -5847,6 +6263,22 @@ D3   Bonus
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ece2-cfcd-df86-1e4f" type="min"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a8c3-96b2-6fb0-c902" type="max"/>
+          </constraints>
+          <categoryLinks/>
+        </entryLink>
+        <entryLink id="ea8e-8d4a-b0f8-bd6a" name="Doom siren" hidden="false" targetId="bbb0-94d7-d83a-bf45" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers>
+            <modifier type="set" field="points" value="0.0">
+              <repeats/>
+              <conditions/>
+              <conditionGroups/>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bd8d-2476-e1bd-adcd" type="min"/>
           </constraints>
           <categoryLinks/>
         </entryLink>
@@ -5926,19 +6358,19 @@ D3   Bonus
       </profiles>
       <rules/>
       <infoLinks>
-        <infoLink id="03ee-da67-d4d4-b2a3" name="New InfoLink" hidden="false" targetId="2946-510b-88fb-5c9c" type="rule">
+        <infoLink id="03ee-da67-d4d4-b2a3" name="Daemonic" hidden="false" targetId="94f5-82c3-bb66-ac0c" type="profile">
           <profiles/>
           <rules/>
           <infoLinks/>
           <modifiers/>
         </infoLink>
-        <infoLink id="7312-680e-f85f-f2bf" name="Infernal Regeneration" hidden="false" targetId="afd3-a04b-c770-90c1" type="rule">
+        <infoLink id="7312-680e-f85f-f2bf" name="Infernal Regeneration" hidden="false" targetId="a46b-e84f-ab7b-a4e4" type="profile">
           <profiles/>
           <rules/>
           <infoLinks/>
           <modifiers/>
         </infoLink>
-        <infoLink id="3d3b-e1b7-a26d-68f7" name="New InfoLink" hidden="false" targetId="3541-94a7-a138-358b" type="rule">
+        <infoLink id="3d3b-e1b7-a26d-68f7" name="Explodes" hidden="false" targetId="9446-1148-da70-4028" type="profile">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -5969,7 +6401,7 @@ D3   Bonus
           <modifiers/>
           <constraints/>
         </categoryLink>
-        <categoryLink id="c798-d8a7-b6b2-9fd2" name="New CategoryLink" hidden="false" targetId="717b-8863-9d25-5e2a" primary="false">
+        <categoryLink id="c798-d8a7-b6b2-9fd2" name="New CategoryLink" hidden="false" targetId="5cf1-acf2-ca3b-c2e5" primary="false">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -6091,7 +6523,7 @@ D3   Bonus
                   <modifiers/>
                   <characteristics>
                     <characteristic name="Range" characteristicTypeId="6fa97fa8-ea74-4a27-a0fb-bc4e5f367464" value="Melee"/>
-                    <characteristic name="Type" characteristicTypeId="077c342f-d7b9-45c6-b8af-88e97cafd3a2" value="Mlee"/>
+                    <characteristic name="Type" characteristicTypeId="077c342f-d7b9-45c6-b8af-88e97cafd3a2" value="Melee"/>
                     <characteristic name="S" characteristicTypeId="59b1-319e-ec13-d466" value="User"/>
                     <characteristic name="AP" characteristicTypeId="75aa-a838-b675-6484" value="-2"/>
                     <characteristic name="D" characteristicTypeId="ae8a-3137-d65b-4ca7" value="2"/>
@@ -6124,16 +6556,32 @@ D3   Bonus
       </costs>
     </selectionEntry>
     <selectionEntry id="5827-0f87-428a-2bdf" name="Mutilators" page="" hidden="false" collective="false" type="unit">
-      <profiles/>
+      <profiles>
+        <profile id="1109-d2d9-cd95-c063" name="Fleshmetal Weapons" hidden="false" profileTypeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" profileTypeName="Abilities">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Description" characteristicTypeId="21befb24-fc85-4f52-a745-64b2e48f8228" value="When a unit of Mutilators is chosen to fight, roll three D3, one after the other. For that fight, the first roll is added to the Mutilator&apos;s Strength for the unit&apos;s attacks, the second roll is the AP for the unit&apos;s attacks, and the third roll is the Damage for the unit&apos;s attacks. For example, if the rolls were a 1, followed by a 3, followed by a 2, then all of the unit&apos;s attacks for that fight would have Strength of +1, an AP of -3, and a Damage of 2."/>
+          </characteristics>
+        </profile>
+      </profiles>
       <rules/>
       <infoLinks>
-        <infoLink id="8bd5-9df1-5496-8b61" name="New InfoLink" hidden="false" targetId="2946-510b-88fb-5c9c" type="rule">
+        <infoLink id="8bd5-9df1-5496-8b61" name="Daemonic" hidden="false" targetId="94f5-82c3-bb66-ac0c" type="profile">
           <profiles/>
           <rules/>
           <infoLinks/>
           <modifiers/>
         </infoLink>
-        <infoLink id="62c9-b399-d000-c0d4" name="New InfoLink" hidden="false" targetId="6349-022a-cea9-524c" type="rule">
+        <infoLink id="62c9-b399-d000-c0d4" name="Death to the False Emperor" hidden="false" targetId="37a4-1d84-4ef0-c4f6" type="profile">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="9633-fd37-ae57-61d8" name="Teleport Strike" hidden="false" targetId="ae9c-d115-d4a9-ba02" type="rule">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -6164,7 +6612,7 @@ D3   Bonus
           <modifiers/>
           <constraints/>
         </categoryLink>
-        <categoryLink id="efeb-24f3-33bb-a8ae" name="New CategoryLink" hidden="false" targetId="717b-8863-9d25-5e2a" primary="false">
+        <categoryLink id="efeb-24f3-33bb-a8ae" name="New CategoryLink" hidden="false" targetId="5cf1-acf2-ca3b-c2e5" primary="false">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -6230,7 +6678,7 @@ D3   Bonus
           </constraints>
           <categoryLinks/>
           <selectionEntries>
-            <selectionEntry id="222e-793c-9607-9777" name="Fleshmetal weapons" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="222e-793c-9607-9777" name="Fleshmetal weapons" hidden="false" collective="true" type="upgrade">
               <profiles>
                 <profile id="1471-0223-11b3-0af8" name="Fleshmetal weapons" hidden="false" profileTypeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" profileTypeName="Weapon">
                   <profiles/>
@@ -6243,19 +6691,11 @@ D3   Bonus
                     <characteristic name="S" characteristicTypeId="59b1-319e-ec13-d466" value="+D3"/>
                     <characteristic name="AP" characteristicTypeId="75aa-a838-b675-6484" value="-D3"/>
                     <characteristic name="D" characteristicTypeId="ae8a-3137-d65b-4ca7" value="D3"/>
-                    <characteristic name="Abilities" characteristicTypeId="837d-5e63-aeb7-1410" value="See below"/>
+                    <characteristic name="Abilities" characteristicTypeId="837d-5e63-aeb7-1410" value="See above"/>
                   </characteristics>
                 </profile>
               </profiles>
-              <rules>
-                <rule id="f2dc-16b2-f603-b826" name="Fleshmetal weapons" hidden="false">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                  <description>When a unit of Mutilators is chosen to fight, roll three D3, oen after the other. For that fight, the first roll is added to the Mutilator&apos;s Strength for the unit&apos;s attacks, the second roll is the Ap for the unit&apos;s attacks, and the third roll is the Damage for the unit&apos;s attacks. FOr example, if the rolls wre a 1, followed by a 3, followed by a 2, then all of the unit&apos;s attacks for that fight would have S +1, Ap -3, and D 2.</description>
-                </rule>
-              </rules>
+              <rules/>
               <infoLinks/>
               <modifiers/>
               <constraints>
@@ -6288,16 +6728,26 @@ D3   Bonus
       </costs>
     </selectionEntry>
     <selectionEntry id="07c3-8ec0-bfc9-8f99" name="Obliterators" page="" hidden="false" collective="false" type="unit">
-      <profiles/>
+      <profiles>
+        <profile id="b471-6570-1bdf-8885" name="Fleshmetal Guns" hidden="false" profileTypeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" profileTypeName="Abilities">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Description" characteristicTypeId="21befb24-fc85-4f52-a745-64b2e48f8228" value="When a unit of Obliterators is chosen to shoot in the Shooting Phase or in Overwatch, roll three D3, one after the other. The first roll is added to 6 to determine the Strength for the unit&apos;s shooting attacks, the second rol is the AP, and the third roll is the Damage. For example, if the rolls were a 1 followed by a 3, followed by a 2, then the unit&apos;s attacks would haev a Strength of 7, an AP of -3 and a Damage of 2 for that Shooting phase and Overwatch phase."/>
+          </characteristics>
+        </profile>
+      </profiles>
       <rules/>
       <infoLinks>
-        <infoLink id="046e-f599-0197-f78c" name="New InfoLink" hidden="false" targetId="6349-022a-cea9-524c" type="rule">
+        <infoLink id="046e-f599-0197-f78c" name="Death to the False Emperor" hidden="false" targetId="37a4-1d84-4ef0-c4f6" type="profile">
           <profiles/>
           <rules/>
           <infoLinks/>
           <modifiers/>
         </infoLink>
-        <infoLink id="7129-8442-7054-1d24" name="New InfoLink" hidden="false" targetId="2946-510b-88fb-5c9c" type="rule">
+        <infoLink id="7129-8442-7054-1d24" name="Daemonic" hidden="false" targetId="94f5-82c3-bb66-ac0c" type="profile">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -6341,7 +6791,7 @@ D3   Bonus
           <modifiers/>
           <constraints/>
         </categoryLink>
-        <categoryLink id="0861-66b2-fa42-9f40" name="New CategoryLink" hidden="false" targetId="717b-8863-9d25-5e2a" primary="false">
+        <categoryLink id="0861-66b2-fa42-9f40" name="New CategoryLink" hidden="false" targetId="5cf1-acf2-ca3b-c2e5" primary="false">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -6400,7 +6850,7 @@ D3   Bonus
           </constraints>
           <categoryLinks/>
           <selectionEntries>
-            <selectionEntry id="da6b-afff-6447-a37f" name="Fleshmetal guns" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="da6b-afff-6447-a37f" name="Fleshmetal guns" hidden="false" collective="true" type="upgrade">
               <profiles>
                 <profile id="46ff-853d-601e-6e92" name="Fleshmetal guns" hidden="false" profileTypeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" profileTypeName="Weapon">
                   <profiles/>
@@ -6417,15 +6867,7 @@ D3   Bonus
                   </characteristics>
                 </profile>
               </profiles>
-              <rules>
-                <rule id="d26a-e269-4603-7873" name="Fleshmetal guns" hidden="false">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                  <description>When a unit of Obliterators is chosen to shoot in the Shooting Phase or in Overwatch, roll three D3, oen after the other. The first roll is added to 6 to determine the S for the unit&apos;s shooting attacks, the second for AP, the third for D. </description>
-                </rule>
-              </rules>
+              <rules/>
               <infoLinks/>
               <modifiers/>
               <constraints>
@@ -6461,13 +6903,13 @@ D3   Bonus
       <profiles/>
       <rules/>
       <infoLinks>
-        <infoLink id="494f-4cfd-8a8f-a694" name="New InfoLink" hidden="false" targetId="e915-bbff-dc8e-5212" type="rule">
+        <infoLink id="494f-4cfd-8a8f-a694" name="Disgustingly Resilient" hidden="false" targetId="649e-7454-0be4-7a71" type="profile">
           <profiles/>
           <rules/>
           <infoLinks/>
           <modifiers/>
         </infoLink>
-        <infoLink id="68c3-ec7a-d237-9e72" name="New InfoLink" hidden="false" targetId="6349-022a-cea9-524c" type="rule">
+        <infoLink id="68c3-ec7a-d237-9e72" name="Death to the False Emperor" hidden="false" targetId="37a4-1d84-4ef0-c4f6" type="profile">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -6540,7 +6982,7 @@ D3   Bonus
           <modifiers/>
           <constraints/>
         </categoryLink>
-        <categoryLink id="8eee-34b9-d38b-7cdb" name="New CategoryLink" hidden="false" targetId="717b-8863-9d25-5e2a" primary="false">
+        <categoryLink id="8eee-34b9-d38b-7cdb" name="New CategoryLink" hidden="false" targetId="5cf1-acf2-ca3b-c2e5" primary="false">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -6549,143 +6991,6 @@ D3   Bonus
         </categoryLink>
       </categoryLinks>
       <selectionEntries>
-        <selectionEntry id="8d5f-fd5a-e5d1-8033" name="Plague Marines" hidden="false" collective="false" type="model">
-          <profiles>
-            <profile id="3a1f-7b96-fa86-dc65" name="Plague Marine" hidden="false" profileTypeId="800f-21d0-4387-c943" profileTypeName="Unit">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <characteristics>
-                <characteristic name="M" characteristicTypeId="0bdf-a96e-9e38-7779" value="5&quot;"/>
-                <characteristic name="WS" characteristicTypeId="e7f0-1278-0250-df0c" value="3+"/>
-                <characteristic name="BS" characteristicTypeId="381b-eb28-74c3-df5f" value="3+"/>
-                <characteristic name="S" characteristicTypeId="2218-aa3c-265f-2939" value="4"/>
-                <characteristic name="T" characteristicTypeId="9c9f-9774-a358-3a39" value="5"/>
-                <characteristic name="W" characteristicTypeId="f330-5e6e-4110-0978" value="1"/>
-                <characteristic name="A" characteristicTypeId="13fc-b29b-31f2-ab9f" value="1"/>
-                <characteristic name="Ld" characteristicTypeId="00ca-f8b8-876d-b705" value="7"/>
-                <characteristic name="Save" characteristicTypeId="c0df-df94-abd7-e8d3" value="3+"/>
-              </characteristics>
-            </profile>
-          </profiles>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints>
-            <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="16be-f986-4901-613e" type="min"/>
-            <constraint field="selections" scope="parent" value="19.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0359-c2b7-f9a3-1779" type="max"/>
-          </constraints>
-          <categoryLinks/>
-          <selectionEntries>
-            <selectionEntry id="6d16-5a5e-1fa8-fa84" name="Plague knife" hidden="false" collective="true" type="upgrade">
-              <profiles/>
-              <rules/>
-              <infoLinks>
-                <infoLink id="b758-63ff-5b60-b887" name="New InfoLink" hidden="false" targetId="b62d-7cc2-1b2a-ca61" type="profile">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                </infoLink>
-              </infoLinks>
-              <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2c68-1a4e-726d-f257" type="max"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" id="7571-41b3-62f1-004b" type="min"/>
-              </constraints>
-              <categoryLinks/>
-              <selectionEntries/>
-              <selectionEntryGroups/>
-              <entryLinks/>
-              <costs>
-                <cost name="pts" costTypeId="points" value="0.0"/>
-                <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="0.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="0175-1a5a-1f29-03df" name="Boltgun" hidden="false" collective="true" type="upgrade">
-              <profiles/>
-              <rules/>
-              <infoLinks>
-                <infoLink id="025b-f78c-6145-d217" hidden="false" targetId="3d4b-95ea-f860-dd22" type="profile">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                </infoLink>
-              </infoLinks>
-              <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="a3e7-c27e-0fef-9957" type="min"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="adff-e5cf-0e26-0072" type="max"/>
-              </constraints>
-              <categoryLinks/>
-              <selectionEntries/>
-              <selectionEntryGroups/>
-              <entryLinks/>
-              <costs>
-                <cost name="pts" costTypeId="points" value="0.0"/>
-                <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="0.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="8b05-47a8-16d4-62c3" name="Krak Grenades" hidden="false" collective="true" type="upgrade">
-              <profiles/>
-              <rules/>
-              <infoLinks>
-                <infoLink id="3ce4-1d3d-11b7-66d6" hidden="false" targetId="3bf6-b4f7-6b2f-bb7b" type="profile">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                </infoLink>
-              </infoLinks>
-              <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="29ee-52ee-80ab-e974" type="min"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="a268-5b83-be37-fe47" type="max"/>
-              </constraints>
-              <categoryLinks/>
-              <selectionEntries/>
-              <selectionEntryGroups/>
-              <entryLinks/>
-              <costs>
-                <cost name="pts" costTypeId="points" value="0.0"/>
-                <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="0.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="e891-0e6c-0056-80b7" name="Blight Grenades" hidden="false" collective="true" type="upgrade">
-              <profiles/>
-              <rules/>
-              <infoLinks>
-                <infoLink id="06e6-35ce-9d0a-7bd2" hidden="false" targetId="1287-6659-b04f-fe37" type="profile">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                </infoLink>
-              </infoLinks>
-              <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="2323-ccbc-0b91-a3d2" type="min"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="cca7-eb76-92fd-60e7" type="max"/>
-              </constraints>
-              <categoryLinks/>
-              <selectionEntries/>
-              <selectionEntryGroups/>
-              <entryLinks/>
-              <costs>
-                <cost name="pts" costTypeId="points" value="0.0"/>
-                <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="0.0"/>
-              </costs>
-            </selectionEntry>
-          </selectionEntries>
-          <selectionEntryGroups/>
-          <entryLinks/>
-          <costs>
-            <cost name="pts" costTypeId="points" value="21.0"/>
-            <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="0.0"/>
-          </costs>
-        </selectionEntry>
         <selectionEntry id="ccf9-1340-88d0-82d1" name="Plague Champion" page="" hidden="false" collective="false" type="model">
           <profiles>
             <profile id="9d49-6194-3b73-0e73" name="Plague Champion" page="0" hidden="false" profileTypeId="800f-21d0-4387-c943" profileTypeName="Unit">
@@ -6715,31 +7020,6 @@ D3   Bonus
           </constraints>
           <categoryLinks/>
           <selectionEntries>
-            <selectionEntry id="641e-06de-9308-2eaf" name="Blight Grenades" hidden="false" collective="false" type="upgrade">
-              <profiles/>
-              <rules/>
-              <infoLinks>
-                <infoLink id="4941-e675-4f41-3741" hidden="false" targetId="1287-6659-b04f-fe37" type="profile">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                </infoLink>
-              </infoLinks>
-              <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="89cc-4956-f153-042f" type="min"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="7769-cb57-7791-2750" type="max"/>
-              </constraints>
-              <categoryLinks/>
-              <selectionEntries/>
-              <selectionEntryGroups/>
-              <entryLinks/>
-              <costs>
-                <cost name="pts" costTypeId="points" value="0.0"/>
-                <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="0.0"/>
-              </costs>
-            </selectionEntry>
             <selectionEntry id="10eb-bb36-4831-a9d4" name="Krak Grenades" hidden="false" collective="true" type="upgrade">
               <profiles/>
               <rules/>
@@ -6830,7 +7110,22 @@ D3   Bonus
               <profiles/>
               <rules/>
               <infoLinks/>
-              <modifiers/>
+              <modifiers>
+                <modifier type="set" field="4362-fd04-d6f0-d58d" value="2">
+                  <repeats/>
+                  <conditions>
+                    <condition field="selections" scope="ccf9-1340-88d0-82d1" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="9dac-d4db-8bb5-47b3" type="atLeast"/>
+                  </conditions>
+                  <conditionGroups/>
+                </modifier>
+                <modifier type="set" field="2c05-3e27-e7b5-81fd" value="2">
+                  <repeats/>
+                  <conditions>
+                    <condition field="selections" scope="ccf9-1340-88d0-82d1" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="9dac-d4db-8bb5-47b3" type="equalTo"/>
+                  </conditions>
+                  <conditionGroups/>
+                </modifier>
+              </modifiers>
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4362-fd04-d6f0-d58d" type="max"/>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2c05-3e27-e7b5-81fd" type="min"/>
@@ -6841,8 +7136,18 @@ D3   Bonus
                   <profiles/>
                   <rules/>
                   <infoLinks/>
-                  <modifiers/>
-                  <constraints/>
+                  <modifiers>
+                    <modifier type="set" field="dc58-7563-ef66-f393" value="0.0">
+                      <repeats/>
+                      <conditions>
+                        <condition field="selections" scope="ccf9-1340-88d0-82d1" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="9dac-d4db-8bb5-47b3" type="atLeast"/>
+                      </conditions>
+                      <conditionGroups/>
+                    </modifier>
+                  </modifiers>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="dc58-7563-ef66-f393" type="max"/>
+                  </constraints>
                   <categoryLinks/>
                   <selectionEntries/>
                   <selectionEntryGroups/>
@@ -6879,8 +7184,18 @@ D3   Bonus
                   <profiles/>
                   <rules/>
                   <infoLinks/>
-                  <modifiers/>
-                  <constraints/>
+                  <modifiers>
+                    <modifier type="set" field="8849-3870-ebbe-d360" value="0.0">
+                      <repeats/>
+                      <conditions>
+                        <condition field="selections" scope="ccf9-1340-88d0-82d1" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="9dac-d4db-8bb5-47b3" type="atLeast"/>
+                      </conditions>
+                      <conditionGroups/>
+                    </modifier>
+                  </modifiers>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8849-3870-ebbe-d360" type="max"/>
+                  </constraints>
                   <categoryLinks/>
                   <selectionEntries/>
                   <selectionEntryGroups/>
@@ -6913,190 +7228,14 @@ D3   Bonus
                     <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="0.0"/>
                   </costs>
                 </selectionEntry>
-                <selectionEntry id="aef2-a2c8-8c8d-9d9f" name="Boltgun and other" hidden="false" collective="false" type="upgrade">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                  <constraints/>
-                  <categoryLinks/>
-                  <selectionEntries/>
-                  <selectionEntryGroups/>
-                  <entryLinks>
-                    <entryLink id="c605-2ff9-7c29-1b8f" name="Champion Equipment" hidden="false" targetId="1912-576e-6a2b-5c6e" type="selectionEntryGroup">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks/>
-                      <modifiers>
-                        <modifier type="set" field="0593-89c5-25e7-d094" value="1">
-                          <repeats/>
-                          <conditions/>
-                          <conditionGroups/>
-                        </modifier>
-                      </modifiers>
-                      <constraints>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="17fe-fe26-9d15-49c2" type="max"/>
-                      </constraints>
-                      <categoryLinks/>
-                    </entryLink>
-                    <entryLink id="f3a3-ded4-7c70-732f" name="Boltgun" hidden="false" targetId="b61f-a3c1-827d-c5b6" type="selectionEntry">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks/>
-                      <modifiers/>
-                      <constraints>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c23a-e2f4-d3f3-0fcc" type="max"/>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1f22-4f28-69fb-ddad" type="min"/>
-                      </constraints>
-                      <categoryLinks/>
-                    </entryLink>
-                  </entryLinks>
-                  <costs>
-                    <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="0.0"/>
-                    <cost name="pts" costTypeId="points" value="0.0"/>
-                  </costs>
-                </selectionEntry>
-                <selectionEntry id="dbf6-991c-a0ee-5694" name="Bolt pistol and other" hidden="false" collective="false" type="upgrade">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                  <constraints/>
-                  <categoryLinks/>
-                  <selectionEntries/>
-                  <selectionEntryGroups/>
-                  <entryLinks>
-                    <entryLink id="bf13-e8db-9b60-0e9c" name="Champion Equipment" hidden="false" targetId="1912-576e-6a2b-5c6e" type="selectionEntryGroup">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks/>
-                      <modifiers>
-                        <modifier type="set" field="0593-89c5-25e7-d094" value="1">
-                          <repeats/>
-                          <conditions/>
-                          <conditionGroups/>
-                        </modifier>
-                      </modifiers>
-                      <constraints/>
-                      <categoryLinks/>
-                    </entryLink>
-                    <entryLink id="fc06-b3a7-7517-5e11" name="Bolt pistol" hidden="false" targetId="0334-f487-8229-0c1a" type="selectionEntry">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks/>
-                      <modifiers/>
-                      <constraints>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d9f6-633f-a28d-9c72" type="max"/>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="626b-02d3-a291-5dc9" type="min"/>
-                      </constraints>
-                      <categoryLinks/>
-                    </entryLink>
-                  </entryLinks>
-                  <costs>
-                    <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="0.0"/>
-                    <cost name="pts" costTypeId="points" value="0.0"/>
-                  </costs>
-                </selectionEntry>
-                <selectionEntry id="2bf8-835d-5af6-60ae" name="Replace bolt pistol and boltgun" hidden="false" collective="false" type="upgrade">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                  <constraints/>
-                  <categoryLinks/>
-                  <selectionEntries/>
-                  <selectionEntryGroups/>
-                  <entryLinks>
-                    <entryLink id="ca7b-6e16-f357-13e1" name="Champion Equipment" hidden="false" targetId="1912-576e-6a2b-5c6e" type="selectionEntryGroup">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks/>
-                      <modifiers/>
-                      <constraints/>
-                      <categoryLinks/>
-                    </entryLink>
-                  </entryLinks>
-                  <costs>
-                    <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="0.0"/>
-                    <cost name="pts" costTypeId="points" value="0.0"/>
-                  </costs>
-                </selectionEntry>
-              </selectionEntries>
-              <selectionEntryGroups/>
-              <entryLinks/>
-            </selectionEntryGroup>
-          </selectionEntryGroups>
-          <entryLinks/>
-          <costs>
-            <cost name="pts" costTypeId="points" value="21.0"/>
-            <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="0.0"/>
-          </costs>
-        </selectionEntry>
-      </selectionEntries>
-      <selectionEntryGroups>
-        <selectionEntryGroup id="335f-13f9-1b57-81b0" name="Special Weapon" hidden="false" collective="false">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints>
-            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="b7fa-c2bc-a139-efa7" type="max"/>
-          </constraints>
-          <categoryLinks/>
-          <selectionEntries/>
-          <selectionEntryGroups>
-            <selectionEntryGroup id="d654-4bb9-540e-6948" name="Replace boltgun with..." hidden="false" collective="false">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints/>
-              <categoryLinks/>
-              <selectionEntries>
-                <selectionEntry id="002a-d242-9b64-8a8f" name="Blight launcher" hidden="false" collective="false" type="upgrade">
-                  <profiles>
-                    <profile id="6920-c10a-3525-f727" name="Blight launcher" hidden="false" profileTypeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" profileTypeName="Weapon">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks/>
-                      <modifiers/>
-                      <characteristics>
-                        <characteristic name="Range" characteristicTypeId="6fa97fa8-ea74-4a27-a0fb-bc4e5f367464" value="24&quot;"/>
-                        <characteristic name="Type" characteristicTypeId="077c342f-d7b9-45c6-b8af-88e97cafd3a2" value="Assault 2"/>
-                        <characteristic name="S" characteristicTypeId="59b1-319e-ec13-d466" value="6"/>
-                        <characteristic name="AP" characteristicTypeId="75aa-a838-b675-6484" value="-2"/>
-                        <characteristic name="D" characteristicTypeId="ae8a-3137-d65b-4ca7" value="D3"/>
-                        <characteristic name="Abilities" characteristicTypeId="837d-5e63-aeb7-1410" value="You can re-roll wound rolls of 1 for this weapon."/>
-                      </characteristics>
-                    </profile>
-                  </profiles>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                  <constraints/>
-                  <categoryLinks/>
-                  <selectionEntries/>
-                  <selectionEntryGroups/>
-                  <entryLinks/>
-                  <costs>
-                    <cost name="pts" costTypeId="points" value="14.0"/>
-                    <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="0.0"/>
-                  </costs>
-                </selectionEntry>
               </selectionEntries>
               <selectionEntryGroups/>
               <entryLinks>
-                <entryLink id="adcc-517e-5e46-0fa8" name="Special Weapons" hidden="false" targetId="a44b-4b4d-46b5-d3a6" type="selectionEntryGroup">
+                <entryLink id="9dac-d4db-8bb5-47b3" name="Champion Equipment" hidden="false" targetId="ad90-3560-ea09-82ef" type="selectionEntryGroup">
                   <profiles/>
                   <rules/>
                   <infoLinks/>
-                  <modifiers>
-                    <modifier type="set" field="5154-f7a1-21fa-cf7f" value="2">
-                      <repeats/>
-                      <conditions/>
-                      <conditionGroups/>
-                    </modifier>
-                  </modifiers>
+                  <modifiers/>
                   <constraints/>
                   <categoryLinks/>
                 </entryLink>
@@ -7104,19 +7243,303 @@ D3   Bonus
             </selectionEntryGroup>
           </selectionEntryGroups>
           <entryLinks>
-            <entryLink id="f00b-012a-5585-ab4b" name="New EntryLink" hidden="false" targetId="83be-1ba9-c326-4760" type="selectionEntry">
+            <entryLink id="509f-5c6d-3c46-7018" name="Blight Grenades" hidden="false" targetId="986e-f410-9c9a-a973" type="selectionEntry">
               <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="89db-0381-a6c0-aabd" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="a920-3ccc-958c-51ed" type="max"/>
+              </constraints>
+              <categoryLinks/>
+            </entryLink>
+          </entryLinks>
+          <costs>
+            <cost name="pts" costTypeId="points" value="21.0"/>
+            <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="0.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="653a-3565-b205-d49b" name="Plague Marines" hidden="false" collective="false" defaultSelectionEntryId="cae0-eaf2-dca4-3770">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="858f-05f4-f4e6-36f4" type="min"/>
+            <constraint field="selections" scope="parent" value="19.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5682-ca8f-8cc8-91e9" type="max"/>
+          </constraints>
+          <categoryLinks/>
+          <selectionEntries>
+            <selectionEntry id="cae0-eaf2-dca4-3770" name="Plague Marines" hidden="false" collective="false" type="model">
+              <profiles>
+                <profile id="7c17-1cf5-e382-ac47" name="Plague Marine" hidden="false" profileTypeId="800f-21d0-4387-c943" profileTypeName="Unit">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <characteristics>
+                    <characteristic name="M" characteristicTypeId="0bdf-a96e-9e38-7779" value="5&quot;"/>
+                    <characteristic name="WS" characteristicTypeId="e7f0-1278-0250-df0c" value="3+"/>
+                    <characteristic name="BS" characteristicTypeId="381b-eb28-74c3-df5f" value="3+"/>
+                    <characteristic name="S" characteristicTypeId="2218-aa3c-265f-2939" value="4"/>
+                    <characteristic name="T" characteristicTypeId="9c9f-9774-a358-3a39" value="5"/>
+                    <characteristic name="W" characteristicTypeId="f330-5e6e-4110-0978" value="1"/>
+                    <characteristic name="A" characteristicTypeId="13fc-b29b-31f2-ab9f" value="1"/>
+                    <characteristic name="Ld" characteristicTypeId="00ca-f8b8-876d-b705" value="7"/>
+                    <characteristic name="Save" characteristicTypeId="c0df-df94-abd7-e8d3" value="3+"/>
+                  </characteristics>
+                </profile>
+              </profiles>
               <rules/>
               <infoLinks/>
               <modifiers/>
               <constraints/>
               <categoryLinks/>
-            </entryLink>
-          </entryLinks>
+              <selectionEntries>
+                <selectionEntry id="0805-749d-a8aa-dc3a" name="Plague knife" hidden="false" collective="true" type="upgrade">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks>
+                    <infoLink id="c045-0528-263f-8eb1" name="Plague knife" hidden="false" targetId="b62d-7cc2-1b2a-ca61" type="profile">
+                      <profiles/>
+                      <rules/>
+                      <infoLinks/>
+                      <modifiers/>
+                    </infoLink>
+                  </infoLinks>
+                  <modifiers/>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="acb0-0d6b-6d7a-e0e7" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" id="ce08-0d58-2349-09d8" type="min"/>
+                  </constraints>
+                  <categoryLinks/>
+                  <selectionEntries/>
+                  <selectionEntryGroups/>
+                  <entryLinks/>
+                  <costs>
+                    <cost name="pts" costTypeId="points" value="0.0"/>
+                    <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="0.0"/>
+                  </costs>
+                </selectionEntry>
+                <selectionEntry id="72be-5d3a-97fe-1dc5" name="Boltgun" hidden="false" collective="true" type="upgrade">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks>
+                    <infoLink id="97eb-a180-2b43-b5f9" hidden="false" targetId="3d4b-95ea-f860-dd22" type="profile">
+                      <profiles/>
+                      <rules/>
+                      <infoLinks/>
+                      <modifiers/>
+                    </infoLink>
+                  </infoLinks>
+                  <modifiers/>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="58f1-33e1-6728-7bb5" type="min"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="8a4b-ccbc-f3e4-6d1b" type="max"/>
+                  </constraints>
+                  <categoryLinks/>
+                  <selectionEntries/>
+                  <selectionEntryGroups/>
+                  <entryLinks/>
+                  <costs>
+                    <cost name="pts" costTypeId="points" value="0.0"/>
+                    <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="0.0"/>
+                  </costs>
+                </selectionEntry>
+                <selectionEntry id="ccda-19d6-e1fe-feaa" name="Krak Grenades" hidden="false" collective="true" type="upgrade">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks>
+                    <infoLink id="c7ed-c284-a4b4-d5c5" hidden="false" targetId="3bf6-b4f7-6b2f-bb7b" type="profile">
+                      <profiles/>
+                      <rules/>
+                      <infoLinks/>
+                      <modifiers/>
+                    </infoLink>
+                  </infoLinks>
+                  <modifiers/>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="367e-a0b0-c211-ff17" type="min"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="10f6-baf9-bc78-1899" type="max"/>
+                  </constraints>
+                  <categoryLinks/>
+                  <selectionEntries/>
+                  <selectionEntryGroups/>
+                  <entryLinks/>
+                  <costs>
+                    <cost name="pts" costTypeId="points" value="0.0"/>
+                    <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="0.0"/>
+                  </costs>
+                </selectionEntry>
+              </selectionEntries>
+              <selectionEntryGroups/>
+              <entryLinks>
+                <entryLink id="2d5a-19e0-01b7-b0c0" name="Blight Grenades" hidden="false" targetId="fe40-0ecc-37e1-e5dd" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b2a7-4f86-0efe-ffe9" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8924-050e-b162-8484" type="min"/>
+                  </constraints>
+                  <categoryLinks/>
+                </entryLink>
+              </entryLinks>
+              <costs>
+                <cost name="pts" costTypeId="points" value="21.0"/>
+                <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="1da3-b974-e930-0574" name="Plague Marine w/ Special Weapon" hidden="false" collective="false" type="model">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1bd6-2df2-9c82-a3b9" type="max"/>
+              </constraints>
+              <categoryLinks/>
+              <selectionEntries/>
+              <selectionEntryGroups>
+                <selectionEntryGroup id="475c-ad11-7fe2-1ef1" name="Weapon option" hidden="false" collective="false">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fb4a-eb1f-97ca-029d" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="53f9-fae3-fc85-3d73" type="min"/>
+                  </constraints>
+                  <categoryLinks/>
+                  <selectionEntries>
+                    <selectionEntry id="2029-4619-9851-ef23" name="Blight launcher" hidden="false" collective="false" type="upgrade">
+                      <profiles>
+                        <profile id="1850-e9f8-d5cb-bd1b" name="Blight launcher" hidden="false" profileTypeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" profileTypeName="Weapon">
+                          <profiles/>
+                          <rules/>
+                          <infoLinks/>
+                          <modifiers/>
+                          <characteristics>
+                            <characteristic name="Range" characteristicTypeId="6fa97fa8-ea74-4a27-a0fb-bc4e5f367464" value="24&quot;"/>
+                            <characteristic name="Type" characteristicTypeId="077c342f-d7b9-45c6-b8af-88e97cafd3a2" value="Assault 2"/>
+                            <characteristic name="S" characteristicTypeId="59b1-319e-ec13-d466" value="6"/>
+                            <characteristic name="AP" characteristicTypeId="75aa-a838-b675-6484" value="-2"/>
+                            <characteristic name="D" characteristicTypeId="ae8a-3137-d65b-4ca7" value="D3"/>
+                            <characteristic name="Abilities" characteristicTypeId="837d-5e63-aeb7-1410" value="You can re-roll wound rolls of 1 for this weapon."/>
+                          </characteristics>
+                        </profile>
+                      </profiles>
+                      <rules/>
+                      <infoLinks/>
+                      <modifiers/>
+                      <constraints>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c2f6-b437-2143-84b9" type="max"/>
+                      </constraints>
+                      <categoryLinks/>
+                      <selectionEntries/>
+                      <selectionEntryGroups/>
+                      <entryLinks/>
+                      <costs>
+                        <cost name="pts" costTypeId="points" value="14.0"/>
+                        <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="0.0"/>
+                      </costs>
+                    </selectionEntry>
+                    <selectionEntry id="7075-997f-fba2-7448" name="Boltgun and Plasma Pistol" hidden="false" collective="false" type="upgrade">
+                      <profiles/>
+                      <rules/>
+                      <infoLinks/>
+                      <modifiers/>
+                      <constraints>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1002-7a92-182e-b6c8" type="max"/>
+                      </constraints>
+                      <categoryLinks/>
+                      <selectionEntries/>
+                      <selectionEntryGroups/>
+                      <entryLinks>
+                        <entryLink id="bd30-2196-8aaa-0287" name="Boltgun" hidden="false" targetId="b61f-a3c1-827d-c5b6" type="selectionEntry">
+                          <profiles/>
+                          <rules/>
+                          <infoLinks/>
+                          <modifiers/>
+                          <constraints>
+                            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0d3d-89a2-50a3-76b1" type="max"/>
+                            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="af95-3f9c-99f3-620c" type="min"/>
+                          </constraints>
+                          <categoryLinks/>
+                        </entryLink>
+                        <entryLink id="9279-4166-b1a6-4bc2" name="Plasma pistol" hidden="false" targetId="83be-1ba9-c326-4760" type="selectionEntry">
+                          <profiles/>
+                          <rules/>
+                          <infoLinks/>
+                          <modifiers/>
+                          <constraints>
+                            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="accd-7719-8bc1-0827" type="max"/>
+                            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e5f0-463d-fe1e-cdab" type="min"/>
+                          </constraints>
+                          <categoryLinks/>
+                        </entryLink>
+                      </entryLinks>
+                      <costs>
+                        <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="0.0"/>
+                        <cost name="pts" costTypeId="points" value="0.0"/>
+                      </costs>
+                    </selectionEntry>
+                  </selectionEntries>
+                  <selectionEntryGroups/>
+                  <entryLinks>
+                    <entryLink id="7d76-e082-f535-4b41" name="Special Weapons" hidden="false" targetId="a44b-4b4d-46b5-d3a6" type="selectionEntryGroup">
+                      <profiles/>
+                      <rules/>
+                      <infoLinks/>
+                      <modifiers/>
+                      <constraints>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4bff-a2e3-68de-4027" type="max"/>
+                      </constraints>
+                      <categoryLinks/>
+                    </entryLink>
+                  </entryLinks>
+                </selectionEntryGroup>
+              </selectionEntryGroups>
+              <entryLinks>
+                <entryLink id="4d22-f783-0406-3758" name="Blight Grenades" hidden="false" targetId="986e-f410-9c9a-a973" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fe47-d04d-e40e-e4e9" type="min"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d70a-53e8-a1c1-2985" type="max"/>
+                  </constraints>
+                  <categoryLinks/>
+                </entryLink>
+                <entryLink id="37e1-9a80-44bc-740e" name="Krak grenade" hidden="false" targetId="0f23-cd69-d106-371e" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8bc2-e047-8afb-7709" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c4e3-1581-cf08-61b2" type="min"/>
+                  </constraints>
+                  <categoryLinks/>
+                </entryLink>
+              </entryLinks>
+              <costs>
+                <cost name="pts" costTypeId="points" value="21.0"/>
+                <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="0.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+          <selectionEntryGroups/>
+          <entryLinks/>
         </selectionEntryGroup>
       </selectionEntryGroups>
       <entryLinks>
-        <entryLink id="6a18-3425-6d7d-cb8d" name="New EntryLink" hidden="false" targetId="2551-97d8-11cb-d026" type="selectionEntry">
+        <entryLink id="6a18-3425-6d7d-cb8d" name="Icon of Despair" hidden="false" targetId="2551-97d8-11cb-d026" type="selectionEntry">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -7157,14 +7580,14 @@ D3   Bonus
           <characteristics>
             <characteristic name="Cast" characteristicTypeId="5afb-9914-904b-d3b3" value="2"/>
             <characteristic name="Deny" characteristicTypeId="b5ac-9c20-5d5a-6f9b" value="1"/>
-            <characteristic name="Powers Known" characteristicTypeId="69d7-b45e-00a2-7e46" value="2 Dark Hereticus"/>
+            <characteristic name="Powers Known" characteristicTypeId="69d7-b45e-00a2-7e46" value="Smite and 2 powers from the Dark Hereticus discipline"/>
             <characteristic name="Other" characteristicTypeId="c2e2-f115-0003-5d7b" value=""/>
           </characteristics>
         </profile>
       </profiles>
       <rules/>
       <infoLinks>
-        <infoLink id="e3a5-1035-6513-5ead" name="New InfoLink" hidden="false" targetId="6349-022a-cea9-524c" type="rule">
+        <infoLink id="e3a5-1035-6513-5ead" name="Death to the False Emperor" hidden="false" targetId="37a4-1d84-4ef0-c4f6" type="profile">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -7319,6 +7742,28 @@ D3   Bonus
           <constraints/>
           <categoryLinks/>
         </entryLink>
+        <entryLink id="ef7b-6b12-187e-aa18" name="Smite" hidden="false" targetId="03fd-db47-5333-1e1f" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="eafb-bb02-f012-b602" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="84fe-d1f1-1850-804c" type="min"/>
+          </constraints>
+          <categoryLinks/>
+        </entryLink>
+        <entryLink id="8452-ce4b-8d4d-5116" name="Dark Hereticus discipline" hidden="false" targetId="0246-3399-3b88-44aa" type="selectionEntryGroup">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e1b3-dcc5-7459-4b5d" type="max"/>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f24c-f17c-8202-06dc" type="min"/>
+          </constraints>
+          <categoryLinks/>
+        </entryLink>
       </entryLinks>
       <costs>
         <cost name="pts" costTypeId="points" value="90.0"/>
@@ -7339,13 +7784,13 @@ D3   Bonus
       </profiles>
       <rules/>
       <infoLinks>
-        <infoLink id="07e4-3519-2235-d9e0" name="New InfoLink" hidden="false" targetId="2946-510b-88fb-5c9c" type="rule">
+        <infoLink id="07e4-3519-2235-d9e0" name="Daemonic" hidden="false" targetId="94f5-82c3-bb66-ac0c" type="profile">
           <profiles/>
           <rules/>
           <infoLinks/>
           <modifiers/>
         </infoLink>
-        <infoLink id="2395-9baf-5a33-15dd" name="New InfoLink" hidden="false" targetId="6349-022a-cea9-524c" type="rule">
+        <infoLink id="2395-9baf-5a33-15dd" name="Death to the False Emperor" hidden="false" targetId="37a4-1d84-4ef0-c4f6" type="profile">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -7391,7 +7836,7 @@ D3   Bonus
           <modifiers/>
           <constraints/>
         </categoryLink>
-        <categoryLink id="6593-2434-d0c5-ca41" name="New CategoryLink" hidden="false" targetId="717b-8863-9d25-5e2a" primary="false">
+        <categoryLink id="6593-2434-d0c5-ca41" name="New CategoryLink" hidden="false" targetId="5cf1-acf2-ca3b-c2e5" primary="false">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -7558,11 +8003,11 @@ D3   Bonus
           <rules/>
           <infoLinks/>
           <modifiers/>
-          <description>At the end of your Movement phase, a Warpsmith can repair a single (Legion) Vehicle (other than models that can Fly) within 1&quot;. That model regains D3 lost wounds. A Warpsmith can instead curse a single enemy Vehicle within 18&quot;. Roll a D6; on a 2+ that vehicle suffers a MW. A Vehicle cannot be repaired or cursed by more than one Warpsmith in the same turn.</description>
+          <description>At the end of your Movement phase, a Warpsmith can repair a single (Legion) Vehicle (other than models that can Fly) within 1&quot;. That model regains D3 lost wounds. A Warpsmith can instead curse a single enemy Vehicle within 18&quot;. Roll a D6; on a 2+ that vehicle suffers a mortal wound. A Vehicle cannot be repaired or cursed by more than one model with Master of Mechanisms in the same turn.</description>
         </rule>
       </rules>
       <infoLinks>
-        <infoLink id="53cd-6925-8955-b1aa" name="New InfoLink" hidden="false" targetId="6349-022a-cea9-524c" type="rule">
+        <infoLink id="53cd-6925-8955-b1aa" name="Death to the False Emperor" hidden="false" targetId="37a4-1d84-4ef0-c4f6" type="profile">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -7579,7 +8024,7 @@ D3   Bonus
           <modifiers/>
           <constraints/>
         </categoryLink>
-        <categoryLink id="29a7-e4d4-8697-0533" name="New CategoryLink" hidden="false" targetId="717b-8863-9d25-5e2a" primary="false">
+        <categoryLink id="29a7-e4d4-8697-0533" name="New CategoryLink" hidden="false" targetId="5cf1-acf2-ca3b-c2e5" primary="false">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -7765,7 +8210,7 @@ D3   Bonus
           <infoLinks/>
           <modifiers/>
           <characteristics>
-            <characteristic name="Description" characteristicTypeId="21befb24-fc85-4f52-a745-64b2e48f8228" value="Enemy units that are within 3&quot; of any units with an Icon of Despair must subtract 1 from their Ld."/>
+            <characteristic name="Description" characteristicTypeId="21befb24-fc85-4f52-a745-64b2e48f8228" value="Enemy units that are within 3&quot; of any units with an Icon of Despair must subtract 1 from their Leadership."/>
           </characteristics>
         </profile>
       </profiles>
@@ -7806,19 +8251,19 @@ D3   Bonus
       </profiles>
       <rules/>
       <infoLinks>
-        <infoLink id="071a-23a5-897d-ec72" name="New InfoLink" hidden="false" targetId="8ce7-b46b-12bd-dbb8" type="rule">
+        <infoLink id="071a-23a5-897d-ec72" name="Lord of Chaos" hidden="false" targetId="69a2-f63e-3d27-5c09" type="profile">
           <profiles/>
           <rules/>
           <infoLinks/>
           <modifiers/>
         </infoLink>
-        <infoLink id="3fc8-d436-34a0-8ceb" name="New InfoLink" hidden="false" targetId="6349-022a-cea9-524c" type="rule">
+        <infoLink id="3fc8-d436-34a0-8ceb" name="Death to the False Emperor" hidden="false" targetId="37a4-1d84-4ef0-c4f6" type="profile">
           <profiles/>
           <rules/>
           <infoLinks/>
           <modifiers/>
         </infoLink>
-        <infoLink id="0cb3-227c-566d-b9e3" name="New InfoLink" hidden="false" targetId="94d8-b556-103a-36ec" type="rule">
+        <infoLink id="0cb3-227c-566d-b9e3" name="Sigil of Corruption" hidden="false" targetId="c237-7aca-a961-6c59" type="profile">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -7841,21 +8286,7 @@ D3   Bonus
           <modifiers/>
           <constraints/>
         </categoryLink>
-        <categoryLink id="8e52-5be4-912a-b3a0" name="New CategoryLink" hidden="false" targetId="717b-8863-9d25-5e2a" primary="false">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints/>
-        </categoryLink>
         <categoryLink id="a534-3739-6587-19bd" name="New CategoryLink" hidden="false" targetId="ef18-746a-369f-43a4" primary="false">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints/>
-        </categoryLink>
-        <categoryLink id="6cee-ae1a-02a0-a03e" name="New CategoryLink" hidden="false" targetId="eb55-bd6b-3e75-d505" primary="false">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -7897,6 +8328,20 @@ D3   Bonus
           <modifiers/>
           <constraints/>
         </categoryLink>
+        <categoryLink id="f873-fafc-2e1f-2efe" name="New CategoryLink" hidden="false" targetId="eb55-bd6b-3e75-d505" primary="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
+        <categoryLink id="5771-28f0-f660-8605" name="New CategoryLink" hidden="false" targetId="5cf1-acf2-ca3b-c2e5" primary="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
       </categoryLinks>
       <selectionEntries/>
       <selectionEntryGroups>
@@ -7923,7 +8368,7 @@ D3   Bonus
               </constraints>
               <categoryLinks/>
             </entryLink>
-            <entryLink id="d89c-78da-6a46-7f1c" name="New EntryLink" hidden="false" targetId="5383-9a88-9883-e144" type="selectionEntryGroup">
+            <entryLink id="d89c-78da-6a46-7f1c" name="Combi-weapons" hidden="false" targetId="5383-9a88-9883-e144" type="selectionEntryGroup">
               <profiles/>
               <rules/>
               <infoLinks/>
@@ -7931,7 +8376,7 @@ D3   Bonus
               <constraints/>
               <categoryLinks/>
             </entryLink>
-            <entryLink id="2c0b-eaa1-31f9-c9f4" name="New EntryLink" hidden="false" targetId="2607-d554-732e-c0b0" type="selectionEntryGroup">
+            <entryLink id="2c0b-eaa1-31f9-c9f4" name="Terminator Melee Weapons" hidden="false" targetId="2607-d554-732e-c0b0" type="selectionEntryGroup">
               <profiles/>
               <rules/>
               <infoLinks/>
@@ -8012,25 +8457,25 @@ D3   Bonus
       </profiles>
       <rules/>
       <infoLinks>
-        <infoLink id="eddc-e83c-e6a6-0a5d" name="New InfoLink" hidden="false" targetId="8ce7-b46b-12bd-dbb8" type="rule">
+        <infoLink id="eddc-e83c-e6a6-0a5d" name="Lord of Chaos" hidden="false" targetId="69a2-f63e-3d27-5c09" type="profile">
           <profiles/>
           <rules/>
           <infoLinks/>
           <modifiers/>
         </infoLink>
-        <infoLink id="5245-0e90-33b5-7c20" name="New InfoLink" hidden="false" targetId="6349-022a-cea9-524c" type="rule">
+        <infoLink id="5245-0e90-33b5-7c20" name="Death to the False Emperor" hidden="false" targetId="37a4-1d84-4ef0-c4f6" type="profile">
           <profiles/>
           <rules/>
           <infoLinks/>
           <modifiers/>
         </infoLink>
-        <infoLink id="52d1-12eb-fcd0-d2dc" name="New InfoLink" hidden="false" targetId="94d8-b556-103a-36ec" type="rule">
+        <infoLink id="52d1-12eb-fcd0-d2dc" name="Sigil of Corruption" hidden="false" targetId="c237-7aca-a961-6c59" type="profile">
           <profiles/>
           <rules/>
           <infoLinks/>
           <modifiers/>
         </infoLink>
-        <infoLink id="ba0d-1a1c-3af2-54e6" name="New InfoLink" hidden="false" targetId="e008-161d-80a5-aef1" type="rule">
+        <infoLink id="ba0d-1a1c-3af2-54e6" name="Turbo-boost" hidden="false" targetId="3923-a411-2e7b-dc9c" type="profile">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -8048,13 +8493,6 @@ D3   Bonus
           <constraints/>
         </categoryLink>
         <categoryLink id="848d-3b84-092c-f07c" name="New CategoryLink" hidden="false" targetId="1c6f-0311-3eba-3180" primary="false">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints/>
-        </categoryLink>
-        <categoryLink id="45d9-5364-2efa-82b4" name="New CategoryLink" hidden="false" targetId="717b-8863-9d25-5e2a" primary="false">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -8090,6 +8528,13 @@ D3   Bonus
           <constraints/>
         </categoryLink>
         <categoryLink id="d21b-725b-6afe-4779" name="New CategoryLink" hidden="false" targetId="a61a-08c8-c7f7-9f78" primary="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
+        <categoryLink id="1d60-2796-f7ac-f0ec" name="New CategoryLink" hidden="false" targetId="5cf1-acf2-ca3b-c2e5" primary="false">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -8271,38 +8716,25 @@ D3   Bonus
             <characteristic name="Save" characteristicTypeId="c0df-df94-abd7-e8d3" value="3+"/>
           </characteristics>
         </profile>
-        <profile id="7239-3163-58b3-4912" name="Blades on Disc of Tzeentch" hidden="false" profileTypeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" profileTypeName="Weapon">
+        <profile id="da6b-7b33-2a54-4ac6" name="Lord of Tzeentch" hidden="false" profileTypeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" profileTypeName="Abilities">
           <profiles/>
           <rules/>
           <infoLinks/>
           <modifiers/>
           <characteristics>
-            <characteristic name="Range" characteristicTypeId="6fa97fa8-ea74-4a27-a0fb-bc4e5f367464" value="Melee"/>
-            <characteristic name="Type" characteristicTypeId="077c342f-d7b9-45c6-b8af-88e97cafd3a2" value="Melee"/>
-            <characteristic name="S" characteristicTypeId="59b1-319e-ec13-d466" value="4"/>
-            <characteristic name="AP" characteristicTypeId="75aa-a838-b675-6484" value="0"/>
-            <characteristic name="D" characteristicTypeId="ae8a-3137-d65b-4ca7" value="1"/>
-            <characteristic name="Abilities" characteristicTypeId="837d-5e63-aeb7-1410" value="After this model makes its close combat attacks, you can attack with its mount. Make 1 additional attack, using this weapon proile."/>
+            <characteristic name="Description" characteristicTypeId="21befb24-fc85-4f52-a745-64b2e48f8228" value="You can re-roll all hit rolls of 1 made for friendly TZEENTCH &lt;LEGION&gt; units within 6&quot; of this model."/>
           </characteristics>
         </profile>
       </profiles>
-      <rules>
-        <rule id="270b-8c13-5c65-49dd" name="Lord of Tzeentch" hidden="false">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <description>You can re-roll all hit rolls of 1 made for friendly Tzeentch (Legion) units within 6&quot; of this model.</description>
-        </rule>
-      </rules>
+      <rules/>
       <infoLinks>
-        <infoLink id="ca59-0f6f-eea1-39c7" name="New InfoLink" hidden="false" targetId="94d8-b556-103a-36ec" type="rule">
+        <infoLink id="ca59-0f6f-eea1-39c7" name="Sigil of Corruption" hidden="false" targetId="c237-7aca-a961-6c59" type="profile">
           <profiles/>
           <rules/>
           <infoLinks/>
           <modifiers/>
         </infoLink>
-        <infoLink id="49d2-f979-9477-87b6" name="New InfoLink" hidden="false" targetId="6349-022a-cea9-524c" type="rule">
+        <infoLink id="49d2-f979-9477-87b6" name="Death to the False Emperor" hidden="false" targetId="37a4-1d84-4ef0-c4f6" type="profile">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -8313,13 +8745,6 @@ D3   Bonus
       <constraints/>
       <categoryLinks>
         <categoryLink id="0c84-fa75-9d7e-31e8" name="New CategoryLink" hidden="false" targetId="848a6ff2-0def-4c72-8433-ff7da70e6bc7" primary="true">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints/>
-        </categoryLink>
-        <categoryLink id="09f3-ac7e-f654-4b30" name="New CategoryLink" hidden="false" targetId="717b-8863-9d25-5e2a" primary="false">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -8376,6 +8801,13 @@ D3   Bonus
           <constraints/>
         </categoryLink>
         <categoryLink id="260a-376f-25ba-33da" name="New CategoryLink" hidden="false" targetId="b2b6-8e4a-9c74-cc37" primary="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
+        <categoryLink id="4fb1-e1cb-e09e-5534" name="New CategoryLink" hidden="false" targetId="5cf1-acf2-ca3b-c2e5" primary="false">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -8572,31 +9004,34 @@ D3   Bonus
             <characteristic name="Save" characteristicTypeId="c0df-df94-abd7-e8d3" value="3+"/>
           </characteristics>
         </profile>
+        <profile id="ea86-92a4-ff3a-d1e6" name="Devastating Charge" hidden="false" profileTypeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" profileTypeName="Abilities">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Description" characteristicTypeId="21befb24-fc85-4f52-a745-64b2e48f8228" value="The sheer impact of a Juggernaut charge can crush enemies into a paste. Add 2 to the Strength of the Juggernaut&apos;s Bladed Horn attack if it charged in the same turn."/>
+          </characteristics>
+        </profile>
+        <profile id="6920-218c-58c9-904f" name="Lord of Khorne" hidden="false" profileTypeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" profileTypeName="Abilities">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Description" characteristicTypeId="21befb24-fc85-4f52-a745-64b2e48f8228" value="You can re-roll hit rolls of 1 made for friendly KHORNE &lt;LEGION&gt; units within 6&quot; of this model."/>
+          </characteristics>
+        </profile>
       </profiles>
-      <rules>
-        <rule id="2675-85cc-2a24-4101" name="Lord of Khorne" hidden="false">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <description>You can re-roll hit rolls of 1 made for friendly Khorne (Legion) units within 6&quot; of this model.</description>
-        </rule>
-        <rule id="e892-97df-486a-f078" name="Devastating Charge" hidden="false">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <description>The sheer impact of a Juggernaut charge can crush enemies into a paste. Add +2 S to the Juggernaut&apos;s Bladed Horn attack if it charged in the same turn.</description>
-        </rule>
-      </rules>
+      <rules/>
       <infoLinks>
-        <infoLink id="d16e-63f5-3305-d426" name="New InfoLink" hidden="false" targetId="94d8-b556-103a-36ec" type="rule">
+        <infoLink id="d16e-63f5-3305-d426" name="Sigil of Corruption" hidden="false" targetId="c237-7aca-a961-6c59" type="profile">
           <profiles/>
           <rules/>
           <infoLinks/>
           <modifiers/>
         </infoLink>
-        <infoLink id="fc4d-3628-92df-8e2f" name="New InfoLink" hidden="false" targetId="6349-022a-cea9-524c" type="rule">
+        <infoLink id="fc4d-3628-92df-8e2f" name="Death to the False Emperor" hidden="false" targetId="37a4-1d84-4ef0-c4f6" type="profile">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -8634,7 +9069,7 @@ D3   Bonus
           <modifiers/>
           <constraints/>
         </categoryLink>
-        <categoryLink id="d8e1-4fdf-0781-f011" name="New CategoryLink" hidden="false" targetId="717b-8863-9d25-5e2a" primary="false">
+        <categoryLink id="d8e1-4fdf-0781-f011" name="New CategoryLink" hidden="false" targetId="5cf1-acf2-ca3b-c2e5" primary="false">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -8859,24 +9294,25 @@ D3   Bonus
             <characteristic name="Save" characteristicTypeId="c0df-df94-abd7-e8d3" value="3+"/>
           </characteristics>
         </profile>
-      </profiles>
-      <rules>
-        <rule id="0128-bf82-850d-bf76" name="Lord of Nurgle" hidden="false">
+        <profile id="fa15-d1cc-8f04-3eeb" name="Lord of Nurgle" hidden="false" profileTypeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" profileTypeName="Abilities">
           <profiles/>
           <rules/>
           <infoLinks/>
           <modifiers/>
-          <description>You can re-roll all hit rolls of 1 made for friendly Nurgle (Legion) units within 6&quot; of this model.</description>
-        </rule>
-      </rules>
+          <characteristics>
+            <characteristic name="Description" characteristicTypeId="21befb24-fc85-4f52-a745-64b2e48f8228" value="You can re-roll all hit rolls of 1 made for friendly NURGLE &lt;LEGION&gt; units within 6&quot; of this model."/>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules/>
       <infoLinks>
-        <infoLink id="3714-95b3-8aba-37b4" name="New InfoLink" hidden="false" targetId="94d8-b556-103a-36ec" type="rule">
+        <infoLink id="3714-95b3-8aba-37b4" name="Sigil of Corruption" hidden="false" targetId="c237-7aca-a961-6c59" type="profile">
           <profiles/>
           <rules/>
           <infoLinks/>
           <modifiers/>
         </infoLink>
-        <infoLink id="61bb-67f7-e7e0-7a3c" name="New InfoLink" hidden="false" targetId="6349-022a-cea9-524c" type="rule">
+        <infoLink id="61bb-67f7-e7e0-7a3c" name="Death to the False Emperor" hidden="false" targetId="37a4-1d84-4ef0-c4f6" type="profile">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -8893,7 +9329,7 @@ D3   Bonus
           <modifiers/>
           <constraints/>
         </categoryLink>
-        <categoryLink id="ea61-1132-ef93-985d" name="New CategoryLink" hidden="false" targetId="717b-8863-9d25-5e2a" primary="false">
+        <categoryLink id="ea61-1132-ef93-985d" name="New CategoryLink" hidden="false" targetId="5cf1-acf2-ca3b-c2e5" primary="false">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -9139,31 +9575,31 @@ D3   Bonus
             <characteristic name="Save" characteristicTypeId="c0df-df94-abd7-e8d3" value="3+"/>
           </characteristics>
         </profile>
+        <profile id="e3a4-124f-48bd-f320" name="Lord of Slaanesh" hidden="false" profileTypeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" profileTypeName="Abilities">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Description" characteristicTypeId="21befb24-fc85-4f52-a745-64b2e48f8228" value="You can re-roll all hit rolls of 1 made for friendly Slaanesh (Legion) units within 6&quot; of this model."/>
+          </characteristics>
+        </profile>
       </profiles>
-      <rules>
-        <rule id="de66-90cc-acc3-eb6c" name="Lord of Slaanesh" hidden="false">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <description>You can re-roll all hit rolls of 1 made for friendly Slaanesh (Legion) units within 6&quot; of this model.</description>
-        </rule>
-        <rule id="2856-9539-bfee-2d56" name="Unholy Speed" hidden="false">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <description>This model can Advance and charge in the same turn.</description>
-        </rule>
-      </rules>
+      <rules/>
       <infoLinks>
-        <infoLink id="7597-8c4b-4baa-fee5" name="New InfoLink" hidden="false" targetId="6349-022a-cea9-524c" type="rule">
+        <infoLink id="7597-8c4b-4baa-fee5" name="Death to the False Emperor" hidden="false" targetId="37a4-1d84-4ef0-c4f6" type="profile">
           <profiles/>
           <rules/>
           <infoLinks/>
           <modifiers/>
         </infoLink>
-        <infoLink id="931c-0eac-1344-0056" name="New InfoLink" hidden="false" targetId="94d8-b556-103a-36ec" type="rule">
+        <infoLink id="931c-0eac-1344-0056" name="Sigil of Corruption" hidden="false" targetId="c237-7aca-a961-6c59" type="profile">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="8adf-3f0a-f1b3-eb74" name="Unholy Speed" hidden="false" targetId="e4c7-f469-f22d-f31b" type="profile">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -9187,7 +9623,7 @@ D3   Bonus
           <modifiers/>
           <constraints/>
         </categoryLink>
-        <categoryLink id="f849-130d-a471-718d" name="New CategoryLink" hidden="false" targetId="717b-8863-9d25-5e2a" primary="false">
+        <categoryLink id="f849-130d-a471-718d" name="New CategoryLink" hidden="false" targetId="5cf1-acf2-ca3b-c2e5" primary="false">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -9427,29 +9863,27 @@ D3   Bonus
           </characteristics>
         </profile>
       </profiles>
-      <rules>
-        <rule id="93af-37fc-6cef-476c" name="Jump Pack Assault" hidden="false">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <description>During deployment you can set it up high in the skies instead of placing it on the battlefield. At the end of any of your Movement phases this model can assault from above - set it up anywhere on the battlefield that is more than 9&quot; away from any enemy models.</description>
-        </rule>
-      </rules>
+      <rules/>
       <infoLinks>
-        <infoLink id="d93a-8ea0-2820-fc3b" name="New InfoLink" hidden="false" targetId="6349-022a-cea9-524c" type="rule">
+        <infoLink id="d93a-8ea0-2820-fc3b" name="Death to the False Emperor" hidden="false" targetId="37a4-1d84-4ef0-c4f6" type="profile">
           <profiles/>
           <rules/>
           <infoLinks/>
           <modifiers/>
         </infoLink>
-        <infoLink id="a042-0bc1-8591-23f3" name="New InfoLink" hidden="false" targetId="94d8-b556-103a-36ec" type="rule">
+        <infoLink id="a042-0bc1-8591-23f3" name="Sigil of Corruption" hidden="false" targetId="c237-7aca-a961-6c59" type="profile">
           <profiles/>
           <rules/>
           <infoLinks/>
           <modifiers/>
         </infoLink>
-        <infoLink id="9617-d732-bb4d-0435" name="New InfoLink" hidden="false" targetId="8ce7-b46b-12bd-dbb8" type="rule">
+        <infoLink id="9617-d732-bb4d-0435" name="Lord of Chaos" hidden="false" targetId="69a2-f63e-3d27-5c09" type="profile">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="6e54-7546-c162-f4e8" name="Jump Pack Assault" hidden="false" targetId="3a84-0b71-5f8f-5b9c" type="rule">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -9466,7 +9900,7 @@ D3   Bonus
           <modifiers/>
           <constraints/>
         </categoryLink>
-        <categoryLink id="2da4-3a44-3e0a-80e4" name="New CategoryLink" hidden="false" targetId="717b-8863-9d25-5e2a" primary="false">
+        <categoryLink id="2da4-3a44-3e0a-80e4" name="New CategoryLink" hidden="false" targetId="5cf1-acf2-ca3b-c2e5" primary="false">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -9673,7 +10107,15 @@ D3   Bonus
           <profiles/>
           <rules/>
           <infoLinks/>
-          <modifiers/>
+          <modifiers>
+            <modifier type="increment" field="13fc-b29b-31f2-ab9f" value="1">
+              <repeats/>
+              <conditions>
+                <condition field="selections" scope="4445-6367-dac4-307a" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="dd66-1289-e5cb-e2d7" type="equalTo"/>
+              </conditions>
+              <conditionGroups/>
+            </modifier>
+          </modifiers>
           <characteristics>
             <characteristic name="M" characteristicTypeId="0bdf-a96e-9e38-7779" value="12&quot;"/>
             <characteristic name="WS" characteristicTypeId="e7f0-1278-0250-df0c" value="2+"/>
@@ -9686,7 +10128,7 @@ D3   Bonus
             <characteristic name="Save" characteristicTypeId="c0df-df94-abd7-e8d3" value="3+"/>
           </characteristics>
         </profile>
-        <profile id="156a-8086-1ca2-227b" name="Daemon Prince" hidden="false" profileTypeId="bc97-dea9-9e88-bb7d" profileTypeName="Psyker">
+        <profile id="4aed-f996-db96-6d4d" name="Daemon Prince" hidden="false" profileTypeId="bc97-dea9-9e88-bb7d" profileTypeName="Psyker">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -9694,42 +10136,20 @@ D3   Bonus
           <characteristics>
             <characteristic name="Cast" characteristicTypeId="5afb-9914-904b-d3b3" value="1"/>
             <characteristic name="Deny" characteristicTypeId="b5ac-9c20-5d5a-6f9b" value="1"/>
-            <characteristic name="Powers Known" characteristicTypeId="69d7-b45e-00a2-7e46" value="1 Dark Hereticus"/>
+            <characteristic name="Powers Known" characteristicTypeId="69d7-b45e-00a2-7e46" value="Smite and one power from the Dark Hereticus discipline"/>
             <characteristic name="Other" characteristicTypeId="c2e2-f115-0003-5d7b" value=""/>
           </characteristics>
         </profile>
       </profiles>
-      <rules>
-        <rule id="d5bd-bf86-3758-01ac" name="Daemonic Allegiance" hidden="false">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <description>When you include a Daemon Prince in your army, you must choose which of the four Chaos Gods it owes its allegiance to: Khorne, Tzeentch, Nurgle, or Slaanesh. It then gains the appropriate keyword.</description>
-        </rule>
-        <rule id="4656-b96f-6f76-a193" name="Prince of Chaos" hidden="false">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <description>You can re-roll hit rolls of 1 made for friendly (Legion) units within 6&quot; of this model. This ability also affects friendly Daemon units within 6&quot;, but only if they owe their allegiance to the same Chaos God e.g., Khorne Daemon units are only affected by Khorne Daemon Princes.</description>
-        </rule>
-        <rule id="8734-efd2-c2d8-9bd9" name="Might over Magic" hidden="false">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <description>A Daemon Prince of Khorne increases its Attacks characteristic by 1.</description>
-        </rule>
-      </rules>
+      <rules/>
       <infoLinks>
-        <infoLink id="4e39-3732-b1e1-220c" name="New InfoLink" hidden="false" targetId="6349-022a-cea9-524c" type="rule">
+        <infoLink id="4e39-3732-b1e1-220c" name="Death to the False Emperor" hidden="false" targetId="37a4-1d84-4ef0-c4f6" type="profile">
           <profiles/>
           <rules/>
           <infoLinks/>
           <modifiers/>
         </infoLink>
-        <infoLink id="53f2-1999-22d7-52e2" name="Daemonic" hidden="false" targetId="2946-510b-88fb-5c9c" type="rule">
+        <infoLink id="53f2-1999-22d7-52e2" name="Daemonic" hidden="false" targetId="94f5-82c3-bb66-ac0c" type="profile">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -9746,7 +10166,7 @@ D3   Bonus
           <modifiers/>
           <constraints/>
         </categoryLink>
-        <categoryLink id="d589-d93b-1730-1039" name="New CategoryLink" hidden="false" targetId="717b-8863-9d25-5e2a" primary="false">
+        <categoryLink id="d589-d93b-1730-1039" name="New CategoryLink" hidden="false" targetId="5cf1-acf2-ca3b-c2e5" primary="false">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -9843,6 +10263,358 @@ D3   Bonus
             </entryLink>
           </entryLinks>
         </selectionEntryGroup>
+        <selectionEntryGroup id="599e-268a-1117-9de1" name="Daemonic Allegiance" hidden="false" collective="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0299-72f3-1af6-b978" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b490-2807-2dfb-26f6" type="min"/>
+          </constraints>
+          <categoryLinks/>
+          <selectionEntries>
+            <selectionEntry id="dd66-1289-e5cb-e2d7" name="Khorne" hidden="false" collective="false" type="upgrade">
+              <profiles>
+                <profile id="8332-1c2b-ea0d-c579" name="Prince of Chaos" hidden="false" profileTypeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" profileTypeName="Abilities">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <characteristics>
+                    <characteristic name="Description" characteristicTypeId="21befb24-fc85-4f52-a745-64b2e48f8228" value="You can re-roll hit rolls of 1 made for friendly KHORNE DAEMON units within 6&quot;."/>
+                  </characteristics>
+                </profile>
+              </profiles>
+              <rules/>
+              <infoLinks>
+                <infoLink id="a3e6-019f-aecc-ee36" name="Unstoppable Ferocity" hidden="false" targetId="0d99-a301-149f-4537" type="profile">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                </infoLink>
+                <infoLink id="2752-2534-5514-26be" name="Might over Magic" hidden="false" targetId="95ad-c89a-501a-6c76" type="profile">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                </infoLink>
+              </infoLinks>
+              <modifiers/>
+              <constraints/>
+              <categoryLinks>
+                <categoryLink id="b1fe-65b6-df9f-ad0c" name="New CategoryLink" hidden="false" targetId="dfc5-aa04-9546-1b4c" primary="false">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </categoryLink>
+              </categoryLinks>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks/>
+              <costs>
+                <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="0.0"/>
+                <cost name="pts" costTypeId="points" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="fa2d-be40-0d78-85f9" name="Nurgle" hidden="false" collective="false" type="upgrade">
+              <profiles>
+                <profile id="50a4-651b-3a2f-5ae7" name="Psyker" hidden="false" profileTypeId="bc97-dea9-9e88-bb7d" profileTypeName="Psyker">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <characteristics>
+                    <characteristic name="Cast" characteristicTypeId="5afb-9914-904b-d3b3" value="1"/>
+                    <characteristic name="Deny" characteristicTypeId="b5ac-9c20-5d5a-6f9b" value="1"/>
+                    <characteristic name="Powers Known" characteristicTypeId="69d7-b45e-00a2-7e46" value="Smite and one power from the Nurgle discipline"/>
+                    <characteristic name="Other" characteristicTypeId="c2e2-f115-0003-5d7b"/>
+                  </characteristics>
+                </profile>
+                <profile id="ddb0-2e7e-a390-d3e9" name="Prince of Chaos" hidden="false" profileTypeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" profileTypeName="Abilities">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <characteristics>
+                    <characteristic name="Description" characteristicTypeId="21befb24-fc85-4f52-a745-64b2e48f8228" value="You can re-roll hit rolls of 1 made for friendly NURGLE DAEMON units within 6&quot;."/>
+                  </characteristics>
+                </profile>
+              </profiles>
+              <rules/>
+              <infoLinks>
+                <infoLink id="7566-6fcb-5efa-238f" name="Disgustingly Resilient" hidden="false" targetId="649e-7454-0be4-7a71" type="profile">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                </infoLink>
+              </infoLinks>
+              <modifiers/>
+              <constraints/>
+              <categoryLinks>
+                <categoryLink id="c5f6-5143-480b-fc91" name="New CategoryLink" hidden="false" targetId="0fb6-fcaf-b180-5dda" primary="false">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </categoryLink>
+                <categoryLink id="3ce2-fb70-e639-b9e2" name="New CategoryLink" hidden="false" targetId="e691-aad7-d21c-1023" primary="false">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </categoryLink>
+              </categoryLinks>
+              <selectionEntries>
+                <selectionEntry id="2598-f278-0295-11c5" name="Smite" hidden="false" collective="false" type="upgrade">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks>
+                    <infoLink id="da52-1924-b189-124f" name="Smite" hidden="false" targetId="5821-6c45-8572-7e0e" type="profile">
+                      <profiles/>
+                      <rules/>
+                      <infoLinks/>
+                      <modifiers/>
+                    </infoLink>
+                  </infoLinks>
+                  <modifiers/>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="20bd-9f4b-6930-5bd6" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="03b6-afed-4b30-f251" type="min"/>
+                  </constraints>
+                  <categoryLinks/>
+                  <selectionEntries/>
+                  <selectionEntryGroups/>
+                  <entryLinks/>
+                  <costs>
+                    <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="0.0"/>
+                    <cost name="pts" costTypeId="points" value="0.0"/>
+                  </costs>
+                </selectionEntry>
+              </selectionEntries>
+              <selectionEntryGroups/>
+              <entryLinks>
+                <entryLink id="4be8-332a-b3d8-9390" name="Dark Hereticus discipline" hidden="false" targetId="0246-3399-3b88-44aa" type="selectionEntryGroup">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="974c-d324-ff48-2c54" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="84fc-9955-1372-d355" type="min"/>
+                  </constraints>
+                  <categoryLinks/>
+                </entryLink>
+              </entryLinks>
+              <costs>
+                <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="0.0"/>
+                <cost name="pts" costTypeId="points" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="545d-a041-da54-0dca" name="Slaanesh" hidden="false" collective="false" type="upgrade">
+              <profiles>
+                <profile id="25fa-33a3-661c-1f1c" name="Psyker" hidden="false" profileTypeId="bc97-dea9-9e88-bb7d" profileTypeName="Psyker">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <characteristics>
+                    <characteristic name="Cast" characteristicTypeId="5afb-9914-904b-d3b3" value="1"/>
+                    <characteristic name="Deny" characteristicTypeId="b5ac-9c20-5d5a-6f9b" value="1"/>
+                    <characteristic name="Powers Known" characteristicTypeId="69d7-b45e-00a2-7e46" value="Smite and one power from the Slaanesh discipline"/>
+                    <characteristic name="Other" characteristicTypeId="c2e2-f115-0003-5d7b"/>
+                  </characteristics>
+                </profile>
+                <profile id="0681-4bb0-e00a-bb85" name="Prince of Chaos" hidden="false" profileTypeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" profileTypeName="Abilities">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <characteristics>
+                    <characteristic name="Description" characteristicTypeId="21befb24-fc85-4f52-a745-64b2e48f8228" value="You can re-roll hit rolls of 1 made for friendly SLAANESH DAEMON units within 6&quot;."/>
+                  </characteristics>
+                </profile>
+              </profiles>
+              <rules/>
+              <infoLinks>
+                <infoLink id="6a57-174b-be59-bd83" name="Quicksilver Swiftness" hidden="false" targetId="b623-8135-5aa4-d13e" type="profile">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                </infoLink>
+              </infoLinks>
+              <modifiers/>
+              <constraints/>
+              <categoryLinks>
+                <categoryLink id="6ff5-88a6-9c64-f67d" name="New CategoryLink" hidden="false" targetId="1da2-76db-f76f-6b6c" primary="false">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </categoryLink>
+                <categoryLink id="6110-d8bc-b5b2-fe54" name="New CategoryLink" hidden="false" targetId="e691-aad7-d21c-1023" primary="false">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </categoryLink>
+              </categoryLinks>
+              <selectionEntries>
+                <selectionEntry id="94a0-4437-a836-0992" name="Smite" hidden="false" collective="false" type="upgrade">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks>
+                    <infoLink id="2ec6-efd9-2ec3-751b" name="Smite" hidden="false" targetId="5821-6c45-8572-7e0e" type="profile">
+                      <profiles/>
+                      <rules/>
+                      <infoLinks/>
+                      <modifiers/>
+                    </infoLink>
+                  </infoLinks>
+                  <modifiers/>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c4cc-c000-d9d9-6f12" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b486-d62f-fde0-20ad" type="min"/>
+                  </constraints>
+                  <categoryLinks/>
+                  <selectionEntries/>
+                  <selectionEntryGroups/>
+                  <entryLinks/>
+                  <costs>
+                    <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="0.0"/>
+                    <cost name="pts" costTypeId="points" value="0.0"/>
+                  </costs>
+                </selectionEntry>
+              </selectionEntries>
+              <selectionEntryGroups/>
+              <entryLinks>
+                <entryLink id="ebd6-753c-a1bb-12f8" name="Dark Hereticus discipline" hidden="false" targetId="0246-3399-3b88-44aa" type="selectionEntryGroup">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e918-e0f7-eaa7-72d6" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="343a-cd10-81ce-f52a" type="min"/>
+                  </constraints>
+                  <categoryLinks/>
+                </entryLink>
+              </entryLinks>
+              <costs>
+                <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="0.0"/>
+                <cost name="pts" costTypeId="points" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="53e4-80ea-a047-ad6e" name="Tzeentch" hidden="false" collective="false" type="upgrade">
+              <profiles>
+                <profile id="07d0-a764-a636-553b" name="Psyker" hidden="false" profileTypeId="bc97-dea9-9e88-bb7d" profileTypeName="Psyker">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <characteristics>
+                    <characteristic name="Cast" characteristicTypeId="5afb-9914-904b-d3b3" value="1"/>
+                    <characteristic name="Deny" characteristicTypeId="b5ac-9c20-5d5a-6f9b" value="1"/>
+                    <characteristic name="Powers Known" characteristicTypeId="69d7-b45e-00a2-7e46" value="Smite and one power from the Tzeentch discipline"/>
+                    <characteristic name="Other" characteristicTypeId="c2e2-f115-0003-5d7b"/>
+                  </characteristics>
+                </profile>
+                <profile id="21d1-0249-6d50-9493" name="Prince of Chaos" hidden="false" profileTypeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" profileTypeName="Abilities">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <characteristics>
+                    <characteristic name="Description" characteristicTypeId="21befb24-fc85-4f52-a745-64b2e48f8228" value="You can re-roll hit rolls of 1 made for friendly TZEENTCH DAEMON units within 6&quot;."/>
+                  </characteristics>
+                </profile>
+              </profiles>
+              <rules/>
+              <infoLinks>
+                <infoLink id="d017-dd9f-64a5-7f7a" name="Ephemeral Form" hidden="false" targetId="cb03-ddea-2ac5-9879" type="profile">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                </infoLink>
+              </infoLinks>
+              <modifiers/>
+              <constraints/>
+              <categoryLinks>
+                <categoryLink id="3dba-1fa4-2738-07e5" name="New CategoryLink" hidden="false" targetId="012f-abfc-397b-3519" primary="false">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </categoryLink>
+                <categoryLink id="9fe0-6b06-cf4d-c934" name="New CategoryLink" hidden="false" targetId="e691-aad7-d21c-1023" primary="false">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </categoryLink>
+              </categoryLinks>
+              <selectionEntries>
+                <selectionEntry id="af4a-ba30-2110-aed5" name="Smite" hidden="false" collective="false" type="upgrade">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks>
+                    <infoLink id="1cc5-a8b2-9756-4897" name="Smite" hidden="false" targetId="5821-6c45-8572-7e0e" type="profile">
+                      <profiles/>
+                      <rules/>
+                      <infoLinks/>
+                      <modifiers/>
+                    </infoLink>
+                  </infoLinks>
+                  <modifiers/>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="445a-d2c0-e7fb-8682" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="942a-1741-323b-5a89" type="min"/>
+                  </constraints>
+                  <categoryLinks/>
+                  <selectionEntries/>
+                  <selectionEntryGroups/>
+                  <entryLinks/>
+                  <costs>
+                    <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="0.0"/>
+                    <cost name="pts" costTypeId="points" value="0.0"/>
+                  </costs>
+                </selectionEntry>
+              </selectionEntries>
+              <selectionEntryGroups/>
+              <entryLinks>
+                <entryLink id="3237-6eb1-6362-c9b1" name="Dark Hereticus discipline" hidden="false" targetId="0246-3399-3b88-44aa" type="selectionEntryGroup">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="24c8-84c5-947d-175e" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ed5c-6c67-0a0c-5dcf" type="min"/>
+                  </constraints>
+                  <categoryLinks/>
+                </entryLink>
+              </entryLinks>
+              <costs>
+                <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="0.0"/>
+                <cost name="pts" costTypeId="points" value="0.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+          <selectionEntryGroups/>
+          <entryLinks/>
+        </selectionEntryGroup>
       </selectionEntryGroups>
       <entryLinks>
         <entryLink id="3e1c-89cb-63ac-6197" name="New EntryLink" hidden="false" targetId="7aa9-b4b1-f87b-6ef6" type="selectionEntry">
@@ -9863,17 +10635,6 @@ D3   Bonus
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="6e3a-a538-633d-0b21" type="min"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="d997-cad4-ef06-3660" type="max"/>
-          </constraints>
-          <categoryLinks/>
-        </entryLink>
-        <entryLink id="12a4-effb-ad1d-37f5" name="Mark of Chaos" hidden="false" targetId="45e8-d3d1-105b-90a3" type="selectionEntryGroup">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f89d-e800-dff6-9753" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d78d-2f1f-7f6f-4908" type="min"/>
           </constraints>
           <categoryLinks/>
         </entryLink>
@@ -9902,7 +10663,7 @@ D3   Bonus
             <characteristic name="Save" characteristicTypeId="c0df-df94-abd7-e8d3" value="2+"/>
           </characteristics>
         </profile>
-        <profile id="82c9-67ad-8365-3033" name="Sorcerer" hidden="false" profileTypeId="bc97-dea9-9e88-bb7d" profileTypeName="Psyker">
+        <profile id="06d9-d82c-f627-da74" name="Sorcerer" hidden="false" profileTypeId="bc97-dea9-9e88-bb7d" profileTypeName="Psyker">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -9910,14 +10671,14 @@ D3   Bonus
           <characteristics>
             <characteristic name="Cast" characteristicTypeId="5afb-9914-904b-d3b3" value="2"/>
             <characteristic name="Deny" characteristicTypeId="b5ac-9c20-5d5a-6f9b" value="1"/>
-            <characteristic name="Powers Known" characteristicTypeId="69d7-b45e-00a2-7e46" value="2 Dark Hereticus"/>
+            <characteristic name="Powers Known" characteristicTypeId="69d7-b45e-00a2-7e46" value="Smite and 2 powers from the Dark Hereticus discipline"/>
             <characteristic name="Other" characteristicTypeId="c2e2-f115-0003-5d7b" value=""/>
           </characteristics>
         </profile>
       </profiles>
       <rules/>
       <infoLinks>
-        <infoLink id="2370-ad7a-4106-a343" name="New InfoLink" hidden="false" targetId="6349-022a-cea9-524c" type="rule">
+        <infoLink id="2370-ad7a-4106-a343" name="Death to the False Emperor" hidden="false" targetId="37a4-1d84-4ef0-c4f6" type="profile">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -9929,7 +10690,7 @@ D3   Bonus
           <infoLinks/>
           <modifiers/>
         </infoLink>
-        <infoLink id="003d-95c4-1498-c261" name="New InfoLink" hidden="false" targetId="e2cc-3e10-f4a9-d911" type="rule">
+        <infoLink id="003d-95c4-1498-c261" name="Terminator Armour" hidden="false" targetId="aa2e-f0e5-04d3-aae3" type="profile">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -9954,7 +10715,7 @@ D3   Bonus
           <modifiers/>
           <constraints/>
         </categoryLink>
-        <categoryLink id="ebe1-3a9c-7830-2b97" name="New CategoryLink" hidden="false" targetId="717b-8863-9d25-5e2a" primary="false">
+        <categoryLink id="ebe1-3a9c-7830-2b97" name="New CategoryLink" hidden="false" targetId="5cf1-acf2-ca3b-c2e5" primary="false">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -10094,12 +10855,34 @@ D3   Bonus
         </selectionEntryGroup>
       </selectionEntryGroups>
       <entryLinks>
-        <entryLink id="ce3f-a6ed-b247-b2de" name="New EntryLink" hidden="false" targetId="45e8-d3d1-105b-90a3" type="selectionEntryGroup">
+        <entryLink id="ce3f-a6ed-b247-b2de" name="Mark of Chaos" hidden="false" targetId="45e8-d3d1-105b-90a3" type="selectionEntryGroup">
           <profiles/>
           <rules/>
           <infoLinks/>
           <modifiers/>
           <constraints/>
+          <categoryLinks/>
+        </entryLink>
+        <entryLink id="2ada-df06-8041-42bb" name="Smite" hidden="false" targetId="03fd-db47-5333-1e1f" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0447-b343-9369-8889" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="084f-6084-b2dc-88be" type="min"/>
+          </constraints>
+          <categoryLinks/>
+        </entryLink>
+        <entryLink id="57fe-e6bf-64e4-06e3" name="Dark Hereticus discipline" hidden="false" targetId="0246-3399-3b88-44aa" type="selectionEntryGroup">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1104-7dd1-152a-1043" type="max"/>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="289e-3846-3774-326b" type="min"/>
+          </constraints>
           <categoryLinks/>
         </entryLink>
       </entryLinks>
@@ -10127,7 +10910,7 @@ D3   Bonus
             <characteristic name="Save" characteristicTypeId="c0df-df94-abd7-e8d3" value="3+"/>
           </characteristics>
         </profile>
-        <profile id="a89f-a710-b20c-ca09" name="Sorcerer" hidden="false" profileTypeId="bc97-dea9-9e88-bb7d" profileTypeName="Psyker">
+        <profile id="2e20-5b03-60a7-69fc" name="Sorcerer" hidden="false" profileTypeId="bc97-dea9-9e88-bb7d" profileTypeName="Psyker">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -10135,20 +10918,20 @@ D3   Bonus
           <characteristics>
             <characteristic name="Cast" characteristicTypeId="5afb-9914-904b-d3b3" value="2"/>
             <characteristic name="Deny" characteristicTypeId="b5ac-9c20-5d5a-6f9b" value="1"/>
-            <characteristic name="Powers Known" characteristicTypeId="69d7-b45e-00a2-7e46" value="2 Dark Hereticus"/>
+            <characteristic name="Powers Known" characteristicTypeId="69d7-b45e-00a2-7e46" value="Smite and 2 powers from the Dark Hereticus discipline"/>
             <characteristic name="Other" characteristicTypeId="c2e2-f115-0003-5d7b" value=""/>
           </characteristics>
         </profile>
       </profiles>
       <rules/>
       <infoLinks>
-        <infoLink id="6f8f-c4de-cc14-ba68" name="New InfoLink" hidden="false" targetId="e008-161d-80a5-aef1" type="rule">
+        <infoLink id="6f8f-c4de-cc14-ba68" name="Turbo-boost" hidden="false" targetId="3923-a411-2e7b-dc9c" type="profile">
           <profiles/>
           <rules/>
           <infoLinks/>
           <modifiers/>
         </infoLink>
-        <infoLink id="93b9-2993-c103-f25e" name="New InfoLink" hidden="false" targetId="6349-022a-cea9-524c" type="rule">
+        <infoLink id="93b9-2993-c103-f25e" name="Death to the False Emperor" hidden="false" targetId="37a4-1d84-4ef0-c4f6" type="profile">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -10180,7 +10963,7 @@ D3   Bonus
           <modifiers/>
           <constraints/>
         </categoryLink>
-        <categoryLink id="7abe-a31e-0cf4-2fab" name="New CategoryLink" hidden="false" targetId="717b-8863-9d25-5e2a" primary="false">
+        <categoryLink id="7abe-a31e-0cf4-2fab" name="New CategoryLink" hidden="false" targetId="5cf1-acf2-ca3b-c2e5" primary="false">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -10349,6 +11132,28 @@ D3   Bonus
           <constraints/>
           <categoryLinks/>
         </entryLink>
+        <entryLink id="0254-bf8e-8138-7438" name="Smite" hidden="false" targetId="03fd-db47-5333-1e1f" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9f82-5fb1-9899-4e1f" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="319d-be07-d771-1627" type="min"/>
+          </constraints>
+          <categoryLinks/>
+        </entryLink>
+        <entryLink id="5cdb-36ef-5100-9389" name="Dark Hereticus discipline" hidden="false" targetId="0246-3399-3b88-44aa" type="selectionEntryGroup">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5d23-a4f3-6c23-6ac0" type="max"/>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1c1b-adc4-84ed-453f" type="min"/>
+          </constraints>
+          <categoryLinks/>
+        </entryLink>
       </entryLinks>
       <costs>
         <cost name="pts" costTypeId="points" value="130.0"/>
@@ -10374,7 +11179,16 @@ D3   Bonus
             <characteristic name="Save" characteristicTypeId="c0df-df94-abd7-e8d3" value="3+"/>
           </characteristics>
         </profile>
-        <profile id="e6b1-04c1-799f-7222" name="Sorcerer" hidden="false" profileTypeId="bc97-dea9-9e88-bb7d" profileTypeName="Psyker">
+        <profile id="2d41-3a30-dcf2-bb9b" name="Favour of Tzeentch" hidden="false" profileTypeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" profileTypeName="Abilities">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Description" characteristicTypeId="21befb24-fc85-4f52-a745-64b2e48f8228" value="This model has a 5+ invulnerable save."/>
+          </characteristics>
+        </profile>
+        <profile id="ba89-37d9-fe9f-9271" name="Sorcerer" hidden="false" profileTypeId="bc97-dea9-9e88-bb7d" profileTypeName="Psyker">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -10382,22 +11196,14 @@ D3   Bonus
           <characteristics>
             <characteristic name="Cast" characteristicTypeId="5afb-9914-904b-d3b3" value="2"/>
             <characteristic name="Deny" characteristicTypeId="b5ac-9c20-5d5a-6f9b" value="1"/>
-            <characteristic name="Powers Known" characteristicTypeId="69d7-b45e-00a2-7e46" value="2 Dark Hereticus"/>
+            <characteristic name="Powers Known" characteristicTypeId="69d7-b45e-00a2-7e46" value="Smite and 2 powers from the Dark Hereticus discipline"/>
             <characteristic name="Other" characteristicTypeId="c2e2-f115-0003-5d7b" value=""/>
           </characteristics>
         </profile>
       </profiles>
-      <rules>
-        <rule id="cacf-a819-539a-1753" name="Favoured of Tzeentch" hidden="false">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <description>This model has a 5++.</description>
-        </rule>
-      </rules>
+      <rules/>
       <infoLinks>
-        <infoLink id="7232-cf00-a9c1-8364" name="New InfoLink" hidden="false" targetId="6349-022a-cea9-524c" type="rule">
+        <infoLink id="7232-cf00-a9c1-8364" name="Death to the False Emperor" hidden="false" targetId="37a4-1d84-4ef0-c4f6" type="profile">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -10429,7 +11235,7 @@ D3   Bonus
           <modifiers/>
           <constraints/>
         </categoryLink>
-        <categoryLink id="fc78-b9db-96bc-2d2f" name="New CategoryLink" hidden="false" targetId="717b-8863-9d25-5e2a" primary="false">
+        <categoryLink id="fc78-b9db-96bc-2d2f" name="New CategoryLink" hidden="false" targetId="5cf1-acf2-ca3b-c2e5" primary="false">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -10627,6 +11433,28 @@ D3   Bonus
           </constraints>
           <categoryLinks/>
         </entryLink>
+        <entryLink id="8222-3e99-b292-752a" name="Smite" hidden="false" targetId="03fd-db47-5333-1e1f" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="994c-072d-aad8-6036" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="54dd-9601-dad5-cadb" type="min"/>
+          </constraints>
+          <categoryLinks/>
+        </entryLink>
+        <entryLink id="e242-6ad9-2692-73b5" name="Dark Hereticus discipline" hidden="false" targetId="0246-3399-3b88-44aa" type="selectionEntryGroup">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="01eb-766b-51ae-24be" type="max"/>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="faed-437b-8d5d-37d6" type="min"/>
+          </constraints>
+          <categoryLinks/>
+        </entryLink>
       </entryLinks>
       <costs>
         <cost name="pts" costTypeId="points" value="125.0"/>
@@ -10652,7 +11480,7 @@ D3   Bonus
             <characteristic name="Save" characteristicTypeId="c0df-df94-abd7-e8d3" value="3+"/>
           </characteristics>
         </profile>
-        <profile id="dc74-7cb7-09c4-a24c" name="Sorcerer" hidden="false" profileTypeId="bc97-dea9-9e88-bb7d" profileTypeName="Psyker">
+        <profile id="6fcc-fb0e-500b-30ef" name="Sorcerer" hidden="false" profileTypeId="bc97-dea9-9e88-bb7d" profileTypeName="Psyker">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -10660,14 +11488,14 @@ D3   Bonus
           <characteristics>
             <characteristic name="Cast" characteristicTypeId="5afb-9914-904b-d3b3" value="2"/>
             <characteristic name="Deny" characteristicTypeId="b5ac-9c20-5d5a-6f9b" value="1"/>
-            <characteristic name="Powers Known" characteristicTypeId="69d7-b45e-00a2-7e46" value="2 Dark Hereticus"/>
+            <characteristic name="Powers Known" characteristicTypeId="69d7-b45e-00a2-7e46" value="Smite and 2 powers from the Dark Hereticus discipline"/>
             <characteristic name="Other" characteristicTypeId="c2e2-f115-0003-5d7b" value=""/>
           </characteristics>
         </profile>
       </profiles>
       <rules/>
       <infoLinks>
-        <infoLink id="414a-0f29-d7fa-21b7" name="New InfoLink" hidden="false" targetId="6349-022a-cea9-524c" type="rule">
+        <infoLink id="414a-0f29-d7fa-21b7" name="Death to the False Emperor" hidden="false" targetId="37a4-1d84-4ef0-c4f6" type="profile">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -10699,7 +11527,7 @@ D3   Bonus
           <modifiers/>
           <constraints/>
         </categoryLink>
-        <categoryLink id="70d2-3bba-8e94-d529" name="New CategoryLink" hidden="false" targetId="717b-8863-9d25-5e2a" primary="false">
+        <categoryLink id="70d2-3bba-8e94-d529" name="New CategoryLink" hidden="false" targetId="5cf1-acf2-ca3b-c2e5" primary="false">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -10883,6 +11711,28 @@ D3   Bonus
           </constraints>
           <categoryLinks/>
         </entryLink>
+        <entryLink id="bc1b-4ee5-7822-3133" name="Smite" hidden="false" targetId="03fd-db47-5333-1e1f" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2632-9309-7bb7-8b39" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1788-a3b3-7ff9-cfd5" type="min"/>
+          </constraints>
+          <categoryLinks/>
+        </entryLink>
+        <entryLink id="9128-250f-d855-99ca" name="Dark Hereticus discipline" hidden="false" targetId="0246-3399-3b88-44aa" type="selectionEntryGroup">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7671-3745-af1c-01c4" type="max"/>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="23c7-90f2-206c-12ee" type="min"/>
+          </constraints>
+          <categoryLinks/>
+        </entryLink>
       </entryLinks>
       <costs>
         <cost name="pts" costTypeId="points" value="123.0"/>
@@ -10908,7 +11758,7 @@ D3   Bonus
             <characteristic name="Save" characteristicTypeId="c0df-df94-abd7-e8d3" value="3+"/>
           </characteristics>
         </profile>
-        <profile id="0731-6ecf-7821-eed5" name="Sorcerer" hidden="false" profileTypeId="bc97-dea9-9e88-bb7d" profileTypeName="Psyker">
+        <profile id="d0e3-e635-869e-3ab1" name="Sorcerer" hidden="false" profileTypeId="bc97-dea9-9e88-bb7d" profileTypeName="Psyker">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -10916,22 +11766,20 @@ D3   Bonus
           <characteristics>
             <characteristic name="Cast" characteristicTypeId="5afb-9914-904b-d3b3" value="2"/>
             <characteristic name="Deny" characteristicTypeId="b5ac-9c20-5d5a-6f9b" value="1"/>
-            <characteristic name="Powers Known" characteristicTypeId="69d7-b45e-00a2-7e46" value="2 Dark Hereticus"/>
+            <characteristic name="Powers Known" characteristicTypeId="69d7-b45e-00a2-7e46" value="Smite and 2 powers from the Dark Hereticus discipline"/>
             <characteristic name="Other" characteristicTypeId="c2e2-f115-0003-5d7b" value=""/>
           </characteristics>
         </profile>
       </profiles>
-      <rules>
-        <rule id="a348-f1b5-cd8e-470b" name="Unholy Speed" hidden="false">
+      <rules/>
+      <infoLinks>
+        <infoLink id="451a-de33-3d0d-f275" name="Death to the False Emperor" hidden="false" targetId="37a4-1d84-4ef0-c4f6" type="profile">
           <profiles/>
           <rules/>
           <infoLinks/>
           <modifiers/>
-          <description>This model can Advance and charge in the same turn.</description>
-        </rule>
-      </rules>
-      <infoLinks>
-        <infoLink id="451a-de33-3d0d-f275" name="New InfoLink" hidden="false" targetId="6349-022a-cea9-524c" type="rule">
+        </infoLink>
+        <infoLink id="6e9a-fe5e-a05b-bd8d" name="Unholy Speed" hidden="false" targetId="e4c7-f469-f22d-f31b" type="profile">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -10963,7 +11811,7 @@ D3   Bonus
           <modifiers/>
           <constraints/>
         </categoryLink>
-        <categoryLink id="d9c1-05b7-fddf-36d5" name="New CategoryLink" hidden="false" targetId="717b-8863-9d25-5e2a" primary="false">
+        <categoryLink id="d9c1-05b7-fddf-36d5" name="New CategoryLink" hidden="false" targetId="5cf1-acf2-ca3b-c2e5" primary="false">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -11147,6 +11995,28 @@ D3   Bonus
           </constraints>
           <categoryLinks/>
         </entryLink>
+        <entryLink id="96d6-2a4c-4994-2493" name="Smite" hidden="false" targetId="03fd-db47-5333-1e1f" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1d1e-e8d8-9cad-e9e4" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f915-b163-a225-20d2" type="min"/>
+          </constraints>
+          <categoryLinks/>
+        </entryLink>
+        <entryLink id="dffd-33e0-bbe6-44db" name="Dark Hereticus discipline" hidden="false" targetId="0246-3399-3b88-44aa" type="selectionEntryGroup">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="98c4-d11a-48c3-f249" type="max"/>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8f2c-5dfe-9582-9d07" type="min"/>
+          </constraints>
+          <categoryLinks/>
+        </entryLink>
       </entryLinks>
       <costs>
         <cost name="pts" costTypeId="points" value="115.0"/>
@@ -11172,7 +12042,7 @@ D3   Bonus
             <characteristic name="Save" characteristicTypeId="c0df-df94-abd7-e8d3" value="3+"/>
           </characteristics>
         </profile>
-        <profile id="0de6-b6b4-8d4e-c3cc" name="Sorcerer" hidden="false" profileTypeId="bc97-dea9-9e88-bb7d" profileTypeName="Psyker">
+        <profile id="6b7d-1267-cf77-565c" name="Sorcerer" hidden="false" profileTypeId="bc97-dea9-9e88-bb7d" profileTypeName="Psyker">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -11180,7 +12050,7 @@ D3   Bonus
           <characteristics>
             <characteristic name="Cast" characteristicTypeId="5afb-9914-904b-d3b3" value="2"/>
             <characteristic name="Deny" characteristicTypeId="b5ac-9c20-5d5a-6f9b" value="1"/>
-            <characteristic name="Powers Known" characteristicTypeId="69d7-b45e-00a2-7e46" value="2 Dark Hereticus"/>
+            <characteristic name="Powers Known" characteristicTypeId="69d7-b45e-00a2-7e46" value="Smite and 2 powers from the Dark Hereticus discipline"/>
             <characteristic name="Other" characteristicTypeId="c2e2-f115-0003-5d7b" value=""/>
           </characteristics>
         </profile>
@@ -11195,7 +12065,7 @@ D3   Bonus
         </rule>
       </rules>
       <infoLinks>
-        <infoLink id="b394-4dae-b58d-112c" name="New InfoLink" hidden="false" targetId="6349-022a-cea9-524c" type="rule">
+        <infoLink id="b394-4dae-b58d-112c" name="Death to the False Emperor" hidden="false" targetId="37a4-1d84-4ef0-c4f6" type="profile">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -11220,7 +12090,7 @@ D3   Bonus
           <modifiers/>
           <constraints/>
         </categoryLink>
-        <categoryLink id="1146-002d-1b52-fd28" name="New CategoryLink" hidden="false" targetId="717b-8863-9d25-5e2a" primary="false">
+        <categoryLink id="1146-002d-1b52-fd28" name="New CategoryLink" hidden="false" targetId="5cf1-acf2-ca3b-c2e5" primary="false">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -11385,67 +12255,32 @@ D3   Bonus
           <constraints/>
           <categoryLinks/>
         </entryLink>
+        <entryLink id="6909-396c-9b18-f102" name="Smite" hidden="false" targetId="03fd-db47-5333-1e1f" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0200-dc09-4ba4-027e" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8238-92c7-ebc3-b8ae" type="min"/>
+          </constraints>
+          <categoryLinks/>
+        </entryLink>
+        <entryLink id="2fdd-a246-3db7-cccd" name="Dark Hereticus discipline" hidden="false" targetId="0246-3399-3b88-44aa" type="selectionEntryGroup">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1a67-d760-13a4-07e5" type="max"/>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0785-6a2e-7efb-be41" type="min"/>
+          </constraints>
+          <categoryLinks/>
+        </entryLink>
       </entryLinks>
       <costs>
         <cost name="pts" costTypeId="points" value="114.0"/>
         <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="8.0"/>
-      </costs>
-    </selectionEntry>
-    <selectionEntry id="8dc2-df9b-82f8-c1e6" name="Cypher" page="" hidden="true" collective="false" type="model">
-      <profiles>
-        <profile id="afe9-2bca-715a-5b95" name="Cypher" hidden="false" profileTypeId="800f-21d0-4387-c943" profileTypeName="Unit">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <characteristics>
-            <characteristic name="M" characteristicTypeId="0bdf-a96e-9e38-7779"/>
-            <characteristic name="WS" characteristicTypeId="e7f0-1278-0250-df0c"/>
-            <characteristic name="BS" characteristicTypeId="381b-eb28-74c3-df5f"/>
-            <characteristic name="S" characteristicTypeId="2218-aa3c-265f-2939"/>
-            <characteristic name="T" characteristicTypeId="9c9f-9774-a358-3a39"/>
-            <characteristic name="W" characteristicTypeId="f330-5e6e-4110-0978"/>
-            <characteristic name="A" characteristicTypeId="13fc-b29b-31f2-ab9f"/>
-            <characteristic name="Ld" characteristicTypeId="00ca-f8b8-876d-b705"/>
-            <characteristic name="Save" characteristicTypeId="c0df-df94-abd7-e8d3"/>
-          </characteristics>
-        </profile>
-      </profiles>
-      <rules/>
-      <infoLinks/>
-      <modifiers>
-        <modifier type="set" field="hidden" value="true">
-          <repeats/>
-          <conditions/>
-          <conditionGroups>
-            <conditionGroup type="or">
-              <conditions>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="ff7b-6430-03d4-ea70" type="greaterThan"/>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="60fa-a65e-c445-61d5" type="greaterThan"/>
-              </conditions>
-              <conditionGroups/>
-            </conditionGroup>
-          </conditionGroups>
-        </modifier>
-      </modifiers>
-      <constraints>
-        <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="3b31-16b4-2b0d-3516" type="max"/>
-      </constraints>
-      <categoryLinks>
-        <categoryLink id="3240-9152-ba8e-9e54" hidden="false" targetId="848a6ff2-0def-4c72-8433-ff7da70e6bc7" primary="true">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints/>
-        </categoryLink>
-      </categoryLinks>
-      <selectionEntries/>
-      <selectionEntryGroups/>
-      <entryLinks/>
-      <costs>
-        <cost name="pts" costTypeId="points" value="110.0"/>
-        <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="5b82-0948-eac4-b35f" name="Icon of Excess" page="0" hidden="false" collective="false" type="upgrade">
@@ -11483,7 +12318,7 @@ D3   Bonus
           <infoLinks/>
           <modifiers/>
           <characteristics>
-            <characteristic name="Description" characteristicTypeId="21befb24-fc85-4f52-a745-64b2e48f8228" value="At the start of your Psychic phase, roll a D6 for each unit with an Icon of Flame. On a roll of 6 inflict 1 MW on the closest enemy unit within 12&quot; of the model carrying the Icon of Flame."/>
+            <characteristic name="Description" characteristicTypeId="21befb24-fc85-4f52-a745-64b2e48f8228" value="At the start of your Psychic phase, roll a D6 for each unit with an Icon of Flame. On a roll of 6 inflict 1 mortal wound on the closest enemy unit within 12&quot; of the model carrying the Icon of Flame."/>
           </characteristics>
         </profile>
       </profiles>
@@ -11510,7 +12345,7 @@ D3   Bonus
           <infoLinks/>
           <modifiers/>
           <characteristics>
-            <characteristic name="Description" characteristicTypeId="21befb24-fc85-4f52-a745-64b2e48f8228" value="Add 1 to the Ld of all models in a unit that has an Icon of Vengeance."/>
+            <characteristic name="Description" characteristicTypeId="21befb24-fc85-4f52-a745-64b2e48f8228" value="Add 1 to the Leadership of all models in a unit that has an Icon of Vengeance."/>
           </characteristics>
         </profile>
       </profiles>
@@ -11770,10 +12605,28 @@ D3   Bonus
       </costs>
     </selectionEntry>
     <selectionEntry id="7b61-1289-ed7e-24c1" name="Chaos Space Marines" page="" hidden="false" collective="false" type="unit">
-      <profiles/>
+      <profiles>
+        <profile id="caa4-cc8c-03eb-df17" name="Chaos Space Marine" hidden="false" profileTypeId="800f-21d0-4387-c943" profileTypeName="Unit">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="M" characteristicTypeId="0bdf-a96e-9e38-7779" value="6&quot;"/>
+            <characteristic name="WS" characteristicTypeId="e7f0-1278-0250-df0c" value="3+"/>
+            <characteristic name="BS" characteristicTypeId="381b-eb28-74c3-df5f" value="3+"/>
+            <characteristic name="S" characteristicTypeId="2218-aa3c-265f-2939" value="4"/>
+            <characteristic name="T" characteristicTypeId="9c9f-9774-a358-3a39" value="4"/>
+            <characteristic name="W" characteristicTypeId="f330-5e6e-4110-0978" value="1"/>
+            <characteristic name="A" characteristicTypeId="13fc-b29b-31f2-ab9f" value="1"/>
+            <characteristic name="Ld" characteristicTypeId="00ca-f8b8-876d-b705" value="7"/>
+            <characteristic name="Save" characteristicTypeId="c0df-df94-abd7-e8d3" value="3+"/>
+          </characteristics>
+        </profile>
+      </profiles>
       <rules/>
       <infoLinks>
-        <infoLink id="6817-74ab-c947-9d87" name="New InfoLink" hidden="false" targetId="6349-022a-cea9-524c" type="rule">
+        <infoLink id="6817-74ab-c947-9d87" name="Death to the False Emperor" hidden="false" targetId="37a4-1d84-4ef0-c4f6" type="profile">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -11805,7 +12658,7 @@ D3   Bonus
       </modifiers>
       <constraints/>
       <categoryLinks>
-        <categoryLink id="b5bf-6f43-f370-e3a7" name="New CategoryLink" hidden="false" targetId="717b-8863-9d25-5e2a" primary="false">
+        <categoryLink id="b5bf-6f43-f370-e3a7" name="New CategoryLink" hidden="false" targetId="5cf1-acf2-ca3b-c2e5" primary="false">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -11849,76 +12702,6 @@ D3   Bonus
         </categoryLink>
       </categoryLinks>
       <selectionEntries>
-        <selectionEntry id="387e-ddef-9708-f81b" name="Chaos Space Marine" hidden="false" collective="false" type="model">
-          <profiles>
-            <profile id="cce4-068c-9496-00a6" name="Chaos Space Marine" hidden="false" profileTypeId="800f-21d0-4387-c943" profileTypeName="Unit">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <characteristics>
-                <characteristic name="M" characteristicTypeId="0bdf-a96e-9e38-7779" value="6&quot;"/>
-                <characteristic name="WS" characteristicTypeId="e7f0-1278-0250-df0c" value="3+"/>
-                <characteristic name="BS" characteristicTypeId="381b-eb28-74c3-df5f" value="3+"/>
-                <characteristic name="S" characteristicTypeId="2218-aa3c-265f-2939" value="4"/>
-                <characteristic name="T" characteristicTypeId="9c9f-9774-a358-3a39" value="4"/>
-                <characteristic name="W" characteristicTypeId="f330-5e6e-4110-0978" value="1"/>
-                <characteristic name="A" characteristicTypeId="13fc-b29b-31f2-ab9f" value="1"/>
-                <characteristic name="Ld" characteristicTypeId="00ca-f8b8-876d-b705" value="7"/>
-                <characteristic name="Save" characteristicTypeId="c0df-df94-abd7-e8d3" value="3+"/>
-              </characteristics>
-            </profile>
-          </profiles>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints>
-            <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d790-ab25-534d-2490" type="min"/>
-            <constraint field="selections" scope="parent" value="19.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6007-7b47-c073-1e09" type="max"/>
-          </constraints>
-          <categoryLinks/>
-          <selectionEntries/>
-          <selectionEntryGroups/>
-          <entryLinks>
-            <entryLink id="73c8-e393-080a-4c82" name="New EntryLink" hidden="false" targetId="cddf-945e-1335-e681" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="43a0-8a24-a50b-e46f" type="max"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5264-ab9e-96ce-6a9f" type="min"/>
-              </constraints>
-              <categoryLinks/>
-            </entryLink>
-            <entryLink id="594c-e159-15c5-00a3" name="Boltgun" hidden="false" targetId="183a-a319-9ba3-541e" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e98c-64a5-eb98-3ea1" type="max"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4242-24dd-0241-b438" type="min"/>
-              </constraints>
-              <categoryLinks/>
-            </entryLink>
-            <entryLink id="1f83-0a4e-6486-437d" name="Bolt pistol" hidden="false" targetId="37d3-7098-d596-9948" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1ccc-ea83-5635-ee23" type="max"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d2f5-c7cc-b44d-e7df" type="min"/>
-              </constraints>
-              <categoryLinks/>
-            </entryLink>
-          </entryLinks>
-          <costs>
-            <cost name="pts" costTypeId="points" value="13.0"/>
-            <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="0.0"/>
-          </costs>
-        </selectionEntry>
         <selectionEntry id="cf18-2a14-90ea-09a9" name="Aspiring Champion" hidden="false" collective="false" type="model">
           <profiles>
             <profile id="e0ad-aeb7-4f46-3675" name="Aspiring Champion" hidden="false" profileTypeId="800f-21d0-4387-c943" profileTypeName="Unit">
@@ -11948,76 +12731,9 @@ D3   Bonus
           </constraints>
           <categoryLinks/>
           <selectionEntries/>
-          <selectionEntryGroups>
-            <selectionEntryGroup id="24da-d1c8-8835-9ead" name="Bolt pistol options" hidden="false" collective="false" defaultSelectionEntryId="df81-0b11-de1f-a3a6">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="43a0-902c-67ea-97ab" type="max"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="6812-fbe3-5f98-fd87" type="min"/>
-              </constraints>
-              <categoryLinks/>
-              <selectionEntries/>
-              <selectionEntryGroups/>
-              <entryLinks>
-                <entryLink id="df81-0b11-de1f-a3a6" name="Bolt pistol" hidden="false" targetId="0334-f487-8229-0c1a" type="selectionEntry">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                  <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0b18-2ee0-e5c5-3b41" type="max"/>
-                  </constraints>
-                  <categoryLinks/>
-                </entryLink>
-                <entryLink id="1b6e-1840-8992-4a07" name="Champion Equipment" hidden="false" targetId="1912-576e-6a2b-5c6e" type="selectionEntryGroup">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                  <constraints/>
-                  <categoryLinks/>
-                </entryLink>
-              </entryLinks>
-            </selectionEntryGroup>
-            <selectionEntryGroup id="5da8-39de-6195-3f29" name="Boltgun options" hidden="false" collective="false" defaultSelectionEntryId="f16e-a5d4-99c6-01c7">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="a5aa-9810-2ed2-b9e8" type="max"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="ba30-e90d-16eb-b06b" type="min"/>
-              </constraints>
-              <categoryLinks/>
-              <selectionEntries/>
-              <selectionEntryGroups/>
-              <entryLinks>
-                <entryLink id="f16e-a5d4-99c6-01c7" name="Boltgun" hidden="false" targetId="b61f-a3c1-827d-c5b6" type="selectionEntry">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                  <constraints>
-                    <constraint field="selections" scope="cf18-2a14-90ea-09a9" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="d9ab-8347-280d-6a02" type="max"/>
-                  </constraints>
-                  <categoryLinks/>
-                </entryLink>
-                <entryLink id="5c27-3101-640d-6c12" name="New EntryLink" hidden="false" targetId="1912-576e-6a2b-5c6e" type="selectionEntryGroup">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                  <constraints/>
-                  <categoryLinks/>
-                </entryLink>
-              </entryLinks>
-            </selectionEntryGroup>
-          </selectionEntryGroups>
+          <selectionEntryGroups/>
           <entryLinks>
-            <entryLink id="55a2-225b-9b4b-92a1" name="New EntryLink" hidden="false" targetId="cddf-945e-1335-e681" type="selectionEntry">
+            <entryLink id="55a2-225b-9b4b-92a1" name="Frag &amp; Krak grenades" hidden="false" targetId="cddf-945e-1335-e681" type="selectionEntry">
               <profiles/>
               <rules/>
               <infoLinks/>
@@ -12028,160 +12744,341 @@ D3   Bonus
               </constraints>
               <categoryLinks/>
             </entryLink>
+            <entryLink id="9f04-4d30-9c6c-a3a3" name="Champion Equipment" hidden="false" targetId="ad90-3560-ea09-82ef" type="selectionEntryGroup">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers>
+                <modifier type="set" field="name" value="Champion Equipment">
+                  <repeats/>
+                  <conditions/>
+                  <conditionGroups/>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c4ad-2556-891b-d1a0" type="max"/>
+                <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5e40-bd6e-cd5d-17b0" type="min"/>
+              </constraints>
+              <categoryLinks/>
+            </entryLink>
           </entryLinks>
           <costs>
             <cost name="pts" costTypeId="points" value="13.0"/>
             <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="0.0"/>
           </costs>
         </selectionEntry>
-        <selectionEntry id="5970-bb05-3d79-47ab" name="Replace boltgun with chainsword" hidden="false" collective="false" type="upgrade">
-          <profiles/>
-          <rules/>
-          <infoLinks>
-            <infoLink id="9e11-98b5-75d6-61d0" name="New InfoLink" hidden="false" targetId="9b1e-61f9-4a5b-0044" type="profile">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-            </infoLink>
-          </infoLinks>
-          <modifiers>
-            <modifier type="increment" field="df71-8366-bbb9-eb68" value="1">
-              <repeats>
-                <repeat field="selections" scope="7b61-1289-ed7e-24c1" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="387e-ddef-9708-f81b" repeats="1" roundUp="false"/>
-              </repeats>
-              <conditions/>
-              <conditionGroups/>
-            </modifier>
-            <modifier type="decrement" field="df71-8366-bbb9-eb68" value="1">
-              <repeats/>
-              <conditions>
-                <condition field="selections" scope="7b61-1289-ed7e-24c1" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e47b-07b6-ce6c-5998" type="equalTo"/>
-              </conditions>
-              <conditionGroups/>
-            </modifier>
-          </modifiers>
-          <constraints>
-            <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="df71-8366-bbb9-eb68" type="max"/>
-          </constraints>
-          <categoryLinks/>
-          <selectionEntries/>
-          <selectionEntryGroups/>
-          <entryLinks/>
-          <costs>
-            <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="0.0"/>
-            <cost name="pts" costTypeId="points" value="0.0"/>
-          </costs>
-        </selectionEntry>
       </selectionEntries>
       <selectionEntryGroups>
-        <selectionEntryGroup id="c139-0210-b200-f92a" name="One weapon swap" hidden="false" collective="false">
+        <selectionEntryGroup id="f156-9dba-ff63-5a9c" name="Marines" hidden="false" collective="false" defaultSelectionEntryId="f348-b327-8e54-434c">
           <profiles/>
           <rules/>
           <infoLinks/>
-          <modifiers>
-            <modifier type="set" field="7579-9e3d-6f25-0063" value="2">
-              <repeats/>
-              <conditions>
-                <condition field="selections" scope="7b61-1289-ed7e-24c1" value="9.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="model" type="greaterThan"/>
-              </conditions>
-              <conditionGroups/>
-            </modifier>
-          </modifiers>
+          <modifiers/>
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="7579-9e3d-6f25-0063" type="max"/>
+            <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7f6f-0996-7a72-5817" type="min"/>
+            <constraint field="selections" scope="parent" value="19.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7158-eac1-b26a-17dc" type="max"/>
           </constraints>
           <categoryLinks/>
-          <selectionEntries/>
-          <selectionEntryGroups>
-            <selectionEntryGroup id="507c-1ee5-d9b8-34f2" name="Bolt or Plasma pistol" hidden="false" collective="false">
+          <selectionEntries>
+            <selectionEntry id="f348-b327-8e54-434c" name="Marine w/ Boltgun" hidden="false" collective="false" type="model">
               <profiles/>
               <rules/>
               <infoLinks/>
               <modifiers/>
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f51c-172b-3055-fbaf" type="max"/>
+                <constraint field="selections" scope="parent" value="19.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="cd38-7956-adc1-c627" type="max"/>
               </constraints>
               <categoryLinks/>
               <selectionEntries/>
               <selectionEntryGroups/>
               <entryLinks>
-                <entryLink id="c44e-e069-b552-f053" name="New EntryLink" hidden="false" targetId="0334-f487-8229-0c1a" type="selectionEntry">
+                <entryLink id="c04d-7761-4c64-7247" name="Frag &amp; Krak grenades" hidden="false" targetId="cddf-945e-1335-e681" type="selectionEntry">
                   <profiles/>
                   <rules/>
                   <infoLinks/>
                   <modifiers/>
-                  <constraints/>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1b0c-203e-38ea-4763" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5d5c-e578-ff9d-00e9" type="min"/>
+                  </constraints>
                   <categoryLinks/>
                 </entryLink>
-                <entryLink id="7295-8433-b952-543d" name="New EntryLink" hidden="false" targetId="83be-1ba9-c326-4760" type="selectionEntry">
+                <entryLink id="f1a6-0dd1-2583-f917" name="Bolt pistol" hidden="false" targetId="37d3-7098-d596-9948" type="selectionEntry">
                   <profiles/>
                   <rules/>
                   <infoLinks/>
                   <modifiers/>
-                  <constraints/>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a834-c76d-4a5f-69eb" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5cbe-5f1e-0af6-16a3" type="min"/>
+                  </constraints>
+                  <categoryLinks/>
+                </entryLink>
+                <entryLink id="91be-1fa1-2b5e-902a" name="Boltgun" hidden="false" targetId="ca06-ac13-d02f-6f9a" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="184f-8fa4-e7e0-6f5b" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bf40-3cf1-83be-98ae" type="min"/>
+                  </constraints>
                   <categoryLinks/>
                 </entryLink>
               </entryLinks>
-            </selectionEntryGroup>
-            <selectionEntryGroup id="e47b-07b6-ce6c-5998" name="Boltgun or other" hidden="false" collective="false">
+              <costs>
+                <cost name="pts" costTypeId="points" value="13.0"/>
+                <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="3e8a-ca3b-7746-d3d8" name="Marine w/ Special Weapon" hidden="false" collective="false" type="model">
               <profiles/>
               <rules/>
               <infoLinks/>
-              <modifiers/>
-              <constraints/>
+              <modifiers>
+                <modifier type="set" field="a9a2-11f9-a376-d30f" value="0.0">
+                  <repeats/>
+                  <conditions>
+                    <condition field="selections" scope="7b61-1289-ed7e-24c1" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7fd9-f2cd-9698-9def" type="equalTo"/>
+                  </conditions>
+                  <conditionGroups/>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a9a2-11f9-a376-d30f" type="max"/>
+              </constraints>
               <categoryLinks/>
               <selectionEntries/>
               <selectionEntryGroups/>
               <entryLinks>
-                <entryLink id="40ab-0d48-1170-e0a9" name="New EntryLink" hidden="false" targetId="b61f-a3c1-827d-c5b6" type="selectionEntry">
+                <entryLink id="e7d0-d137-da35-3857" name="Special Weapons" hidden="false" targetId="a44b-4b4d-46b5-d3a6" type="selectionEntryGroup">
                   <profiles/>
                   <rules/>
                   <infoLinks/>
                   <modifiers/>
-                  <constraints/>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c800-a376-1716-8b47" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1191-fdb7-3978-9d76" type="min"/>
+                  </constraints>
                   <categoryLinks/>
                 </entryLink>
-                <entryLink id="b8dc-350c-07dd-c9f0" name="Special Weapons" hidden="false" targetId="a44b-4b4d-46b5-d3a6" type="selectionEntryGroup">
+                <entryLink id="94b7-f282-21d9-0448" name="Bolt pistol" hidden="false" targetId="0334-f487-8229-0c1a" type="selectionEntry">
                   <profiles/>
                   <rules/>
                   <infoLinks/>
-                  <modifiers>
-                    <modifier type="set" field="5154-f7a1-21fa-cf7f" value="2">
-                      <repeats/>
-                      <conditions>
-                        <condition field="selections" scope="7b61-1289-ed7e-24c1" value="9.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="model" type="greaterThan"/>
-                      </conditions>
-                      <conditionGroups/>
-                    </modifier>
-                  </modifiers>
-                  <constraints/>
-                  <categoryLinks/>
-                </entryLink>
-                <entryLink id="5d03-47f3-c8ee-12e7" name="Heavy Weapons" hidden="false" targetId="d16e-f416-d268-b2b4" type="selectionEntryGroup">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers>
-                    <modifier type="set" field="7362-27ce-2e1c-2089" value="2">
-                      <repeats/>
-                      <conditions>
-                        <condition field="selections" scope="7b61-1289-ed7e-24c1" value="9.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="model" type="greaterThan"/>
-                      </conditions>
-                      <conditionGroups/>
-                    </modifier>
-                  </modifiers>
-                  <constraints/>
+                  <modifiers/>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="aab9-bf52-7542-7c8f" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3ecc-492d-cfa8-01fb" type="min"/>
+                  </constraints>
                   <categoryLinks/>
                 </entryLink>
               </entryLinks>
-            </selectionEntryGroup>
-          </selectionEntryGroups>
+              <costs>
+                <cost name="pts" costTypeId="points" value="13.0"/>
+                <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="34ee-3726-87dd-5c39" name="Marine w/ Heavy or Special Weapon" hidden="false" collective="false" type="model">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers>
+                <modifier type="set" field="be18-d9ac-4df5-485e" value="0.0">
+                  <repeats/>
+                  <conditions>
+                    <condition field="selections" scope="7b61-1289-ed7e-24c1" value="10.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="model" type="lessThan"/>
+                  </conditions>
+                  <conditionGroups/>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="be18-d9ac-4df5-485e" type="max"/>
+              </constraints>
+              <categoryLinks/>
+              <selectionEntries/>
+              <selectionEntryGroups>
+                <selectionEntryGroup id="4817-9127-41fc-db59" name="Weapon Options" hidden="false" collective="false">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b039-a3f4-3d3a-2e82" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="69f4-861b-d4d8-54a8" type="min"/>
+                  </constraints>
+                  <categoryLinks/>
+                  <selectionEntries/>
+                  <selectionEntryGroups/>
+                  <entryLinks>
+                    <entryLink id="5861-4fa9-dda8-a299" name="Heavy Weapons" hidden="false" targetId="d16e-f416-d268-b2b4" type="selectionEntryGroup">
+                      <profiles/>
+                      <rules/>
+                      <infoLinks/>
+                      <modifiers/>
+                      <constraints/>
+                      <categoryLinks/>
+                    </entryLink>
+                    <entryLink id="03a3-2c6a-81f8-0b1b" name="Special Weapons" hidden="false" targetId="a44b-4b4d-46b5-d3a6" type="selectionEntryGroup">
+                      <profiles/>
+                      <rules/>
+                      <infoLinks/>
+                      <modifiers/>
+                      <constraints/>
+                      <categoryLinks/>
+                    </entryLink>
+                  </entryLinks>
+                </selectionEntryGroup>
+              </selectionEntryGroups>
+              <entryLinks>
+                <entryLink id="7e05-8409-a822-0a7d" name="Bolt pistol" hidden="false" targetId="0334-f487-8229-0c1a" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="317c-aed2-a061-dd01" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1f72-fa0b-f027-b83a" type="min"/>
+                  </constraints>
+                  <categoryLinks/>
+                </entryLink>
+              </entryLinks>
+              <costs>
+                <cost name="pts" costTypeId="points" value="13.0"/>
+                <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="4222-74f2-38d2-22c1" name="Marine w/ Chainsword" hidden="false" collective="false" type="model">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="19.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d963-24f7-46d6-1bb5" type="max"/>
+              </constraints>
+              <categoryLinks/>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks>
+                <entryLink id="2144-7c17-dd89-ac09" name="Chainsword" hidden="false" targetId="704f-026f-22fd-89d5" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0b5f-574d-ed3b-e44c" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5aff-d7e0-9161-a009" type="min"/>
+                  </constraints>
+                  <categoryLinks/>
+                </entryLink>
+                <entryLink id="a8b5-bd29-0bb4-6ca5" name="Bolt pistol" hidden="false" targetId="37d3-7098-d596-9948" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ca27-d965-13c9-d78b" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7964-2869-13c9-a5a8" type="min"/>
+                  </constraints>
+                  <categoryLinks/>
+                </entryLink>
+                <entryLink id="d9b4-5939-26dd-2387" name="Frag &amp; Krak grenades" hidden="false" targetId="cddf-945e-1335-e681" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ff7b-95c7-ad1e-5642" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="adcd-4ffd-2b8b-0523" type="min"/>
+                  </constraints>
+                  <categoryLinks/>
+                </entryLink>
+              </entryLinks>
+              <costs>
+                <cost name="pts" costTypeId="points" value="13.0"/>
+                <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="7fd9-f2cd-9698-9def" name="Marine w/ Plasma pistol" hidden="false" collective="false" type="model">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers>
+                <modifier type="set" field="c43d-8693-0ccf-dc98" value="0.0">
+                  <repeats/>
+                  <conditions>
+                    <condition field="selections" scope="7b61-1289-ed7e-24c1" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="3e8a-ca3b-7746-d3d8" type="equalTo"/>
+                  </conditions>
+                  <conditionGroups/>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c43d-8693-0ccf-dc98" type="max"/>
+              </constraints>
+              <categoryLinks/>
+              <selectionEntries/>
+              <selectionEntryGroups>
+                <selectionEntryGroup id="a4ba-9833-2561-cf76" name="Select one" hidden="false" collective="false" defaultSelectionEntryId="c125-15e5-b343-d9ca">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6bef-9894-dafc-b7a4" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b162-af12-8b3b-ed95" type="min"/>
+                  </constraints>
+                  <categoryLinks/>
+                  <selectionEntries/>
+                  <selectionEntryGroups/>
+                  <entryLinks>
+                    <entryLink id="c125-15e5-b343-d9ca" name="Boltgun" hidden="false" targetId="b61f-a3c1-827d-c5b6" type="selectionEntry">
+                      <profiles/>
+                      <rules/>
+                      <infoLinks/>
+                      <modifiers/>
+                      <constraints>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3abe-3071-01ac-057a" type="max"/>
+                      </constraints>
+                      <categoryLinks/>
+                    </entryLink>
+                    <entryLink id="7950-28fc-f1dd-f027" name="Chainsword" hidden="false" targetId="0dd1-2e2b-7dd1-5495" type="selectionEntry">
+                      <profiles/>
+                      <rules/>
+                      <infoLinks/>
+                      <modifiers/>
+                      <constraints>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4d0e-9800-4a08-b336" type="max"/>
+                      </constraints>
+                      <categoryLinks/>
+                    </entryLink>
+                  </entryLinks>
+                </selectionEntryGroup>
+              </selectionEntryGroups>
+              <entryLinks>
+                <entryLink id="d8a5-71e8-7521-5c67" name="Plasma pistol" hidden="false" targetId="83be-1ba9-c326-4760" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2df7-d5c3-6089-9872" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="423a-d542-ab4e-e177" type="min"/>
+                  </constraints>
+                  <categoryLinks/>
+                </entryLink>
+              </entryLinks>
+              <costs>
+                <cost name="pts" costTypeId="points" value="13.0"/>
+                <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="0.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+          <selectionEntryGroups/>
           <entryLinks/>
         </selectionEntryGroup>
       </selectionEntryGroups>
       <entryLinks>
-        <entryLink id="fec0-4116-8958-cecb" name="New EntryLink" hidden="false" targetId="f995-21ce-bbe7-f8fe" type="selectionEntryGroup">
+        <entryLink id="fec0-4116-8958-cecb" name="Mark of Chaos with Icons" hidden="false" targetId="f995-21ce-bbe7-f8fe" type="selectionEntryGroup">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -12226,10 +13123,28 @@ D3   Bonus
       </costs>
     </selectionEntry>
     <selectionEntry id="62f4-742a-7149-3b31" name="Chosen" page="" hidden="false" collective="false" type="unit">
-      <profiles/>
+      <profiles>
+        <profile id="bbff-cfb6-9180-a5cf" name="Chosen" hidden="false" profileTypeId="800f-21d0-4387-c943" profileTypeName="Unit">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="M" characteristicTypeId="0bdf-a96e-9e38-7779" value="6&quot;"/>
+            <characteristic name="WS" characteristicTypeId="e7f0-1278-0250-df0c" value="3+"/>
+            <characteristic name="BS" characteristicTypeId="381b-eb28-74c3-df5f" value="3+"/>
+            <characteristic name="S" characteristicTypeId="2218-aa3c-265f-2939" value="4"/>
+            <characteristic name="T" characteristicTypeId="9c9f-9774-a358-3a39" value="4"/>
+            <characteristic name="W" characteristicTypeId="f330-5e6e-4110-0978" value="1"/>
+            <characteristic name="A" characteristicTypeId="13fc-b29b-31f2-ab9f" value="2"/>
+            <characteristic name="Ld" characteristicTypeId="00ca-f8b8-876d-b705" value="8"/>
+            <characteristic name="Save" characteristicTypeId="c0df-df94-abd7-e8d3" value="3+"/>
+          </characteristics>
+        </profile>
+      </profiles>
       <rules/>
       <infoLinks>
-        <infoLink id="b7f3-2be4-2bbd-3dbb" name="New InfoLink" hidden="false" targetId="6349-022a-cea9-524c" type="rule">
+        <infoLink id="b7f3-2be4-2bbd-3dbb" name="Death to the False Emperor" hidden="false" targetId="37a4-1d84-4ef0-c4f6" type="profile">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -12247,7 +13162,7 @@ D3   Bonus
       </modifiers>
       <constraints/>
       <categoryLinks>
-        <categoryLink id="c731-60f2-d693-02eb" name="New CategoryLink" hidden="false" targetId="717b-8863-9d25-5e2a" primary="false">
+        <categoryLink id="c731-60f2-d693-02eb" name="New CategoryLink" hidden="false" targetId="5cf1-acf2-ca3b-c2e5" primary="false">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -12291,76 +13206,6 @@ D3   Bonus
         </categoryLink>
       </categoryLinks>
       <selectionEntries>
-        <selectionEntry id="e7cd-2975-e203-ca19" name="Chosen" hidden="false" collective="false" type="model">
-          <profiles>
-            <profile id="e039-ab75-84b8-fa9a" name="Chosen" hidden="false" profileTypeId="800f-21d0-4387-c943" profileTypeName="Unit">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <characteristics>
-                <characteristic name="M" characteristicTypeId="0bdf-a96e-9e38-7779" value="6&quot;"/>
-                <characteristic name="WS" characteristicTypeId="e7f0-1278-0250-df0c" value="3+"/>
-                <characteristic name="BS" characteristicTypeId="381b-eb28-74c3-df5f" value="3+"/>
-                <characteristic name="S" characteristicTypeId="2218-aa3c-265f-2939" value="4"/>
-                <characteristic name="T" characteristicTypeId="9c9f-9774-a358-3a39" value="4"/>
-                <characteristic name="W" characteristicTypeId="f330-5e6e-4110-0978" value="1"/>
-                <characteristic name="A" characteristicTypeId="13fc-b29b-31f2-ab9f" value="2"/>
-                <characteristic name="Ld" characteristicTypeId="00ca-f8b8-876d-b705" value="8"/>
-                <characteristic name="Save" characteristicTypeId="c0df-df94-abd7-e8d3" value="3+"/>
-              </characteristics>
-            </profile>
-          </profiles>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints>
-            <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="dd7a-9999-58da-9cef" type="min"/>
-            <constraint field="selections" scope="parent" value="9.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6260-6931-b2c3-b781" type="max"/>
-          </constraints>
-          <categoryLinks/>
-          <selectionEntries/>
-          <selectionEntryGroups/>
-          <entryLinks>
-            <entryLink id="53f7-4ed7-03bd-87b7" name="New EntryLink" hidden="false" targetId="cddf-945e-1335-e681" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9a99-2a88-0361-6df8" type="max"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="811b-5a7c-ed9c-01e5" type="min"/>
-              </constraints>
-              <categoryLinks/>
-            </entryLink>
-            <entryLink id="6f76-a074-fd67-820b" name="New EntryLink" hidden="false" targetId="183a-a319-9ba3-541e" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3b24-fb51-c0b6-86eb" type="max"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d3e9-591a-7e73-f5cd" type="min"/>
-              </constraints>
-              <categoryLinks/>
-            </entryLink>
-            <entryLink id="8256-28c6-474c-6dfe" name="Bolt pistol" hidden="false" targetId="37d3-7098-d596-9948" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="207b-41f8-cb6c-432d" type="max"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="058f-518a-7350-f161" type="min"/>
-              </constraints>
-              <categoryLinks/>
-            </entryLink>
-          </entryLinks>
-          <costs>
-            <cost name="pts" costTypeId="points" value="16.0"/>
-            <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="0.0"/>
-          </costs>
-        </selectionEntry>
         <selectionEntry id="83b8-70b9-b2e2-61e5" name="Chosen Champion" hidden="false" collective="false" type="model">
           <profiles>
             <profile id="ef04-4cda-bcf2-84a5" name="Chosen Champion" hidden="false" profileTypeId="800f-21d0-4387-c943" profileTypeName="Unit">
@@ -12390,70 +13235,7 @@ D3   Bonus
           </constraints>
           <categoryLinks/>
           <selectionEntries/>
-          <selectionEntryGroups>
-            <selectionEntryGroup id="5c59-cf0b-83bf-65d6" name="Bolt pistol options" hidden="false" collective="false" defaultSelectionEntryId="536a-d5c6-8655-3f37">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="5ce6-4594-9af8-5eeb" type="max"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3af7-f2e6-0975-e7ff" type="min"/>
-              </constraints>
-              <categoryLinks/>
-              <selectionEntries/>
-              <selectionEntryGroups/>
-              <entryLinks>
-                <entryLink id="536a-d5c6-8655-3f37" name="New EntryLink" hidden="false" targetId="0334-f487-8229-0c1a" type="selectionEntry">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                  <constraints/>
-                  <categoryLinks/>
-                </entryLink>
-                <entryLink id="768e-3096-9fb2-e7c2" name="Champion Equipment" hidden="false" targetId="1912-576e-6a2b-5c6e" type="selectionEntryGroup">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                  <constraints/>
-                  <categoryLinks/>
-                </entryLink>
-              </entryLinks>
-            </selectionEntryGroup>
-            <selectionEntryGroup id="c593-abd9-aa7a-7bcb" name="Boltgun options" hidden="false" collective="false" defaultSelectionEntryId="8238-c610-1fb5-b5be">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="7177-f7cd-9d41-a591" type="max"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="534f-e3f8-0ca2-c568" type="min"/>
-              </constraints>
-              <categoryLinks/>
-              <selectionEntries/>
-              <selectionEntryGroups/>
-              <entryLinks>
-                <entryLink id="8238-c610-1fb5-b5be" name="New EntryLink" hidden="false" targetId="b61f-a3c1-827d-c5b6" type="selectionEntry">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                  <constraints/>
-                  <categoryLinks/>
-                </entryLink>
-                <entryLink id="e826-18e9-ff51-90bc" name="New EntryLink" hidden="false" targetId="1912-576e-6a2b-5c6e" type="selectionEntryGroup">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                  <constraints/>
-                  <categoryLinks/>
-                </entryLink>
-              </entryLinks>
-            </selectionEntryGroup>
-          </selectionEntryGroups>
+          <selectionEntryGroups/>
           <entryLinks>
             <entryLink id="813a-a24a-5763-8a26" name="Frag &amp; Krak grenades" hidden="false" targetId="cddf-945e-1335-e681" type="selectionEntry">
               <profiles/>
@@ -12466,6 +13248,17 @@ D3   Bonus
               </constraints>
               <categoryLinks/>
             </entryLink>
+            <entryLink id="cdb6-dde7-f2b2-1507" name="Champion Equipment" hidden="false" targetId="ad90-3560-ea09-82ef" type="selectionEntryGroup">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e682-bc40-5d82-a336" type="max"/>
+                <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c082-f573-38c8-a394" type="min"/>
+              </constraints>
+              <categoryLinks/>
+            </entryLink>
           </entryLinks>
           <costs>
             <cost name="pts" costTypeId="points" value="13.0"/>
@@ -12474,145 +13267,332 @@ D3   Bonus
         </selectionEntry>
       </selectionEntries>
       <selectionEntryGroups>
-        <selectionEntryGroup id="4cf6-b239-752d-1a43" name="Weapon replacements (Up to 4)" hidden="false" collective="false">
+        <selectionEntryGroup id="a824-9a7c-0d4a-3529" name="Chosen" hidden="false" collective="false" defaultSelectionEntryId="8c3f-7824-124e-21e5">
           <profiles/>
           <rules/>
           <infoLinks/>
           <modifiers/>
           <constraints>
-            <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="fb7b-e3e0-413a-efca" type="max"/>
+            <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9039-7ff8-e2cf-b0af" type="min"/>
+            <constraint field="selections" scope="parent" value="9.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d85b-fd04-51c8-c02e" type="max"/>
           </constraints>
           <categoryLinks/>
           <selectionEntries>
-            <selectionEntry id="867e-3dbc-5158-b14d" name="Replace bolt pistol with plasma pistol" hidden="false" collective="false" type="upgrade">
-              <profiles/>
-              <rules/>
-              <infoLinks>
-                <infoLink id="9a62-4bb4-d397-7444" name="New InfoLink" hidden="false" targetId="ff12-161a-ca85-339f" type="profile">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                </infoLink>
-                <infoLink id="2294-0ccd-3fa1-96a8" name="New InfoLink" hidden="false" targetId="5779-2931-fe17-2b27" type="profile">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                </infoLink>
-              </infoLinks>
-              <modifiers/>
-              <constraints/>
-              <categoryLinks/>
-              <selectionEntries/>
-              <selectionEntryGroups/>
-              <entryLinks/>
-              <costs>
-                <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="0.0"/>
-                <cost name="pts" costTypeId="points" value="7.0"/>
-              </costs>
-            </selectionEntry>
-          </selectionEntries>
-          <selectionEntryGroups>
-            <selectionEntryGroup id="360a-6587-2108-3826" name="Replace boltgun with..." hidden="false" collective="false">
+            <selectionEntry id="8c3f-7824-124e-21e5" name="Chosen w/ boltgun" hidden="false" collective="false" type="model">
               <profiles/>
               <rules/>
               <infoLinks/>
               <modifiers/>
-              <constraints/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="9.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="58e4-0fa8-658e-0a9c" type="max"/>
+              </constraints>
               <categoryLinks/>
               <selectionEntries/>
               <selectionEntryGroups/>
               <entryLinks>
-                <entryLink id="c30f-78e3-9f64-6f35" name="Combi-weapons" hidden="false" targetId="5383-9a88-9883-e144" type="selectionEntryGroup">
+                <entryLink id="3454-abf4-b954-8d71" name="Frag &amp; Krak grenades" hidden="false" targetId="cddf-945e-1335-e681" type="selectionEntry">
                   <profiles/>
                   <rules/>
                   <infoLinks/>
-                  <modifiers>
-                    <modifier type="set" field="2dbb-20ac-4393-0622" value="4">
-                      <repeats/>
-                      <conditions/>
-                      <conditionGroups/>
-                    </modifier>
-                  </modifiers>
-                  <constraints/>
+                  <modifiers/>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a8cf-82ac-012f-011d" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="864c-5007-903d-9815" type="min"/>
+                  </constraints>
                   <categoryLinks/>
                 </entryLink>
-                <entryLink id="f2ce-48fd-f0f3-6fb3" name="Melee Weapons" hidden="false" targetId="becb-9ac2-cb36-95f7" type="selectionEntryGroup">
+                <entryLink id="a92e-40e5-1933-012c" name="Boltgun" hidden="false" targetId="183a-a319-9ba3-541e" type="selectionEntry">
                   <profiles/>
                   <rules/>
                   <infoLinks/>
-                  <modifiers>
-                    <modifier type="set" field="d64f-a953-8bc4-0da2" value="4">
-                      <repeats/>
-                      <conditions/>
-                      <conditionGroups/>
-                    </modifier>
-                  </modifiers>
-                  <constraints/>
+                  <modifiers/>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2a1b-ec28-61f8-0b93" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c6f7-ad2c-57ef-f12b" type="min"/>
+                  </constraints>
                   <categoryLinks/>
                 </entryLink>
-                <entryLink id="28d9-87cd-8a83-a031" name="Special Weapons" hidden="false" targetId="a44b-4b4d-46b5-d3a6" type="selectionEntryGroup">
+                <entryLink id="7702-4eea-9b7e-2c11" name="Bolt pistol" hidden="false" targetId="37d3-7098-d596-9948" type="selectionEntry">
                   <profiles/>
                   <rules/>
                   <infoLinks/>
-                  <modifiers>
-                    <modifier type="set" field="5154-f7a1-21fa-cf7f" value="4">
-                      <repeats/>
-                      <conditions/>
-                      <conditionGroups/>
-                    </modifier>
-                  </modifiers>
-                  <constraints/>
+                  <modifiers/>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9c25-cfcd-205d-0196" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f9d4-bf3b-3173-b74d" type="min"/>
+                  </constraints>
                   <categoryLinks/>
                 </entryLink>
               </entryLinks>
-            </selectionEntryGroup>
-          </selectionEntryGroups>
-          <entryLinks>
-            <entryLink id="b6ac-9186-b4e0-050f" name="New EntryLink" hidden="false" targetId="7603-6241-ab8b-4603" type="selectionEntry">
+              <costs>
+                <cost name="pts" costTypeId="points" value="16.0"/>
+                <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="b1f8-b08f-b2b0-df75" name="Chosen w/ chainsword" hidden="false" collective="false" type="model">
               <profiles/>
               <rules/>
               <infoLinks/>
               <modifiers/>
-              <constraints/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="9.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6bd5-eb4a-a81a-c2b6" type="max"/>
+              </constraints>
               <categoryLinks/>
-            </entryLink>
-          </entryLinks>
-        </selectionEntryGroup>
-        <selectionEntryGroup id="92a1-31e0-1692-a903" name="Replace one boltgun with..." hidden="false" collective="false">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints>
-            <constraint field="selections" scope="62f4-742a-7149-3b31" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="5b9b-2333-a299-6a71" type="max"/>
-          </constraints>
-          <categoryLinks/>
-          <selectionEntries/>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks>
+                <entryLink id="e212-3abb-07e2-5784" name="Frag &amp; Krak grenades" hidden="false" targetId="cddf-945e-1335-e681" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="19d5-2047-200f-d005" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7f95-9ef2-c537-585f" type="min"/>
+                  </constraints>
+                  <categoryLinks/>
+                </entryLink>
+                <entryLink id="6082-67f0-1582-c20e" name="Chainsword" hidden="false" targetId="704f-026f-22fd-89d5" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ce84-18ac-df45-9cd2" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e507-f9c0-da0e-4cc8" type="min"/>
+                  </constraints>
+                  <categoryLinks/>
+                </entryLink>
+                <entryLink id="410f-9660-c8a1-1218" name="Bolt pistol" hidden="false" targetId="37d3-7098-d596-9948" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9ee4-f51d-0dcb-9126" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="44f0-bb61-79d4-61a1" type="min"/>
+                  </constraints>
+                  <categoryLinks/>
+                </entryLink>
+              </entryLinks>
+              <costs>
+                <cost name="pts" costTypeId="points" value="16.0"/>
+                <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="64c8-ad43-da9e-da82" name="Chosen w/ weapon option" hidden="false" collective="false" type="model">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers>
+                <modifier type="set" field="name" value="Chosen w/ combi weapon">
+                  <repeats/>
+                  <conditions>
+                    <condition field="selections" scope="64c8-ad43-da9e-da82" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="8c67-8d8e-88ba-b2ec" type="equalTo"/>
+                  </conditions>
+                  <conditionGroups/>
+                </modifier>
+                <modifier type="set" field="name" value="Chosen w/ special weapon">
+                  <repeats/>
+                  <conditions>
+                    <condition field="selections" scope="64c8-ad43-da9e-da82" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="cf18-24f2-6ff7-bffc" type="equalTo"/>
+                  </conditions>
+                  <conditionGroups/>
+                </modifier>
+                <modifier type="set" field="name" value="Chosen w/ melee weapon">
+                  <repeats/>
+                  <conditions>
+                    <condition field="selections" scope="64c8-ad43-da9e-da82" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="b24f-d68f-6c83-5e4a" type="equalTo"/>
+                  </conditions>
+                  <conditionGroups/>
+                </modifier>
+                <modifier type="set" field="name" value="Chosen w/ lightning claws">
+                  <repeats/>
+                  <conditions>
+                    <condition field="selections" scope="64c8-ad43-da9e-da82" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="b606-4848-049c-d2e3" type="equalTo"/>
+                  </conditions>
+                  <conditionGroups/>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="adb8-837e-14ec-4c2f" type="max"/>
+              </constraints>
+              <categoryLinks/>
+              <selectionEntries/>
+              <selectionEntryGroups>
+                <selectionEntryGroup id="66b6-3ccc-29d3-0b37" name="Weapon option" hidden="false" collective="false">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c354-4838-2702-0ae3" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a691-5b08-8c8f-34c6" type="min"/>
+                  </constraints>
+                  <categoryLinks/>
+                  <selectionEntries/>
+                  <selectionEntryGroups/>
+                  <entryLinks>
+                    <entryLink id="b24f-d68f-6c83-5e4a" name="Melee Weapons" hidden="false" targetId="becb-9ac2-cb36-95f7" type="selectionEntryGroup">
+                      <profiles/>
+                      <rules/>
+                      <infoLinks/>
+                      <modifiers/>
+                      <constraints/>
+                      <categoryLinks/>
+                    </entryLink>
+                    <entryLink id="cf18-24f2-6ff7-bffc" name="Special Weapons" hidden="false" targetId="a44b-4b4d-46b5-d3a6" type="selectionEntryGroup">
+                      <profiles/>
+                      <rules/>
+                      <infoLinks/>
+                      <modifiers/>
+                      <constraints/>
+                      <categoryLinks/>
+                    </entryLink>
+                    <entryLink id="8c67-8d8e-88ba-b2ec" name="Combi-weapons" hidden="false" targetId="5383-9a88-9883-e144" type="selectionEntryGroup">
+                      <profiles/>
+                      <rules/>
+                      <infoLinks/>
+                      <modifiers/>
+                      <constraints/>
+                      <categoryLinks/>
+                    </entryLink>
+                    <entryLink id="b606-4848-049c-d2e3" name="Lightning Claw (Pair)" hidden="false" targetId="7603-6241-ab8b-4603" type="selectionEntry">
+                      <profiles/>
+                      <rules/>
+                      <infoLinks/>
+                      <modifiers/>
+                      <constraints>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5779-d415-b603-b605" type="max"/>
+                      </constraints>
+                      <categoryLinks/>
+                    </entryLink>
+                  </entryLinks>
+                </selectionEntryGroup>
+              </selectionEntryGroups>
+              <entryLinks>
+                <entryLink id="7fa9-936f-98e6-fb97" name="Frag &amp; Krak grenades" hidden="false" targetId="bb78-534a-7b77-edbc" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b504-2471-87cf-6578" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="eeb0-24b7-e0e3-60f0" type="min"/>
+                  </constraints>
+                  <categoryLinks/>
+                </entryLink>
+                <entryLink id="cad1-4299-ab93-7a7e" name="Bolt pistol" hidden="false" targetId="0334-f487-8229-0c1a" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ef4d-70bb-1418-9ea0" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7a01-380f-78d0-e082" type="min"/>
+                  </constraints>
+                  <categoryLinks/>
+                </entryLink>
+              </entryLinks>
+              <costs>
+                <cost name="pts" costTypeId="points" value="16.0"/>
+                <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="a5dd-3378-0dbc-9a34" name="Chosen w/ Heavy or Special weapon" hidden="false" collective="false" type="model">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers>
+                <modifier type="set" field="name" value="Chosen w/ heavy weapon">
+                  <repeats/>
+                  <conditions>
+                    <condition field="selections" scope="a5dd-3378-0dbc-9a34" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="5c11-afb7-601e-c4f7" type="equalTo"/>
+                  </conditions>
+                  <conditionGroups/>
+                </modifier>
+                <modifier type="set" field="name" value="Chosen w/ special weapon">
+                  <repeats/>
+                  <conditions>
+                    <condition field="selections" scope="a5dd-3378-0dbc-9a34" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="24c3-a247-1b9d-8b0e" type="equalTo"/>
+                  </conditions>
+                  <conditionGroups/>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="016b-5feb-02a3-0882" type="max"/>
+              </constraints>
+              <categoryLinks/>
+              <selectionEntries/>
+              <selectionEntryGroups>
+                <selectionEntryGroup id="220e-5e06-bb17-a344" name="Weapon option" hidden="false" collective="false">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="97b3-e32f-e4b3-df16" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a7a3-0a7b-b98a-8edd" type="min"/>
+                  </constraints>
+                  <categoryLinks/>
+                  <selectionEntries/>
+                  <selectionEntryGroups/>
+                  <entryLinks>
+                    <entryLink id="24c3-a247-1b9d-8b0e" name="Special Weapons" hidden="false" targetId="a44b-4b4d-46b5-d3a6" type="selectionEntryGroup">
+                      <profiles/>
+                      <rules/>
+                      <infoLinks/>
+                      <modifiers/>
+                      <constraints/>
+                      <categoryLinks/>
+                    </entryLink>
+                    <entryLink id="5c11-afb7-601e-c4f7" name="Heavy Weapons" hidden="false" targetId="d16e-f416-d268-b2b4" type="selectionEntryGroup">
+                      <profiles/>
+                      <rules/>
+                      <infoLinks/>
+                      <modifiers/>
+                      <constraints/>
+                      <categoryLinks/>
+                    </entryLink>
+                  </entryLinks>
+                </selectionEntryGroup>
+              </selectionEntryGroups>
+              <entryLinks>
+                <entryLink id="46db-5819-9213-c332" name="Frag &amp; Krak grenades" hidden="false" targetId="bb78-534a-7b77-edbc" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9cda-7f25-8bc3-ac0f" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5b28-d1e0-dc71-8633" type="min"/>
+                  </constraints>
+                  <categoryLinks/>
+                </entryLink>
+                <entryLink id="2e9a-ce8a-4c08-155e" name="Bolt pistol" hidden="false" targetId="0334-f487-8229-0c1a" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d748-5575-4637-524c" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3c8b-c250-41f9-1b97" type="min"/>
+                  </constraints>
+                  <categoryLinks/>
+                </entryLink>
+              </entryLinks>
+              <costs>
+                <cost name="pts" costTypeId="points" value="16.0"/>
+                <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="0.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
           <selectionEntryGroups/>
-          <entryLinks>
-            <entryLink id="ee25-3ad2-0b2b-18e7" name="New EntryLink" hidden="false" targetId="d16e-f416-d268-b2b4" type="selectionEntryGroup">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints/>
-              <categoryLinks/>
-            </entryLink>
-            <entryLink id="950a-d51a-30c9-8eab" name="New EntryLink" hidden="false" targetId="a44b-4b4d-46b5-d3a6" type="selectionEntryGroup">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints/>
-              <categoryLinks/>
-            </entryLink>
-          </entryLinks>
+          <entryLinks/>
         </selectionEntryGroup>
       </selectionEntryGroups>
       <entryLinks>
-        <entryLink id="a961-761c-ba87-8241" name="New EntryLink" hidden="false" targetId="f995-21ce-bbe7-f8fe" type="selectionEntryGroup">
+        <entryLink id="a961-761c-ba87-8241" name="Mark of Chaos with Icons" hidden="false" targetId="f995-21ce-bbe7-f8fe" type="selectionEntryGroup">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -12630,13 +13610,13 @@ D3   Bonus
       <profiles/>
       <rules/>
       <infoLinks>
-        <infoLink id="9f8b-8a4d-83a2-c1f7" name="Daemonic" hidden="false" targetId="2946-510b-88fb-5c9c" type="rule">
+        <infoLink id="9f8b-8a4d-83a2-c1f7" name="Daemonic" hidden="false" targetId="94f5-82c3-bb66-ac0c" type="profile">
           <profiles/>
           <rules/>
           <infoLinks/>
           <modifiers/>
         </infoLink>
-        <infoLink id="494f-6064-ca0f-9507" name="New InfoLink" hidden="false" targetId="6349-022a-cea9-524c" type="rule">
+        <infoLink id="494f-6064-ca0f-9507" name="Death to the False Emperor" hidden="false" targetId="37a4-1d84-4ef0-c4f6" type="profile">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -12675,7 +13655,7 @@ D3   Bonus
           <modifiers/>
           <constraints/>
         </categoryLink>
-        <categoryLink id="635d-874f-e48d-2a8b" name="New CategoryLink" hidden="false" targetId="717b-8863-9d25-5e2a" primary="false">
+        <categoryLink id="635d-874f-e48d-2a8b" name="New CategoryLink" hidden="false" targetId="5cf1-acf2-ca3b-c2e5" primary="false">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -12731,6 +13711,15 @@ D3   Bonus
                 <characteristic name="Save" characteristicTypeId="c0df-df94-abd7-e8d3" value="3+"/>
               </characteristics>
             </profile>
+            <profile id="2763-d733-656d-2746" name="Writhing Tentacles" book="" hidden="false" profileTypeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" profileTypeName="Abilities">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <characteristics>
+                <characteristic name="Description" characteristicTypeId="21befb24-fc85-4f52-a745-64b2e48f8228" value="Roll a D3 when a unit of Possessed is selected to attack in the Fight phase. The result is the Attacks characteristic of each model in the unit."/>
+              </characteristics>
+            </profile>
           </profiles>
           <rules/>
           <infoLinks/>
@@ -12741,15 +13730,20 @@ D3   Bonus
           </constraints>
           <categoryLinks/>
           <selectionEntries>
-            <selectionEntry id="966a-9616-5ca7-a8a5" name="Writhing Tentacles" hidden="false" collective="true" type="upgrade">
+            <selectionEntry id="966a-9616-5ca7-a8a5" name="Horrifying Mutations" hidden="false" collective="true" type="upgrade">
               <profiles>
-                <profile id="0ea4-321e-eccc-970d" name="Writhing Tentacles" book="" hidden="false" profileTypeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" profileTypeName="Abilities">
+                <profile id="188c-fb04-846d-c886" name="Horrifying Mutations" hidden="false" profileTypeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" profileTypeName="Weapon">
                   <profiles/>
                   <rules/>
                   <infoLinks/>
                   <modifiers/>
                   <characteristics>
-                    <characteristic name="Description" characteristicTypeId="21befb24-fc85-4f52-a745-64b2e48f8228" value="Roll a D3 when a unit of Possessed is selected to attack in the Fight phase. The result is the Attacks characteristic of each model in the unit."/>
+                    <characteristic name="Range" characteristicTypeId="6fa97fa8-ea74-4a27-a0fb-bc4e5f367464" value="Melee"/>
+                    <characteristic name="Type" characteristicTypeId="077c342f-d7b9-45c6-b8af-88e97cafd3a2" value="Melee"/>
+                    <characteristic name="S" characteristicTypeId="59b1-319e-ec13-d466" value="User"/>
+                    <characteristic name="AP" characteristicTypeId="75aa-a838-b675-6484" value="-2"/>
+                    <characteristic name="D" characteristicTypeId="ae8a-3137-d65b-4ca7" value="1"/>
+                    <characteristic name="Abilities" characteristicTypeId="837d-5e63-aeb7-1410" value=""/>
                   </characteristics>
                 </profile>
               </profiles>
@@ -12800,7 +13794,29 @@ D3   Bonus
           <profiles/>
           <rules/>
           <infoLinks/>
-          <modifiers/>
+          <modifiers>
+            <modifier type="set" field="13fc-b29b-31f2-ab9f" value="5">
+              <repeats/>
+              <conditions/>
+              <conditionGroups>
+                <conditionGroup type="and">
+                  <conditions>
+                    <condition field="selections" scope="5cae-15dc-4a5d-0b9b" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="b082-190f-1c58-4f3d" type="equalTo"/>
+                  </conditions>
+                  <conditionGroups>
+                    <conditionGroup type="or">
+                      <conditions>
+                        <condition field="selections" scope="5cae-15dc-4a5d-0b9b" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="840e-6586-1162-9d68" type="equalTo"/>
+                        <condition field="selections" scope="5cae-15dc-4a5d-0b9b" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="f789-c214-2335-e2cf" type="equalTo"/>
+                        <condition field="selections" scope="5cae-15dc-4a5d-0b9b" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="ce8d-9406-bcf1-fdae" type="equalTo"/>
+                      </conditions>
+                      <conditionGroups/>
+                    </conditionGroup>
+                  </conditionGroups>
+                </conditionGroup>
+              </conditionGroups>
+            </modifier>
+          </modifiers>
           <characteristics>
             <characteristic name="M" characteristicTypeId="0bdf-a96e-9e38-7779" value="8&quot;"/>
             <characteristic name="WS" characteristicTypeId="e7f0-1278-0250-df0c" value="3+"/>
@@ -12822,51 +13838,51 @@ D3   Bonus
             <characteristic name="Description" characteristicTypeId="21befb24-fc85-4f52-a745-64b2e48f8228" value="At the end of any phase in which this model suffers any unsaved wounds or mortal wounds, roll a D6. On a roll of 6, this model immediately makes a shooting attack as if it were your Shooting phase if there no enemies within 1&quot;, or a piles in and fights as if it were in the Fight phase if there are enemies within 1&quot;. If there is no visible target within range, nothing happens."/>
           </characteristics>
         </profile>
-        <profile id="a3d2-cbb8-77f5-44d3" name="Battering Onslaught" hidden="false" profileTypeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" profileTypeName="Abilities">
+        <profile id="a3d2-cbb8-77f5-44d3" name="Battering Onslaught" hidden="true" profileTypeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" profileTypeName="Abilities">
           <profiles/>
           <rules/>
           <infoLinks/>
-          <modifiers/>
+          <modifiers>
+            <modifier type="set" field="hidden" value="false">
+              <repeats/>
+              <conditions/>
+              <conditionGroups>
+                <conditionGroup type="and">
+                  <conditions>
+                    <condition field="selections" scope="5cae-15dc-4a5d-0b9b" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="b082-190f-1c58-4f3d" type="equalTo"/>
+                  </conditions>
+                  <conditionGroups>
+                    <conditionGroup type="or">
+                      <conditions>
+                        <condition field="selections" scope="5cae-15dc-4a5d-0b9b" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="840e-6586-1162-9d68" type="equalTo"/>
+                        <condition field="selections" scope="5cae-15dc-4a5d-0b9b" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="f789-c214-2335-e2cf" type="equalTo"/>
+                        <condition field="selections" scope="5cae-15dc-4a5d-0b9b" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="ce8d-9406-bcf1-fdae" type="equalTo"/>
+                      </conditions>
+                      <conditionGroups/>
+                    </conditionGroup>
+                  </conditionGroups>
+                </conditionGroup>
+              </conditionGroups>
+            </modifier>
+          </modifiers>
           <characteristics>
-            <characteristic name="Description" characteristicTypeId="21befb24-fc85-4f52-a745-64b2e48f8228" value="Add 1 to this model&apos;s Attacks characteristic if it is equipped with two melee weapons."/>
+            <characteristic name="Description" characteristicTypeId="21befb24-fc85-4f52-a745-64b2e48f8228" value="Add 1 to this model&apos;s Attacks characteristic if it is equipped with two melee weapons. This extra attack has been added to its profile."/>
           </characteristics>
         </profile>
       </profiles>
-      <rules>
-        <rule id="14a6-e40d-31fb-7010" name="Explodes" hidden="false">
+      <rules/>
+      <infoLinks>
+        <infoLink id="e47b-4dff-ebf5-d4d0" name="Explodes" hidden="false" targetId="9446-1148-da70-4028" type="profile">
           <profiles/>
           <rules/>
           <infoLinks/>
           <modifiers/>
-          <description>If this model is reduced to 0 wounds, roll a D6 before removing the model from the battlefield; on a 6 is explodes, and each unit within 3&quot; suffers D3 MW.</description>
-        </rule>
-      </rules>
-      <infoLinks/>
+        </infoLink>
+      </infoLinks>
       <modifiers/>
       <constraints/>
       <categoryLinks>
-        <categoryLink id="724d-bb4c-4e8e-94c9" name="New CategoryLink" hidden="false" targetId="717b-8863-9d25-5e2a" primary="false">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints/>
-        </categoryLink>
-        <categoryLink id="69fa-3679-e364-db5c" name="New CategoryLink" hidden="false" targetId="ca10-a5dd-f54f-0ed5" primary="false">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints/>
-        </categoryLink>
-        <categoryLink id="8b3c-2401-6ed2-2d1a" name="New CategoryLink" hidden="false" targetId="b2b6-8e4a-9c74-cc37" primary="false">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints/>
-        </categoryLink>
-        <categoryLink id="9ad9-ba16-b9a9-7304" name="New CategoryLink" hidden="false" targetId="a61a-08c8-c7f7-9f78" primary="false">
+        <categoryLink id="724d-bb4c-4e8e-94c9" name="New CategoryLink" hidden="false" targetId="5cf1-acf2-ca3b-c2e5" primary="false">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -12881,6 +13897,27 @@ D3   Bonus
           <constraints/>
         </categoryLink>
         <categoryLink id="b131-bec7-2c8f-b0b2" name="New CategoryLink" hidden="false" targetId="c8fd-783f-3230-493e" primary="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
+        <categoryLink id="0836-2e1b-c531-cae8" name="New CategoryLink" hidden="false" targetId="ca10-a5dd-f54f-0ed5" primary="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
+        <categoryLink id="8257-70f3-306f-05a9" name="New CategoryLink" hidden="false" targetId="a61a-08c8-c7f7-9f78" primary="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
+        <categoryLink id="0314-3c7c-6aa6-d933" name="New CategoryLink" hidden="false" targetId="649f-80f9-0d71-64c3" primary="false">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -13148,7 +14185,7 @@ D3   Bonus
           </selectionEntries>
           <selectionEntryGroups/>
           <entryLinks>
-            <entryLink id="cc08-1413-3e3b-d1f5" name="New EntryLink" hidden="false" targetId="2b37-65ee-9443-b4ef" type="selectionEntry">
+            <entryLink id="cc08-1413-3e3b-d1f5" name="Multi-melta" hidden="false" targetId="2b37-65ee-9443-b4ef" type="selectionEntry">
               <profiles/>
               <rules/>
               <infoLinks/>
@@ -13200,7 +14237,7 @@ D3   Bonus
         </selectionEntryGroup>
       </selectionEntryGroups>
       <entryLinks>
-        <entryLink id="7772-bbd3-124b-8ff6" name="New EntryLink" hidden="false" targetId="45e8-d3d1-105b-90a3" type="selectionEntryGroup">
+        <entryLink id="7772-bbd3-124b-8ff6" name="Mark of Chaos" hidden="false" targetId="45e8-d3d1-105b-90a3" type="selectionEntryGroup">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -13293,7 +14330,7 @@ D3   Bonus
       </profiles>
       <rules/>
       <infoLinks>
-        <infoLink id="05a1-3e72-2b75-58c9" name="New InfoLink" hidden="false" targetId="3541-94a7-a138-358b" type="rule">
+        <infoLink id="d6b0-6873-981f-2009" name="Explodes" hidden="false" targetId="9446-1148-da70-4028" type="profile">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -13317,7 +14354,7 @@ D3   Bonus
           <modifiers/>
           <constraints/>
         </categoryLink>
-        <categoryLink id="bf72-5601-14e0-d96f" name="New CategoryLink" hidden="false" targetId="717b-8863-9d25-5e2a" primary="false">
+        <categoryLink id="bf72-5601-14e0-d96f" name="New CategoryLink" hidden="false" targetId="5cf1-acf2-ca3b-c2e5" primary="false">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -13356,7 +14393,7 @@ D3   Bonus
       <selectionEntries/>
       <selectionEntryGroups/>
       <entryLinks>
-        <entryLink id="1e9a-c7fb-b70e-256f" name="New EntryLink" hidden="false" targetId="5383-9a88-9883-e144" type="selectionEntryGroup">
+        <entryLink id="1e9a-c7fb-b70e-256f" name="Combi-weapons" hidden="false" targetId="5383-9a88-9883-e144" type="selectionEntryGroup">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -13375,7 +14412,7 @@ D3   Bonus
           </constraints>
           <categoryLinks/>
         </entryLink>
-        <entryLink id="f378-325f-f828-a939" name="New EntryLink" hidden="false" targetId="eba0-9fc6-5334-a390" type="selectionEntry">
+        <entryLink id="f378-325f-f828-a939" name="Combi-bolter" hidden="false" targetId="eba0-9fc6-5334-a390" type="selectionEntry">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -13386,7 +14423,7 @@ D3   Bonus
           </constraints>
           <categoryLinks/>
         </entryLink>
-        <entryLink id="9ac1-8310-9179-ae5e" name="New EntryLink" hidden="false" targetId="f668-0ff7-69d5-be65" type="selectionEntry">
+        <entryLink id="9ac1-8310-9179-ae5e" name="Havoc launcher" hidden="false" targetId="f668-0ff7-69d5-be65" type="selectionEntry">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -13499,7 +14536,7 @@ D3   Bonus
           <infoLinks/>
           <modifiers/>
           <characteristics>
-            <characteristic name="Description" characteristicTypeId="21befb24-fc85-4f52-a745-64b2e48f8228" value="When a Psyker (friendly or enemy) attempts to manifest a psychic power that inflicts MW on the Greater Brass Scorpion of Khorne, the Psyker suffers Perils of the Warp on any roll of a double, not just double 1 or double 6 as would normally be the case."/>
+            <characteristic name="Description" characteristicTypeId="21befb24-fc85-4f52-a745-64b2e48f8228" value="When a PSYKER (friendly or enemy) attempts to manifest a psychic power that inflicts mortal wounds on the Greater Brass Scorpion of Khorne, the PSYKER suffers Perils of the Warp on any roll of a double, not just double 1 or double 6 as would normally be the case."/>
           </characteristics>
         </profile>
         <profile id="0c89-e0b2-4941-04c7" name="Doomsday Reactor" hidden="false" profileTypeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" profileTypeName="Abilities">
@@ -13508,13 +14545,13 @@ D3   Bonus
           <infoLinks/>
           <modifiers/>
           <characteristics>
-            <characteristic name="Description" characteristicTypeId="21befb24-fc85-4f52-a745-64b2e48f8228" value="If this model is reduced to 0 wounds, roll a D6 before removing the model from the battlefield; on a 4+ it explodes and each unit within 2D6&quot; suffers D6 MW."/>
+            <characteristic name="Description" characteristicTypeId="21befb24-fc85-4f52-a745-64b2e48f8228" value="If this model is reduced to 0 wounds, roll a D6 before removing the model from the battlefield; on a 4+ it explodes and each unit within 2D6&quot; suffers D6 mortal wounds."/>
           </characteristics>
         </profile>
       </profiles>
       <rules/>
       <infoLinks>
-        <infoLink id="ffd3-339a-28b7-98e7" name="New InfoLink" hidden="false" targetId="afd3-a04b-c770-90c1" type="rule">
+        <infoLink id="ffd3-339a-28b7-98e7" name="Infernal Regeneration" hidden="false" targetId="a46b-e84f-ab7b-a4e4" type="profile">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -13537,7 +14574,7 @@ D3   Bonus
           <modifiers/>
           <constraints/>
         </categoryLink>
-        <categoryLink id="1361-8304-34f2-3823" name="New CategoryLink" hidden="false" targetId="717b-8863-9d25-5e2a" primary="false">
+        <categoryLink id="1361-8304-34f2-3823" name="New CategoryLink" hidden="false" targetId="5cf1-acf2-ca3b-c2e5" primary="false">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -13736,10 +14773,28 @@ D3   Bonus
       </costs>
     </selectionEntry>
     <selectionEntry id="f7d5-82fa-df6a-b9e2" name="Havocs" page="" hidden="false" collective="false" type="unit">
-      <profiles/>
+      <profiles>
+        <profile id="26f7-4767-d20c-b066" name="Havoc" hidden="false" profileTypeId="800f-21d0-4387-c943" profileTypeName="Unit">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="M" characteristicTypeId="0bdf-a96e-9e38-7779" value="6&quot;"/>
+            <characteristic name="WS" characteristicTypeId="e7f0-1278-0250-df0c" value="3+"/>
+            <characteristic name="BS" characteristicTypeId="381b-eb28-74c3-df5f" value="3+"/>
+            <characteristic name="S" characteristicTypeId="2218-aa3c-265f-2939" value="4"/>
+            <characteristic name="T" characteristicTypeId="9c9f-9774-a358-3a39" value="4"/>
+            <characteristic name="W" characteristicTypeId="f330-5e6e-4110-0978" value="1"/>
+            <characteristic name="A" characteristicTypeId="13fc-b29b-31f2-ab9f" value="1"/>
+            <characteristic name="Ld" characteristicTypeId="00ca-f8b8-876d-b705" value="7"/>
+            <characteristic name="Save" characteristicTypeId="c0df-df94-abd7-e8d3" value="3+"/>
+          </characteristics>
+        </profile>
+      </profiles>
       <rules/>
       <infoLinks>
-        <infoLink id="ed8a-7705-1644-58db" name="New InfoLink" hidden="false" targetId="6349-022a-cea9-524c" type="rule">
+        <infoLink id="ed8a-7705-1644-58db" name="Death to the False Emperor" hidden="false" targetId="37a4-1d84-4ef0-c4f6" type="profile">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -13764,7 +14819,7 @@ D3   Bonus
       </modifiers>
       <constraints/>
       <categoryLinks>
-        <categoryLink id="a6e7-fde9-ed23-c6d9" name="New CategoryLink" hidden="false" targetId="717b-8863-9d25-5e2a" primary="false">
+        <categoryLink id="a6e7-fde9-ed23-c6d9" name="New CategoryLink" hidden="false" targetId="5cf1-acf2-ca3b-c2e5" primary="false">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -13801,76 +14856,6 @@ D3   Bonus
         </categoryLink>
       </categoryLinks>
       <selectionEntries>
-        <selectionEntry id="c6d7-b544-5766-8f36" name="Havoc" hidden="false" collective="false" type="model">
-          <profiles>
-            <profile id="06f9-3740-2b28-4865" name="Havoc" hidden="false" profileTypeId="800f-21d0-4387-c943" profileTypeName="Unit">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <characteristics>
-                <characteristic name="M" characteristicTypeId="0bdf-a96e-9e38-7779" value="6&quot;"/>
-                <characteristic name="WS" characteristicTypeId="e7f0-1278-0250-df0c" value="3+"/>
-                <characteristic name="BS" characteristicTypeId="381b-eb28-74c3-df5f" value="3+"/>
-                <characteristic name="S" characteristicTypeId="2218-aa3c-265f-2939" value="4"/>
-                <characteristic name="T" characteristicTypeId="9c9f-9774-a358-3a39" value="4"/>
-                <characteristic name="W" characteristicTypeId="f330-5e6e-4110-0978" value="1"/>
-                <characteristic name="A" characteristicTypeId="13fc-b29b-31f2-ab9f" value="1"/>
-                <characteristic name="Ld" characteristicTypeId="00ca-f8b8-876d-b705" value="7"/>
-                <characteristic name="Save" characteristicTypeId="c0df-df94-abd7-e8d3" value="3+"/>
-              </characteristics>
-            </profile>
-          </profiles>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints>
-            <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="da55-7214-0b68-8b6f" type="min"/>
-            <constraint field="selections" scope="parent" value="9.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c6e2-f063-4850-cabf" type="max"/>
-          </constraints>
-          <categoryLinks/>
-          <selectionEntries/>
-          <selectionEntryGroups/>
-          <entryLinks>
-            <entryLink id="cfe1-9c61-5cb9-7227" name="Frag &amp; Krak grenades" hidden="false" targetId="cddf-945e-1335-e681" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3b8a-718f-8c7e-c76b" type="max"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3f3c-0a1e-3218-fb7c" type="min"/>
-              </constraints>
-              <categoryLinks/>
-            </entryLink>
-            <entryLink id="2bf4-c6d8-49be-7170" name="Bolt pistol" hidden="false" targetId="37d3-7098-d596-9948" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fd67-7510-57b1-e2d2" type="max"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9f61-3f73-2132-7924" type="min"/>
-              </constraints>
-              <categoryLinks/>
-            </entryLink>
-            <entryLink id="ff11-828b-677a-35f5" name="Boltgun" hidden="false" targetId="183a-a319-9ba3-541e" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5511-4719-8819-e544" type="max"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6e3a-cbad-f307-fda6" type="min"/>
-              </constraints>
-              <categoryLinks/>
-            </entryLink>
-          </entryLinks>
-          <costs>
-            <cost name="pts" costTypeId="points" value="13.0"/>
-            <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="0.0"/>
-          </costs>
-        </selectionEntry>
         <selectionEntry id="97b3-7f1e-7f15-9700" name="Aspiring Champion" hidden="false" collective="false" type="model">
           <profiles>
             <profile id="ce3d-79ee-e9a3-5305" name="Aspiring Champion" hidden="false" profileTypeId="800f-21d0-4387-c943" profileTypeName="Unit">
@@ -13900,72 +14885,9 @@ D3   Bonus
           </constraints>
           <categoryLinks/>
           <selectionEntries/>
-          <selectionEntryGroups>
-            <selectionEntryGroup id="a70f-3483-6514-dd62" name="Bolt pistol options" hidden="false" collective="false" defaultSelectionEntryId="bea8-daaf-36c6-d1f5">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="a07e-0487-bfe5-8677" type="max"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="f1fc-5b06-ee49-0e6b" type="min"/>
-              </constraints>
-              <categoryLinks/>
-              <selectionEntries/>
-              <selectionEntryGroups/>
-              <entryLinks>
-                <entryLink id="bea8-daaf-36c6-d1f5" name="New EntryLink" hidden="false" targetId="0334-f487-8229-0c1a" type="selectionEntry">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                  <constraints/>
-                  <categoryLinks/>
-                </entryLink>
-                <entryLink id="bbc4-2ff1-bbbc-c1e9" name="New EntryLink" hidden="false" targetId="1912-576e-6a2b-5c6e" type="selectionEntryGroup">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                  <constraints/>
-                  <categoryLinks/>
-                </entryLink>
-              </entryLinks>
-            </selectionEntryGroup>
-            <selectionEntryGroup id="a636-f952-6932-df43" name="Boltgun options" hidden="false" collective="false" defaultSelectionEntryId="5087-ca68-c617-1f60">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="9cec-7159-aebd-7efd" type="max"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="8b06-80b1-1434-8b11" type="min"/>
-              </constraints>
-              <categoryLinks/>
-              <selectionEntries/>
-              <selectionEntryGroups/>
-              <entryLinks>
-                <entryLink id="5087-ca68-c617-1f60" name="New EntryLink" hidden="false" targetId="b61f-a3c1-827d-c5b6" type="selectionEntry">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                  <constraints/>
-                  <categoryLinks/>
-                </entryLink>
-                <entryLink id="29a1-b921-ecc6-309f" name="New EntryLink" hidden="false" targetId="1912-576e-6a2b-5c6e" type="selectionEntryGroup">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                  <constraints/>
-                  <categoryLinks/>
-                </entryLink>
-              </entryLinks>
-            </selectionEntryGroup>
-          </selectionEntryGroups>
+          <selectionEntryGroups/>
           <entryLinks>
-            <entryLink id="0e3b-1018-1b02-94a2" name="New EntryLink" hidden="false" targetId="cddf-945e-1335-e681" type="selectionEntry">
+            <entryLink id="0e3b-1018-1b02-94a2" name="Frag &amp; Krak grenades" hidden="false" targetId="cddf-945e-1335-e681" type="selectionEntry">
               <profiles/>
               <rules/>
               <infoLinks/>
@@ -13976,119 +14898,263 @@ D3   Bonus
               </constraints>
               <categoryLinks/>
             </entryLink>
+            <entryLink id="c0c9-733e-4ee2-8bed" name="Champion Equipment" hidden="false" targetId="ad90-3560-ea09-82ef" type="selectionEntryGroup">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8cd0-30c2-1abd-439c" type="max"/>
+                <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="50a7-6628-cfd1-9d92" type="min"/>
+              </constraints>
+              <categoryLinks/>
+            </entryLink>
           </entryLinks>
           <costs>
             <cost name="pts" costTypeId="points" value="13.0"/>
             <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="0.0"/>
           </costs>
         </selectionEntry>
-        <selectionEntry id="74e2-981e-68ab-11cd" name="Swap boltgun for chainsword" hidden="false" collective="false" type="upgrade">
-          <profiles/>
-          <rules/>
-          <infoLinks>
-            <infoLink id="e20c-da00-d230-a3c1" name="New InfoLink" hidden="false" targetId="9b1e-61f9-4a5b-0044" type="profile">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-            </infoLink>
-          </infoLinks>
-          <modifiers>
-            <modifier type="increment" field="9155-8e2e-87f5-6c56" value="1">
-              <repeats>
-                <repeat field="selections" scope="f7d5-82fa-df6a-b9e2" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="model" repeats="1" roundUp="false"/>
-              </repeats>
-              <conditions/>
-              <conditionGroups/>
-            </modifier>
-          </modifiers>
-          <constraints>
-            <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9155-8e2e-87f5-6c56" type="max"/>
-          </constraints>
-          <categoryLinks/>
-          <selectionEntries/>
-          <selectionEntryGroups/>
-          <entryLinks/>
-          <costs>
-            <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="0.0"/>
-            <cost name="pts" costTypeId="points" value="0.0"/>
-          </costs>
-        </selectionEntry>
       </selectionEntries>
       <selectionEntryGroups>
-        <selectionEntryGroup id="b187-eb59-281c-0cb7" name="Heavy or special weapons" hidden="false" collective="false">
+        <selectionEntryGroup id="2d18-d1dc-bffa-bd5d" name="Havocs" hidden="false" collective="false" defaultSelectionEntryId="e3e7-df40-8d06-4655">
           <profiles/>
           <rules/>
           <infoLinks/>
           <modifiers/>
           <constraints>
-            <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="bab3-b3eb-ab27-db54" type="max"/>
+            <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f734-71b2-f47f-d224" type="min"/>
+            <constraint field="selections" scope="parent" value="9.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e60f-1348-ae72-f3a0" type="max"/>
           </constraints>
           <categoryLinks/>
-          <selectionEntries/>
+          <selectionEntries>
+            <selectionEntry id="e3e7-df40-8d06-4655" name="Havoc w/ boltgun" hidden="false" collective="false" type="model">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="9.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="72fc-cabc-6870-038a" type="max"/>
+              </constraints>
+              <categoryLinks/>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks>
+                <entryLink id="3fb7-6e62-ab9c-27c3" name="Frag &amp; Krak grenades" hidden="false" targetId="cddf-945e-1335-e681" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b05a-cff9-c570-c321" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4c43-aee0-44b7-2e44" type="min"/>
+                  </constraints>
+                  <categoryLinks/>
+                </entryLink>
+                <entryLink id="519b-4642-61cf-7283" name="Bolt pistol" hidden="false" targetId="37d3-7098-d596-9948" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="88ec-eb06-9daf-b251" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="26f7-e279-ad9c-43ed" type="min"/>
+                  </constraints>
+                  <categoryLinks/>
+                </entryLink>
+                <entryLink id="271b-d2d6-a97a-bcd1" name="Boltgun" hidden="false" targetId="183a-a319-9ba3-541e" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="993c-7015-4268-f34d" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9fcc-f212-8c61-e417" type="min"/>
+                  </constraints>
+                  <categoryLinks/>
+                </entryLink>
+              </entryLinks>
+              <costs>
+                <cost name="pts" costTypeId="points" value="13.0"/>
+                <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="1765-4976-d2e2-961e" name="Havoc w/ chainsword" hidden="false" collective="false" type="model">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="9.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b3af-f748-b619-11ab" type="max"/>
+              </constraints>
+              <categoryLinks/>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks>
+                <entryLink id="cd4c-96b9-8ee6-d576" name="Frag &amp; Krak grenades" hidden="false" targetId="cddf-945e-1335-e681" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ff30-2c12-40f3-b45c" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b366-ebb0-30b4-b36e" type="min"/>
+                  </constraints>
+                  <categoryLinks/>
+                </entryLink>
+                <entryLink id="90bb-579c-2131-8346" name="Bolt pistol" hidden="false" targetId="37d3-7098-d596-9948" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d5c4-db19-b20c-7e5d" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="19a4-bc0b-9e15-3599" type="min"/>
+                  </constraints>
+                  <categoryLinks/>
+                </entryLink>
+                <entryLink id="daec-a317-151a-e831" name="Chainsword" hidden="false" targetId="4334-d2da-32f5-dc53" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="289c-1438-b66b-984e" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="634c-67c1-d128-114f" type="min"/>
+                  </constraints>
+                  <categoryLinks/>
+                </entryLink>
+              </entryLinks>
+              <costs>
+                <cost name="pts" costTypeId="points" value="13.0"/>
+                <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="d2cc-2897-abf3-2aff" name="Havoc w/ heavy weapon" hidden="false" collective="false" type="model">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers>
+                <modifier type="decrement" field="7979-051b-fb8a-d544" value="1">
+                  <repeats>
+                    <repeat field="selections" scope="f7d5-82fa-df6a-b9e2" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="51fd-e6c0-5fc0-77d8" repeats="1" roundUp="false"/>
+                  </repeats>
+                  <conditions/>
+                  <conditionGroups/>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7979-051b-fb8a-d544" type="max"/>
+              </constraints>
+              <categoryLinks/>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks>
+                <entryLink id="f058-a5e1-2f35-2d5e" name="Frag &amp; Krak grenades" hidden="false" targetId="cddf-945e-1335-e681" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1809-fd77-6709-a7a6" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="590f-d013-5b2a-8a67" type="min"/>
+                  </constraints>
+                  <categoryLinks/>
+                </entryLink>
+                <entryLink id="fbbf-ee6d-10ad-d712" name="Bolt pistol" hidden="false" targetId="37d3-7098-d596-9948" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a44d-a5a7-50a9-c9bf" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3346-43f0-94ae-3b3d" type="min"/>
+                  </constraints>
+                  <categoryLinks/>
+                </entryLink>
+                <entryLink id="e47f-3c6f-dde8-11c2" name="Heavy Weapons" hidden="false" targetId="d16e-f416-d268-b2b4" type="selectionEntryGroup">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9bd7-a465-1f82-faf1" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9386-2370-8d27-337f" type="min"/>
+                  </constraints>
+                  <categoryLinks/>
+                </entryLink>
+              </entryLinks>
+              <costs>
+                <cost name="pts" costTypeId="points" value="13.0"/>
+                <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="51fd-e6c0-5fc0-77d8" name="Havoc w/ special weapon" hidden="false" collective="false" type="model">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers>
+                <modifier type="decrement" field="c4d8-e4fe-8cfc-dcb6" value="1">
+                  <repeats>
+                    <repeat field="selections" scope="f7d5-82fa-df6a-b9e2" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="d2cc-2897-abf3-2aff" repeats="1" roundUp="false"/>
+                  </repeats>
+                  <conditions/>
+                  <conditionGroups/>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c4d8-e4fe-8cfc-dcb6" type="max"/>
+              </constraints>
+              <categoryLinks/>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks>
+                <entryLink id="3e58-8413-dfa7-6a19" name="Frag &amp; Krak grenades" hidden="false" targetId="cddf-945e-1335-e681" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a105-7135-15d0-dc3d" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b702-1890-8bc3-92ff" type="min"/>
+                  </constraints>
+                  <categoryLinks/>
+                </entryLink>
+                <entryLink id="d7f9-5938-864c-232a" name="Bolt pistol" hidden="false" targetId="37d3-7098-d596-9948" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="16fd-e0fc-a40a-a436" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6c28-ef44-795d-3ea5" type="min"/>
+                  </constraints>
+                  <categoryLinks/>
+                </entryLink>
+                <entryLink id="c1ca-1024-7c92-676d" name="Special Weapons" hidden="false" targetId="a44b-4b4d-46b5-d3a6" type="selectionEntryGroup">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b549-fdae-9503-ca2a" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d68b-1f73-3faa-0a28" type="min"/>
+                  </constraints>
+                  <categoryLinks/>
+                </entryLink>
+              </entryLinks>
+              <costs>
+                <cost name="pts" costTypeId="points" value="13.0"/>
+                <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="0.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
           <selectionEntryGroups/>
-          <entryLinks>
-            <entryLink id="b2b4-bac5-51f6-ea6c" name="New EntryLink" hidden="false" targetId="5210-8cb2-b5a2-a04f" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints/>
-              <categoryLinks/>
-            </entryLink>
-            <entryLink id="5639-19fe-da49-6725" name="New EntryLink" hidden="false" targetId="fd22-6743-2d4c-dd62" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints/>
-              <categoryLinks/>
-            </entryLink>
-            <entryLink id="be2a-59f7-9c91-9ec6" name="New EntryLink" hidden="false" targetId="05ab-e7cc-e856-c36f" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints/>
-              <categoryLinks/>
-            </entryLink>
-            <entryLink id="6584-ee97-a762-312b" name="New EntryLink" hidden="false" targetId="a908-4664-11cd-f8b2" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints/>
-              <categoryLinks/>
-            </entryLink>
-            <entryLink id="4351-53ac-6b46-ae97" name="New EntryLink" hidden="false" targetId="efc8-c51d-5b02-a3a2" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints/>
-              <categoryLinks/>
-            </entryLink>
-            <entryLink id="e614-b1f3-0cbc-c7b0" name="New EntryLink" hidden="false" targetId="1469-1964-7a91-94d4" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints/>
-              <categoryLinks/>
-            </entryLink>
-            <entryLink id="bb1b-10c9-57c6-1567" name="New EntryLink" hidden="false" targetId="8c14-22cc-93ce-b85a" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints/>
-              <categoryLinks/>
-            </entryLink>
-          </entryLinks>
+          <entryLinks/>
         </selectionEntryGroup>
       </selectionEntryGroups>
       <entryLinks>
-        <entryLink id="1450-abe4-5154-be96" name="New EntryLink" hidden="false" targetId="f995-21ce-bbe7-f8fe" type="selectionEntryGroup">
+        <entryLink id="1450-abe4-5154-be96" name="Mark of Chaos with Icons" hidden="false" targetId="f995-21ce-bbe7-f8fe" type="selectionEntryGroup">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -14173,10 +15239,27 @@ D3   Bonus
             <characteristic name="Description" characteristicTypeId="21befb24-fc85-4f52-a745-64b2e48f8228" value="Each time a model in this unit is slain, it is driven to make one last attack before succumbing to its injuries. Do not remove the slain model yet, after the attacking unit has finished making all its attacks, the slain model can make a shooting attack with one of its ranged weapons, or throw a grenade, even if the model&apos;s unit is within 1&quot; of the enemy. The slain model is then removed as a casualty as normal."/>
           </characteristics>
         </profile>
+        <profile id="f5f3-601e-e449-a5e6" name="Noise Marine" hidden="false" profileTypeId="800f-21d0-4387-c943" profileTypeName="Unit">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="M" characteristicTypeId="0bdf-a96e-9e38-7779" value="6&quot;"/>
+            <characteristic name="WS" characteristicTypeId="e7f0-1278-0250-df0c" value="3+"/>
+            <characteristic name="BS" characteristicTypeId="381b-eb28-74c3-df5f" value="3+"/>
+            <characteristic name="S" characteristicTypeId="2218-aa3c-265f-2939" value="5"/>
+            <characteristic name="T" characteristicTypeId="9c9f-9774-a358-3a39" value="4"/>
+            <characteristic name="W" characteristicTypeId="f330-5e6e-4110-0978" value="1"/>
+            <characteristic name="A" characteristicTypeId="13fc-b29b-31f2-ab9f" value="2"/>
+            <characteristic name="Ld" characteristicTypeId="00ca-f8b8-876d-b705" value="7"/>
+            <characteristic name="Save" characteristicTypeId="c0df-df94-abd7-e8d3" value="3+"/>
+          </characteristics>
+        </profile>
       </profiles>
       <rules/>
       <infoLinks>
-        <infoLink id="5094-a05c-fb4d-096a" name="New InfoLink" hidden="false" targetId="6349-022a-cea9-524c" type="rule">
+        <infoLink id="5094-a05c-fb4d-096a" name="Death to the False Emperor" hidden="false" targetId="37a4-1d84-4ef0-c4f6" type="profile">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -14220,7 +15303,7 @@ D3   Bonus
       </modifiers>
       <constraints/>
       <categoryLinks>
-        <categoryLink id="c045-1c4c-0fa2-6ba0" name="New CategoryLink" hidden="false" targetId="717b-8863-9d25-5e2a" primary="false">
+        <categoryLink id="c045-1c4c-0fa2-6ba0" name="New CategoryLink" hidden="false" targetId="5cf1-acf2-ca3b-c2e5" primary="false">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -14257,76 +15340,6 @@ D3   Bonus
         </categoryLink>
       </categoryLinks>
       <selectionEntries>
-        <selectionEntry id="0251-0c91-1166-a629" name="Noise Marine" hidden="false" collective="false" type="model">
-          <profiles>
-            <profile id="6598-4bdf-2063-d5e5" name="Noise Marine" hidden="false" profileTypeId="800f-21d0-4387-c943" profileTypeName="Unit">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <characteristics>
-                <characteristic name="M" characteristicTypeId="0bdf-a96e-9e38-7779" value="6&quot;"/>
-                <characteristic name="WS" characteristicTypeId="e7f0-1278-0250-df0c" value="3+"/>
-                <characteristic name="BS" characteristicTypeId="381b-eb28-74c3-df5f" value="3+"/>
-                <characteristic name="S" characteristicTypeId="2218-aa3c-265f-2939" value="5"/>
-                <characteristic name="T" characteristicTypeId="9c9f-9774-a358-3a39" value="4"/>
-                <characteristic name="W" characteristicTypeId="f330-5e6e-4110-0978" value="1"/>
-                <characteristic name="A" characteristicTypeId="13fc-b29b-31f2-ab9f" value="2"/>
-                <characteristic name="Ld" characteristicTypeId="00ca-f8b8-876d-b705" value="7"/>
-                <characteristic name="Save" characteristicTypeId="c0df-df94-abd7-e8d3" value="3+"/>
-              </characteristics>
-            </profile>
-          </profiles>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints>
-            <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="be5d-1eff-efb3-e420" type="min"/>
-            <constraint field="selections" scope="parent" value="19.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c8ee-0848-5109-85bf" type="max"/>
-          </constraints>
-          <categoryLinks/>
-          <selectionEntries/>
-          <selectionEntryGroups/>
-          <entryLinks>
-            <entryLink id="494a-8150-0409-3ce0" name="New EntryLink" hidden="false" targetId="cddf-945e-1335-e681" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2dcc-055a-d61b-0336" type="max"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8822-1dd0-abca-68b2" type="min"/>
-              </constraints>
-              <categoryLinks/>
-            </entryLink>
-            <entryLink id="3780-aa6f-43b8-b56f" name="Bolt pistol" hidden="false" targetId="37d3-7098-d596-9948" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="713f-de4d-c661-ac16" type="max"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ebbe-3a15-c73a-374c" type="min"/>
-              </constraints>
-              <categoryLinks/>
-            </entryLink>
-            <entryLink id="bbb7-e33f-2f4e-abf6" name="New EntryLink" hidden="false" targetId="183a-a319-9ba3-541e" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3b39-1368-8560-5112" type="max"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ec9f-7b31-4849-a728" type="min"/>
-              </constraints>
-              <categoryLinks/>
-            </entryLink>
-          </entryLinks>
-          <costs>
-            <cost name="pts" costTypeId="points" value="16.0"/>
-            <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="0.0"/>
-          </costs>
-        </selectionEntry>
         <selectionEntry id="e87b-9cae-23f5-f2c1" name="Noise Champion" hidden="false" collective="false" type="model">
           <profiles>
             <profile id="4444-9b7a-f41d-f9a7" name="Noise Champion" hidden="false" profileTypeId="800f-21d0-4387-c943" profileTypeName="Unit">
@@ -14355,49 +15368,31 @@ D3   Bonus
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="76b1-eb9e-0e34-3818" type="max"/>
           </constraints>
           <categoryLinks/>
-          <selectionEntries>
-            <selectionEntry id="3af3-e75f-e4f2-ab5f" name="Doom siren" hidden="false" collective="false" type="upgrade">
-              <profiles>
-                <profile id="b94b-c931-3e59-f3da" name="Doom siren" hidden="false" profileTypeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" profileTypeName="Weapon">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                  <characteristics>
-                    <characteristic name="Range" characteristicTypeId="6fa97fa8-ea74-4a27-a0fb-bc4e5f367464" value="8&quot;"/>
-                    <characteristic name="Type" characteristicTypeId="077c342f-d7b9-45c6-b8af-88e97cafd3a2" value="Assault D3"/>
-                    <characteristic name="S" characteristicTypeId="59b1-319e-ec13-d466" value="5"/>
-                    <characteristic name="AP" characteristicTypeId="75aa-a838-b675-6484" value="-2"/>
-                    <characteristic name="D" characteristicTypeId="ae8a-3137-d65b-4ca7" value="1"/>
-                    <characteristic name="Abilities" characteristicTypeId="837d-5e63-aeb7-1410" value="This weapon automatically htis its target. Units targeted by this weapon do not gain any bonus to their saving throws for being in cover."/>
-                  </characteristics>
-                </profile>
-              </profiles>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8809-708b-3653-0e72" type="max"/>
-              </constraints>
-              <categoryLinks/>
-              <selectionEntries/>
-              <selectionEntryGroups/>
-              <entryLinks/>
-              <costs>
-                <cost name="pts" costTypeId="points" value="22.0"/>
-                <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="0.0"/>
-              </costs>
-            </selectionEntry>
-          </selectionEntries>
+          <selectionEntries/>
           <selectionEntryGroups>
-            <selectionEntryGroup id="3330-0169-4452-a772" name="Weapon options" hidden="false" collective="false">
+            <selectionEntryGroup id="3330-0169-4452-a772" name="Weapon options" hidden="false" collective="false" defaultSelectionEntryId="1913-4c76-c716-ead4">
               <profiles/>
               <rules/>
               <infoLinks/>
-              <modifiers/>
+              <modifiers>
+                <modifier type="set" field="c3ce-9a47-43bd-285f" value="2">
+                  <repeats/>
+                  <conditions>
+                    <condition field="selections" scope="e87b-9cae-23f5-f2c1" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7605-aa3a-8857-8ce3" type="atLeast"/>
+                  </conditions>
+                  <conditionGroups/>
+                </modifier>
+                <modifier type="set" field="aea8-0a48-5836-dc8c" value="2">
+                  <repeats/>
+                  <conditions>
+                    <condition field="selections" scope="e87b-9cae-23f5-f2c1" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7605-aa3a-8857-8ce3" type="atLeast"/>
+                  </conditions>
+                  <conditionGroups/>
+                </modifier>
+              </modifiers>
               <constraints>
-                <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="c3ce-9a47-43bd-285f" type="max"/>
-                <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="aea8-0a48-5836-dc8c" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="c3ce-9a47-43bd-285f" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="aea8-0a48-5836-dc8c" type="min"/>
               </constraints>
               <categoryLinks/>
               <selectionEntries>
@@ -14444,7 +15439,7 @@ D3   Bonus
                   </constraints>
                   <categoryLinks/>
                 </entryLink>
-                <entryLink id="7605-aa3a-8857-8ce3" name="Champion Equipment" hidden="false" targetId="1912-576e-6a2b-5c6e" type="selectionEntryGroup">
+                <entryLink id="7605-aa3a-8857-8ce3" name="Champion Equipment" hidden="false" targetId="ad90-3560-ea09-82ef" type="selectionEntryGroup">
                   <profiles/>
                   <rules/>
                   <infoLinks/>
@@ -14467,156 +15462,312 @@ D3   Bonus
               </constraints>
               <categoryLinks/>
             </entryLink>
+            <entryLink id="edfa-e5e0-8c15-8502" name="Doom siren" hidden="false" targetId="bbb0-94d7-d83a-bf45" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+              <categoryLinks/>
+            </entryLink>
           </entryLinks>
           <costs>
             <cost name="pts" costTypeId="points" value="16.0"/>
             <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="0.0"/>
           </costs>
         </selectionEntry>
-        <selectionEntry id="7a1b-ebb7-06bc-8679" name="Replace Boltgun w/ sonic blaster" hidden="false" collective="false" type="upgrade">
-          <profiles>
-            <profile id="d6f6-6967-dc23-4134" name="Sonic blaster" hidden="false" profileTypeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" profileTypeName="Weapon">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <characteristics>
-                <characteristic name="Range" characteristicTypeId="6fa97fa8-ea74-4a27-a0fb-bc4e5f367464" value="24&quot;"/>
-                <characteristic name="Type" characteristicTypeId="077c342f-d7b9-45c6-b8af-88e97cafd3a2" value="Assault 3"/>
-                <characteristic name="S" characteristicTypeId="59b1-319e-ec13-d466" value="4"/>
-                <characteristic name="AP" characteristicTypeId="75aa-a838-b675-6484" value="0"/>
-                <characteristic name="D" characteristicTypeId="ae8a-3137-d65b-4ca7" value="1"/>
-                <characteristic name="Abilities" characteristicTypeId="837d-5e63-aeb7-1410" value="Units targeted by this weapon do not gain any bonus to their saving throws for being in cover."/>
-              </characteristics>
-            </profile>
-          </profiles>
-          <rules/>
-          <infoLinks/>
-          <modifiers>
-            <modifier type="increment" field="0dd6-a17a-acb4-af52" value="1">
-              <repeats>
-                <repeat field="selections" scope="b0d5-1a19-e2b9-d5bc" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0251-0c91-1166-a629" repeats="1" roundUp="false"/>
-              </repeats>
-              <conditions/>
-              <conditionGroups/>
-            </modifier>
-            <modifier type="decrement" field="0dd6-a17a-acb4-af52" value="1">
-              <repeats>
-                <repeat field="selections" scope="b0d5-1a19-e2b9-d5bc" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9a51-fc4b-305a-5fb8" repeats="1" roundUp="false"/>
-              </repeats>
-              <conditions/>
-              <conditionGroups/>
-            </modifier>
-          </modifiers>
-          <constraints>
-            <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="0dd6-a17a-acb4-af52" type="max"/>
-          </constraints>
-          <categoryLinks/>
-          <selectionEntries/>
-          <selectionEntryGroups/>
-          <entryLinks/>
-          <costs>
-            <cost name="pts" costTypeId="points" value="4.0"/>
-            <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="0.0"/>
-          </costs>
-        </selectionEntry>
-        <selectionEntry id="a81c-eca1-2383-5744" name="Replace Boltgun w/ blastmaster" page="0" hidden="false" collective="false" type="upgrade">
-          <profiles>
-            <profile id="6186-0c0f-e8ed-5d4b" name="Blastmaster, Single frequency" hidden="false" profileTypeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" profileTypeName="Weapon">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <characteristics>
-                <characteristic name="Range" characteristicTypeId="6fa97fa8-ea74-4a27-a0fb-bc4e5f367464" value="48&quot;"/>
-                <characteristic name="Type" characteristicTypeId="077c342f-d7b9-45c6-b8af-88e97cafd3a2" value="Heavy D3"/>
-                <characteristic name="S" characteristicTypeId="59b1-319e-ec13-d466" value="8"/>
-                <characteristic name="AP" characteristicTypeId="75aa-a838-b675-6484" value="-2"/>
-                <characteristic name="D" characteristicTypeId="ae8a-3137-d65b-4ca7" value="D3"/>
-                <characteristic name="Abilities" characteristicTypeId="837d-5e63-aeb7-1410" value="Units targeted by this weapon do not gain any bonus to their saving throws for being in cover."/>
-              </characteristics>
-            </profile>
-            <profile id="c13b-c419-1512-8cec" name="Blastmaster, Varied frequency" hidden="false" profileTypeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" profileTypeName="Weapon">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <characteristics>
-                <characteristic name="Range" characteristicTypeId="6fa97fa8-ea74-4a27-a0fb-bc4e5f367464" value="36&quot;"/>
-                <characteristic name="Type" characteristicTypeId="077c342f-d7b9-45c6-b8af-88e97cafd3a2" value="Assault D6"/>
-                <characteristic name="S" characteristicTypeId="59b1-319e-ec13-d466" value="4"/>
-                <characteristic name="AP" characteristicTypeId="75aa-a838-b675-6484" value="-1"/>
-                <characteristic name="D" characteristicTypeId="ae8a-3137-d65b-4ca7" value="1"/>
-                <characteristic name="Abilities" characteristicTypeId="837d-5e63-aeb7-1410" value="Units targeted by this weapon do not gain any bonus to their saving throws for being in cover."/>
-              </characteristics>
-            </profile>
-          </profiles>
-          <rules/>
-          <infoLinks/>
-          <modifiers>
-            <modifier type="set" field="6bc2-c1fc-9b55-48ca" value="2">
-              <repeats/>
-              <conditions>
-                <condition field="selections" scope="b0d5-1a19-e2b9-d5bc" value="9.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0251-0c91-1166-a629" type="atLeast"/>
-              </conditions>
-              <conditionGroups/>
-            </modifier>
-          </modifiers>
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="6bc2-c1fc-9b55-48ca" type="max"/>
-          </constraints>
-          <categoryLinks/>
-          <selectionEntries/>
-          <selectionEntryGroups/>
-          <entryLinks/>
-          <costs>
-            <cost name="pts" costTypeId="points" value="28.0"/>
-            <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="0.0"/>
-          </costs>
-        </selectionEntry>
-        <selectionEntry id="9a51-fc4b-305a-5fb8" name="Replace Boltgun w/ chainsword" hidden="false" collective="false" type="upgrade">
+      </selectionEntries>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="6a1b-b972-7ca0-854c" name="Noise Marines" hidden="false" collective="false" defaultSelectionEntryId="8d98-59a4-6f96-f2d2">
           <profiles/>
           <rules/>
-          <infoLinks>
-            <infoLink id="f927-6cbc-0373-83a8" name="New InfoLink" hidden="false" targetId="9b1e-61f9-4a5b-0044" type="profile">
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1464-29c9-d1b5-086f" type="min"/>
+            <constraint field="selections" scope="parent" value="19.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0dce-f140-356a-f0b2" type="max"/>
+          </constraints>
+          <categoryLinks/>
+          <selectionEntries>
+            <selectionEntry id="8d98-59a4-6f96-f2d2" name="Marine w/ boltgun" hidden="false" collective="false" type="model">
               <profiles/>
               <rules/>
               <infoLinks/>
               <modifiers/>
-            </infoLink>
-          </infoLinks>
-          <modifiers>
-            <modifier type="increment" field="8236-2ee2-ff30-ea20" value="1">
-              <repeats>
-                <repeat field="selections" scope="b0d5-1a19-e2b9-d5bc" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0251-0c91-1166-a629" repeats="1" roundUp="false"/>
-              </repeats>
-              <conditions/>
-              <conditionGroups/>
-            </modifier>
-            <modifier type="decrement" field="8236-2ee2-ff30-ea20" value="1">
-              <repeats>
-                <repeat field="selections" scope="b0d5-1a19-e2b9-d5bc" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7a1b-ebb7-06bc-8679" repeats="1" roundUp="false"/>
-              </repeats>
-              <conditions/>
-              <conditionGroups/>
-            </modifier>
-          </modifiers>
-          <constraints>
-            <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="8236-2ee2-ff30-ea20" type="max"/>
-          </constraints>
-          <categoryLinks/>
-          <selectionEntries/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="19.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="517a-3a1a-8fad-dc1c" type="max"/>
+              </constraints>
+              <categoryLinks/>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks>
+                <entryLink id="a40a-9d48-2f01-575c" name="Frag &amp; Krak grenades" hidden="false" targetId="cddf-945e-1335-e681" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="aefe-1a67-febe-a2b5" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="98ec-9f57-6c06-b1d2" type="min"/>
+                  </constraints>
+                  <categoryLinks/>
+                </entryLink>
+                <entryLink id="86a7-4831-b9da-9abe" name="Bolt pistol" hidden="false" targetId="37d3-7098-d596-9948" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3984-77c6-acc2-8a1d" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2099-b411-0f53-8697" type="min"/>
+                  </constraints>
+                  <categoryLinks/>
+                </entryLink>
+                <entryLink id="c017-5382-b856-63e8" name="New EntryLink" hidden="false" targetId="183a-a319-9ba3-541e" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="61a9-d2ce-28ca-aab0" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a00a-8119-fd54-4fe8" type="min"/>
+                  </constraints>
+                  <categoryLinks/>
+                </entryLink>
+              </entryLinks>
+              <costs>
+                <cost name="pts" costTypeId="points" value="16.0"/>
+                <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="95ca-f802-a2ee-abbf" name="Marine w/ chainsword" hidden="false" collective="false" type="model">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="19.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4cb2-3795-3c25-8d6c" type="max"/>
+              </constraints>
+              <categoryLinks/>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks>
+                <entryLink id="d9c0-0e8b-f8e6-5c63" name="Bolt pistol" hidden="false" targetId="37d3-7098-d596-9948" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0c5b-d040-1b36-9795" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ece6-eb4a-c072-d22c" type="min"/>
+                  </constraints>
+                  <categoryLinks/>
+                </entryLink>
+                <entryLink id="8ba2-4892-b028-aac7" name="Frag &amp; Krak grenades" hidden="false" targetId="cddf-945e-1335-e681" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1b6b-a327-d077-72c3" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6bc0-e95d-5065-7b5a" type="min"/>
+                  </constraints>
+                  <categoryLinks/>
+                </entryLink>
+                <entryLink id="836c-89ff-cc16-b1b5" name="Chainsword" hidden="false" targetId="704f-026f-22fd-89d5" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7b2d-0b04-d3c4-9e03" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4573-4283-bf8d-e60c" type="min"/>
+                  </constraints>
+                  <categoryLinks/>
+                </entryLink>
+              </entryLinks>
+              <costs>
+                <cost name="pts" costTypeId="points" value="16.0"/>
+                <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="9e4e-866c-0b2c-def4" name="Marine w/ Sonic blaster" hidden="false" collective="false" type="model">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="19.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ac8d-9c3f-eaa0-493d" type="max"/>
+              </constraints>
+              <categoryLinks/>
+              <selectionEntries>
+                <selectionEntry id="6950-788e-09c8-1177" name="Sonic Blaster" hidden="false" collective="true" type="upgrade">
+                  <profiles>
+                    <profile id="b050-a95f-8336-81d0" name="Sonic Blaster" hidden="false" profileTypeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" profileTypeName="Weapon">
+                      <profiles/>
+                      <rules/>
+                      <infoLinks/>
+                      <modifiers/>
+                      <characteristics>
+                        <characteristic name="Range" characteristicTypeId="6fa97fa8-ea74-4a27-a0fb-bc4e5f367464" value="24&quot;"/>
+                        <characteristic name="Type" characteristicTypeId="077c342f-d7b9-45c6-b8af-88e97cafd3a2" value="Assault 3"/>
+                        <characteristic name="S" characteristicTypeId="59b1-319e-ec13-d466" value="4"/>
+                        <characteristic name="AP" characteristicTypeId="75aa-a838-b675-6484" value="0"/>
+                        <characteristic name="D" characteristicTypeId="ae8a-3137-d65b-4ca7" value="1"/>
+                        <characteristic name="Abilities" characteristicTypeId="837d-5e63-aeb7-1410" value="Units targeted by this weapon do not gain any bonus to their saving throws for being in cover."/>
+                      </characteristics>
+                    </profile>
+                  </profiles>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7f29-93e9-e711-0fbc" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="52c9-573c-ceca-4739" type="min"/>
+                  </constraints>
+                  <categoryLinks/>
+                  <selectionEntries/>
+                  <selectionEntryGroups/>
+                  <entryLinks/>
+                  <costs>
+                    <cost name="pts" costTypeId="points" value="4.0"/>
+                    <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="0.0"/>
+                  </costs>
+                </selectionEntry>
+              </selectionEntries>
+              <selectionEntryGroups/>
+              <entryLinks>
+                <entryLink id="59c2-2823-e568-c0ed" name="Bolt pistol" hidden="false" targetId="37d3-7098-d596-9948" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="da44-2960-ecb3-c5dd" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1987-43c5-c566-212e" type="min"/>
+                  </constraints>
+                  <categoryLinks/>
+                </entryLink>
+                <entryLink id="b0bc-9ebd-3254-95c6" name="Frag &amp; Krak grenades" hidden="false" targetId="cddf-945e-1335-e681" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ae27-94f6-b6ab-b972" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="950e-a475-4f97-c94d" type="min"/>
+                  </constraints>
+                  <categoryLinks/>
+                </entryLink>
+              </entryLinks>
+              <costs>
+                <cost name="pts" costTypeId="points" value="16.0"/>
+                <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="9d86-8fb4-061f-571c" name="Marine w/ Blastmaster" hidden="false" collective="false" type="model">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers>
+                <modifier type="increment" field="31bd-16d7-db20-2705" value="1">
+                  <repeats/>
+                  <conditions>
+                    <condition field="selections" scope="b0d5-1a19-e2b9-d5bc" value="10.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="model" type="atLeast"/>
+                  </conditions>
+                  <conditionGroups/>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="31bd-16d7-db20-2705" type="max"/>
+              </constraints>
+              <categoryLinks/>
+              <selectionEntries>
+                <selectionEntry id="ba62-aaea-050f-870c" name="Blastmaster" hidden="false" collective="true" type="upgrade">
+                  <profiles>
+                    <profile id="ed1c-819b-4df9-cad0" name="Blastmaster, Single frequency" hidden="false" profileTypeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" profileTypeName="Weapon">
+                      <profiles/>
+                      <rules/>
+                      <infoLinks/>
+                      <modifiers/>
+                      <characteristics>
+                        <characteristic name="Range" characteristicTypeId="6fa97fa8-ea74-4a27-a0fb-bc4e5f367464" value="48&quot;"/>
+                        <characteristic name="Type" characteristicTypeId="077c342f-d7b9-45c6-b8af-88e97cafd3a2" value="Heavy D3"/>
+                        <characteristic name="S" characteristicTypeId="59b1-319e-ec13-d466" value="8"/>
+                        <characteristic name="AP" characteristicTypeId="75aa-a838-b675-6484" value="-2"/>
+                        <characteristic name="D" characteristicTypeId="ae8a-3137-d65b-4ca7" value="D3"/>
+                        <characteristic name="Abilities" characteristicTypeId="837d-5e63-aeb7-1410" value="Units targeted by this weapon do not gain any bonus to their saving throws for being in cover."/>
+                      </characteristics>
+                    </profile>
+                    <profile id="1fb2-1561-ff83-020c" name="Blastmaster, Varied frequency" hidden="false" profileTypeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" profileTypeName="Weapon">
+                      <profiles/>
+                      <rules/>
+                      <infoLinks/>
+                      <modifiers/>
+                      <characteristics>
+                        <characteristic name="Range" characteristicTypeId="6fa97fa8-ea74-4a27-a0fb-bc4e5f367464" value="36&quot;"/>
+                        <characteristic name="Type" characteristicTypeId="077c342f-d7b9-45c6-b8af-88e97cafd3a2" value="Assault D6"/>
+                        <characteristic name="S" characteristicTypeId="59b1-319e-ec13-d466" value="4"/>
+                        <characteristic name="AP" characteristicTypeId="75aa-a838-b675-6484" value="-1"/>
+                        <characteristic name="D" characteristicTypeId="ae8a-3137-d65b-4ca7" value="1"/>
+                        <characteristic name="Abilities" characteristicTypeId="837d-5e63-aeb7-1410" value="Units targeted by this weapon do not gain any bonus to their saving throws for being in cover."/>
+                      </characteristics>
+                    </profile>
+                  </profiles>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="30e1-e15e-2eb6-b21a" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1e19-4c8b-024e-b830" type="min"/>
+                  </constraints>
+                  <categoryLinks/>
+                  <selectionEntries/>
+                  <selectionEntryGroups/>
+                  <entryLinks/>
+                  <costs>
+                    <cost name="pts" costTypeId="points" value="28.0"/>
+                    <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="0.0"/>
+                  </costs>
+                </selectionEntry>
+              </selectionEntries>
+              <selectionEntryGroups/>
+              <entryLinks>
+                <entryLink id="7d34-49d2-ae34-1cee" name="Frag &amp; Krak grenades" hidden="false" targetId="cddf-945e-1335-e681" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="218b-1b80-7b49-7873" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="14cf-6fc4-29f2-03f9" type="min"/>
+                  </constraints>
+                  <categoryLinks/>
+                </entryLink>
+                <entryLink id="1de5-d288-b2c4-2b92" name="Bolt pistol" hidden="false" targetId="37d3-7098-d596-9948" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2c00-f027-5208-9c9c" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="56bb-4b35-bac7-a664" type="min"/>
+                  </constraints>
+                  <categoryLinks/>
+                </entryLink>
+              </entryLinks>
+              <costs>
+                <cost name="pts" costTypeId="points" value="16.0"/>
+                <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="0.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
           <selectionEntryGroups/>
           <entryLinks/>
-          <costs>
-            <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="0.0"/>
-            <cost name="pts" costTypeId="points" value="0.0"/>
-          </costs>
-        </selectionEntry>
-      </selectionEntries>
-      <selectionEntryGroups/>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
       <entryLinks>
-        <entryLink id="9320-b450-c45e-3b12" name="New EntryLink" hidden="false" targetId="5b82-0948-eac4-b35f" type="selectionEntry">
+        <entryLink id="9320-b450-c45e-3b12" name="Icon of Excess" hidden="false" targetId="5b82-0948-eac4-b35f" type="selectionEntry">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -14638,21 +15789,36 @@ D3   Bonus
           <infoLinks/>
           <modifiers/>
           <characteristics>
-            <characteristic name="Description" characteristicTypeId="21befb24-fc85-4f52-a745-64b2e48f8228" value="All models in this unit have a 5++."/>
+            <characteristic name="Description" characteristicTypeId="21befb24-fc85-4f52-a745-64b2e48f8228" value="All models in this unit have a 5+ invulnerable save."/>
           </characteristics>
         </profile>
-      </profiles>
-      <rules>
-        <rule id="65f0-89ea-e91b-759c" name="All is Dust" hidden="false">
+        <profile id="1c10-0c20-681d-d1cc" name="Rubric Marine" page="0" hidden="false" profileTypeId="800f-21d0-4387-c943" profileTypeName="Unit">
           <profiles/>
           <rules/>
           <infoLinks/>
           <modifiers/>
-          <description>Add 1 to the saving throws for Rubric Marines if the attack has a Damage characteristic of 1. In addition, the -1 modifier to hit rolls for moving and shooting with a Heavy weapon does not apply to Rubric Marines.</description>
-        </rule>
-      </rules>
+          <characteristics>
+            <characteristic name="M" characteristicTypeId="0bdf-a96e-9e38-7779" value="5&quot;"/>
+            <characteristic name="WS" characteristicTypeId="e7f0-1278-0250-df0c" value="3+"/>
+            <characteristic name="BS" characteristicTypeId="381b-eb28-74c3-df5f" value="3+"/>
+            <characteristic name="S" characteristicTypeId="2218-aa3c-265f-2939" value="4"/>
+            <characteristic name="T" characteristicTypeId="9c9f-9774-a358-3a39" value="4"/>
+            <characteristic name="W" characteristicTypeId="f330-5e6e-4110-0978" value="1"/>
+            <characteristic name="A" characteristicTypeId="13fc-b29b-31f2-ab9f" value="1"/>
+            <characteristic name="Ld" characteristicTypeId="00ca-f8b8-876d-b705" value="7"/>
+            <characteristic name="Save" characteristicTypeId="c0df-df94-abd7-e8d3" value="3+"/>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules/>
       <infoLinks>
-        <infoLink id="001d-59f6-0b85-3014" name="New InfoLink" hidden="false" targetId="6349-022a-cea9-524c" type="rule">
+        <infoLink id="001d-59f6-0b85-3014" name="Death to the False Emperor" hidden="false" targetId="37a4-1d84-4ef0-c4f6" type="profile">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="0331-f941-ec03-dc7e" name="All is Dust" hidden="false" targetId="11c7-1054-a93c-c0b5" type="profile">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -14704,7 +15870,7 @@ D3   Bonus
           <modifiers/>
           <constraints/>
         </categoryLink>
-        <categoryLink id="7fd4-e8e5-bac5-1d41" name="New CategoryLink" hidden="false" targetId="717b-8863-9d25-5e2a" primary="false">
+        <categoryLink id="7fd4-e8e5-bac5-1d41" name="New CategoryLink" hidden="false" targetId="5cf1-acf2-ca3b-c2e5" primary="false">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -14760,16 +15926,16 @@ D3   Bonus
                 <characteristic name="Save" characteristicTypeId="c0df-df94-abd7-e8d3" value="3+"/>
               </characteristics>
             </profile>
-            <profile id="f2ed-e825-461d-a0e0" name="Aspiring Sorcerer" hidden="false" profileTypeId="bc97-dea9-9e88-bb7d" profileTypeName="Psyker">
+            <profile id="3457-3122-748a-e81a" name="Aspiring Sorcerer" hidden="false" profileTypeId="bc97-dea9-9e88-bb7d" profileTypeName="Psyker">
               <profiles/>
               <rules/>
               <infoLinks/>
               <modifiers/>
               <characteristics>
-                <characteristic name="Cast" characteristicTypeId="5afb-9914-904b-d3b3" value="An Aspiring Sorcerer can attempt to manifest one psychic power in each friendly Psychic phase, and attempt to deny one psychic power in each enemy Psychic phase. He knows the Smite psychic power. When an Aspiring Sorcerer manifests the Smite psychic power, he inflicts 1 MW instead of D3, or D3 MW instead of D6 if the result of the Psychic test is 10 or more."/>
-                <characteristic name="Deny" characteristicTypeId="b5ac-9c20-5d5a-6f9b"/>
-                <characteristic name="Powers Known" characteristicTypeId="69d7-b45e-00a2-7e46"/>
-                <characteristic name="Other" characteristicTypeId="c2e2-f115-0003-5d7b"/>
+                <characteristic name="Cast" characteristicTypeId="5afb-9914-904b-d3b3" value="1"/>
+                <characteristic name="Deny" characteristicTypeId="b5ac-9c20-5d5a-6f9b" value="1"/>
+                <characteristic name="Powers Known" characteristicTypeId="69d7-b45e-00a2-7e46" value="Smite"/>
+                <characteristic name="Other" characteristicTypeId="c2e2-f115-0003-5d7b" value="When an Aspiring Sorcerer manifests the Smite psychic power, he inflicts 1 mortal wound instead of D3, and D3 mortal wounds instead of D6 if the Psychic Test is 10 or more."/>
               </characteristics>
             </profile>
           </profiles>
@@ -14781,7 +15947,38 @@ D3   Bonus
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="45ad-9a8f-0d38-c59b" type="max"/>
           </constraints>
           <categoryLinks/>
-          <selectionEntries/>
+          <selectionEntries>
+            <selectionEntry id="7a00-c672-86ed-7921" name="Smite" hidden="false" collective="false" type="upgrade">
+              <profiles>
+                <profile id="5892-bb4e-dd82-2ae1" name="Smite" hidden="false" profileTypeId="ae70-4738-0161-bec0" profileTypeName="Psychic Power">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <characteristics>
+                    <characteristic name="Warp Charge" characteristicTypeId="5ffd-b800-c317-532a" value="5"/>
+                    <characteristic name="Range" characteristicTypeId="fd64-cbc4-94de-24cc" value="18&quot;"/>
+                    <characteristic name="Details" characteristicTypeId="ad96-dfa4-b4ed-656d" value="If manifested, the closest visible enemy unit within 18&quot; of the psyker suffers 1 mortal wound. If the result of the Psychic test was more than 10 the target suffers D3 mortal wounds instead."/>
+                  </characteristics>
+                </profile>
+              </profiles>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="52a5-36d9-748f-0560" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7237-270f-b928-ec84" type="min"/>
+              </constraints>
+              <categoryLinks/>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks/>
+              <costs>
+                <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="0.0"/>
+                <cost name="pts" costTypeId="points" value="0.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
           <selectionEntryGroups>
             <selectionEntryGroup id="a5f6-ea13-a015-07cc" name="Pistol" hidden="false" collective="false" defaultSelectionEntryId="2f71-9f4a-ff83-8312">
               <profiles/>
@@ -14904,165 +16101,181 @@ D3   Bonus
             <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="0.0"/>
           </costs>
         </selectionEntry>
-        <selectionEntry id="b6a1-4c62-0f9d-e853" name="Rubric Marine" page="" hidden="false" collective="false" type="model">
-          <profiles>
-            <profile id="e596-3419-2a5a-e08b" name="Rubric Marine" page="0" hidden="false" profileTypeId="800f-21d0-4387-c943" profileTypeName="Unit">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <characteristics>
-                <characteristic name="M" characteristicTypeId="0bdf-a96e-9e38-7779" value="5&quot;"/>
-                <characteristic name="WS" characteristicTypeId="e7f0-1278-0250-df0c" value="3+"/>
-                <characteristic name="BS" characteristicTypeId="381b-eb28-74c3-df5f" value="3+"/>
-                <characteristic name="S" characteristicTypeId="2218-aa3c-265f-2939" value="4"/>
-                <characteristic name="T" characteristicTypeId="9c9f-9774-a358-3a39" value="4"/>
-                <characteristic name="W" characteristicTypeId="f330-5e6e-4110-0978" value="1"/>
-                <characteristic name="A" characteristicTypeId="13fc-b29b-31f2-ab9f" value="1"/>
-                <characteristic name="Ld" characteristicTypeId="00ca-f8b8-876d-b705" value="7"/>
-                <characteristic name="Save" characteristicTypeId="c0df-df94-abd7-e8d3" value="3+"/>
-              </characteristics>
-            </profile>
-          </profiles>
+      </selectionEntries>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="5391-392f-dfa5-4144" name="Rubric Marines" hidden="false" collective="false">
+          <profiles/>
           <rules/>
           <infoLinks/>
           <modifiers/>
           <constraints>
-            <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="965e-d038-1315-1e9d" type="min"/>
-            <constraint field="selections" scope="parent" value="19.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="e480-6a25-02b5-7bc6" type="max"/>
+            <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="7f7d-f574-bfc1-faa8" type="min"/>
+            <constraint field="selections" scope="parent" value="19.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="14a0-669e-c264-33a6" type="max"/>
           </constraints>
           <categoryLinks/>
           <selectionEntries>
-            <selectionEntry id="0a3f-9a37-7519-b6db" name="Inferno boltgun" hidden="false" collective="true" type="upgrade">
-              <profiles>
-                <profile id="61cc-e78a-bf01-b35a" name="Inferno boltgun" hidden="false" profileTypeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" profileTypeName="Weapon">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                  <characteristics>
-                    <characteristic name="Range" characteristicTypeId="6fa97fa8-ea74-4a27-a0fb-bc4e5f367464" value="24&quot;"/>
-                    <characteristic name="Type" characteristicTypeId="077c342f-d7b9-45c6-b8af-88e97cafd3a2" value="Rapid Fire 1"/>
-                    <characteristic name="S" characteristicTypeId="59b1-319e-ec13-d466" value="4"/>
-                    <characteristic name="AP" characteristicTypeId="75aa-a838-b675-6484" value="-2"/>
-                    <characteristic name="D" characteristicTypeId="ae8a-3137-d65b-4ca7" value="1"/>
-                    <characteristic name="Abilities" characteristicTypeId="837d-5e63-aeb7-1410" value="-"/>
-                  </characteristics>
-                </profile>
-              </profiles>
+            <selectionEntry id="e9f5-a48a-97dc-7215" name="Rubric Marine w/ Inferno Boltgun" page="" hidden="false" collective="false" type="model">
+              <profiles/>
               <rules/>
               <infoLinks/>
               <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5761-babc-f179-0a34" type="max"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c131-7771-e880-5ce8" type="min"/>
-              </constraints>
+              <constraints/>
               <categoryLinks/>
-              <selectionEntries/>
+              <selectionEntries>
+                <selectionEntry id="13fd-2d34-6db9-ff8d" name="Inferno boltgun" hidden="false" collective="true" type="upgrade">
+                  <profiles>
+                    <profile id="fce7-4e91-3368-3cf8" name="Inferno boltgun" hidden="false" profileTypeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" profileTypeName="Weapon">
+                      <profiles/>
+                      <rules/>
+                      <infoLinks/>
+                      <modifiers/>
+                      <characteristics>
+                        <characteristic name="Range" characteristicTypeId="6fa97fa8-ea74-4a27-a0fb-bc4e5f367464" value="24&quot;"/>
+                        <characteristic name="Type" characteristicTypeId="077c342f-d7b9-45c6-b8af-88e97cafd3a2" value="Rapid Fire 1"/>
+                        <characteristic name="S" characteristicTypeId="59b1-319e-ec13-d466" value="4"/>
+                        <characteristic name="AP" characteristicTypeId="75aa-a838-b675-6484" value="-2"/>
+                        <characteristic name="D" characteristicTypeId="ae8a-3137-d65b-4ca7" value="1"/>
+                        <characteristic name="Abilities" characteristicTypeId="837d-5e63-aeb7-1410" value="-"/>
+                      </characteristics>
+                    </profile>
+                  </profiles>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e7b1-e435-0723-6baa" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3653-4306-bf0f-348a" type="min"/>
+                  </constraints>
+                  <categoryLinks/>
+                  <selectionEntries/>
+                  <selectionEntryGroups/>
+                  <entryLinks/>
+                  <costs>
+                    <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="0.0"/>
+                    <cost name="pts" costTypeId="points" value="2.0"/>
+                  </costs>
+                </selectionEntry>
+              </selectionEntries>
               <selectionEntryGroups/>
               <entryLinks/>
               <costs>
+                <cost name="pts" costTypeId="points" value="18.0"/>
                 <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="0.0"/>
-                <cost name="pts" costTypeId="points" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="0227-2007-657b-964f" name="Rubric Marine w/ Warpflamer" hidden="false" collective="false" type="model">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+              <categoryLinks/>
+              <selectionEntries>
+                <selectionEntry id="7f6f-980d-ce75-a9cb" name="Warpflamer" hidden="false" collective="true" type="upgrade">
+                  <profiles>
+                    <profile id="91d9-54b3-fc51-488c" name="Warpflamer" hidden="false" profileTypeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" profileTypeName="Weapon">
+                      <profiles/>
+                      <rules/>
+                      <infoLinks/>
+                      <modifiers/>
+                      <characteristics>
+                        <characteristic name="Range" characteristicTypeId="6fa97fa8-ea74-4a27-a0fb-bc4e5f367464" value="8&quot;"/>
+                        <characteristic name="Type" characteristicTypeId="077c342f-d7b9-45c6-b8af-88e97cafd3a2" value="Assault D6"/>
+                        <characteristic name="S" characteristicTypeId="59b1-319e-ec13-d466" value="4"/>
+                        <characteristic name="AP" characteristicTypeId="75aa-a838-b675-6484" value="-2"/>
+                        <characteristic name="D" characteristicTypeId="ae8a-3137-d65b-4ca7" value="1"/>
+                        <characteristic name="Abilities" characteristicTypeId="837d-5e63-aeb7-1410" value="This weapon automatically hits its target."/>
+                      </characteristics>
+                    </profile>
+                  </profiles>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="0df8-7bef-9e83-6dc1" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9b8f-82ff-8ecd-9cae" type="min"/>
+                  </constraints>
+                  <categoryLinks/>
+                  <selectionEntries/>
+                  <selectionEntryGroups/>
+                  <entryLinks/>
+                  <costs>
+                    <cost name="pts" costTypeId="points" value="13.0"/>
+                    <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="0.0"/>
+                  </costs>
+                </selectionEntry>
+              </selectionEntries>
+              <selectionEntryGroups/>
+              <entryLinks/>
+              <costs>
+                <cost name="pts" costTypeId="points" value="18.0"/>
+                <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="9407-c7b1-3a2f-91f5" name="Rubric Marine w/ Soulreaper cannon" hidden="false" collective="false" type="model">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers>
+                <modifier type="increment" field="b04c-a430-81c8-8790" value="1">
+                  <repeats>
+                    <repeat field="selections" scope="bf56-7051-d9a1-621b" value="10.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="model" repeats="1" roundUp="false"/>
+                  </repeats>
+                  <conditions/>
+                  <conditionGroups/>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="b04c-a430-81c8-8790" type="max"/>
+              </constraints>
+              <categoryLinks/>
+              <selectionEntries>
+                <selectionEntry id="d70e-75fb-e9ff-c4d3" name="Soulreaper cannon" hidden="false" collective="true" type="upgrade">
+                  <profiles>
+                    <profile id="e945-38cb-3007-9e4f" name="Soulreaper Cannon" hidden="false" profileTypeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" profileTypeName="Weapon">
+                      <profiles/>
+                      <rules/>
+                      <infoLinks/>
+                      <modifiers/>
+                      <characteristics>
+                        <characteristic name="Range" characteristicTypeId="6fa97fa8-ea74-4a27-a0fb-bc4e5f367464" value="24&quot;"/>
+                        <characteristic name="Type" characteristicTypeId="077c342f-d7b9-45c6-b8af-88e97cafd3a2" value="Heavy 4"/>
+                        <characteristic name="S" characteristicTypeId="59b1-319e-ec13-d466" value="5"/>
+                        <characteristic name="AP" characteristicTypeId="75aa-a838-b675-6484" value="-3"/>
+                        <characteristic name="D" characteristicTypeId="ae8a-3137-d65b-4ca7" value="1"/>
+                        <characteristic name="Abilities" characteristicTypeId="837d-5e63-aeb7-1410" value="-"/>
+                      </characteristics>
+                    </profile>
+                  </profiles>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6409-15b6-55e3-5b96" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0575-d6e7-56ba-4450" type="min"/>
+                  </constraints>
+                  <categoryLinks/>
+                  <selectionEntries/>
+                  <selectionEntryGroups/>
+                  <entryLinks/>
+                  <costs>
+                    <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="0.0"/>
+                    <cost name="pts" costTypeId="points" value="0.0"/>
+                  </costs>
+                </selectionEntry>
+              </selectionEntries>
+              <selectionEntryGroups/>
+              <entryLinks/>
+              <costs>
+                <cost name="pts" costTypeId="points" value="18.0"/>
+                <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
           <selectionEntryGroups/>
           <entryLinks/>
-          <costs>
-            <cost name="pts" costTypeId="points" value="18.0"/>
-            <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="0.0"/>
-          </costs>
-        </selectionEntry>
-        <selectionEntry id="dae8-440d-dc2e-f0ad" name="Replace inferno boltgun with warpflamer" hidden="false" collective="false" type="upgrade">
-          <profiles>
-            <profile id="4c48-e3fe-ceb8-071a" name="Warpflamer" hidden="false" profileTypeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" profileTypeName="Weapon">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <characteristics>
-                <characteristic name="Range" characteristicTypeId="6fa97fa8-ea74-4a27-a0fb-bc4e5f367464" value="8&quot;"/>
-                <characteristic name="Type" characteristicTypeId="077c342f-d7b9-45c6-b8af-88e97cafd3a2" value="Assault D6"/>
-                <characteristic name="S" characteristicTypeId="59b1-319e-ec13-d466" value="4"/>
-                <characteristic name="AP" characteristicTypeId="75aa-a838-b675-6484" value="-2"/>
-                <characteristic name="D" characteristicTypeId="ae8a-3137-d65b-4ca7" value="1"/>
-                <characteristic name="Abilities" characteristicTypeId="837d-5e63-aeb7-1410" value="This weapon automatically hits its target."/>
-              </characteristics>
-            </profile>
-          </profiles>
-          <rules/>
-          <infoLinks/>
-          <modifiers>
-            <modifier type="increment" field="458d-7560-8305-b8a4" value="1">
-              <repeats>
-                <repeat field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b6a1-4c62-0f9d-e853" repeats="1" roundUp="false"/>
-              </repeats>
-              <conditions/>
-              <conditionGroups/>
-            </modifier>
-          </modifiers>
-          <constraints>
-            <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="458d-7560-8305-b8a4" type="max"/>
-          </constraints>
-          <categoryLinks/>
-          <selectionEntries/>
-          <selectionEntryGroups/>
-          <entryLinks/>
-          <costs>
-            <cost name="pts" costTypeId="points" value="13.0"/>
-            <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="0.0"/>
-          </costs>
-        </selectionEntry>
-        <selectionEntry id="db43-502f-613b-64e7" name="Replace inferno boltgun with soulreaper cannon" hidden="false" collective="false" type="upgrade">
-          <profiles>
-            <profile id="8434-9e82-ec5a-2b40" name="Soulreaper Cannon" hidden="false" profileTypeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" profileTypeName="Weapon">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <characteristics>
-                <characteristic name="Range" characteristicTypeId="6fa97fa8-ea74-4a27-a0fb-bc4e5f367464" value="24&quot;"/>
-                <characteristic name="Type" characteristicTypeId="077c342f-d7b9-45c6-b8af-88e97cafd3a2" value="Heavy 4"/>
-                <characteristic name="S" characteristicTypeId="59b1-319e-ec13-d466" value="5"/>
-                <characteristic name="AP" characteristicTypeId="75aa-a838-b675-6484" value="-3"/>
-                <characteristic name="D" characteristicTypeId="ae8a-3137-d65b-4ca7" value="1"/>
-                <characteristic name="Abilities" characteristicTypeId="837d-5e63-aeb7-1410" value="-"/>
-              </characteristics>
-            </profile>
-          </profiles>
-          <rules/>
-          <infoLinks/>
-          <modifiers>
-            <modifier type="increment" field="14fb-b79f-fa8c-ec0e" value="1">
-              <repeats>
-                <repeat field="selections" scope="bf56-7051-d9a1-621b" value="10.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="model" repeats="1" roundUp="false"/>
-              </repeats>
-              <conditions/>
-              <conditionGroups/>
-            </modifier>
-            <modifier type="set" field="hidden" value="true">
-              <repeats/>
-              <conditions>
-                <condition field="selections" scope="bf56-7051-d9a1-621b" value="10.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="model" type="lessThan"/>
-              </conditions>
-              <conditionGroups/>
-            </modifier>
-          </modifiers>
-          <constraints>
-            <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="14fb-b79f-fa8c-ec0e" type="max"/>
-          </constraints>
-          <categoryLinks/>
-          <selectionEntries/>
-          <selectionEntryGroups/>
-          <entryLinks/>
-          <costs>
-            <cost name="pts" costTypeId="points" value="18.0"/>
-            <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="0.0"/>
-          </costs>
-        </selectionEntry>
-      </selectionEntries>
-      <selectionEntryGroups/>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
       <entryLinks>
         <entryLink id="eec0-cb3b-3f6f-68e2" name="New EntryLink" hidden="false" targetId="0844-29e7-5ca3-1b56" type="selectionEntry">
           <profiles/>
@@ -15171,7 +16384,7 @@ D3   Bonus
           <infoLinks/>
           <modifiers/>
           <characteristics>
-            <characteristic name="Description" characteristicTypeId="21befb24-fc85-4f52-a745-64b2e48f8228" value="Enemy units within 1&quot; of any Chaos Spawn must subtract 1 from their Ld."/>
+            <characteristic name="Description" characteristicTypeId="21befb24-fc85-4f52-a745-64b2e48f8228" value="Enemy units within 1&quot; of any Chaos Spawn must subtract 1 from their Leadership."/>
           </characteristics>
         </profile>
         <profile id="1d6c-d177-7ebb-9e37" name="Mutated Beyond Reason" hidden="false" profileTypeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" profileTypeName="Abilities">
@@ -15180,7 +16393,37 @@ D3   Bonus
           <infoLinks/>
           <modifiers/>
           <characteristics>
-            <characteristic name="Description" characteristicTypeId="21befb24-fc85-4f52-a745-64b2e48f8228" value="When a unit of Chaos Spawn makes its close combat attacks, roll a D3 and consult the table below.  &lt;table&gt;&lt;tr&gt;&lt;th&gt;D3&lt;/th&gt;&lt;th&gt;Result&lt;/th&gt;&lt;/tr&gt; &lt;tr&gt;&lt;td&gt;1&lt;/td&gt;&lt;td&gt;Razor Claws: The hideous mutations of all Chaos Spawn in the unit have an AP of -4 until the end of the Fight phase.&lt;/td&gt;&lt;/tr&gt; &lt;tr&gt;&lt;td&gt;2&lt;/td&gt;&lt;td&gt;Grasping Pseudopods: Each Chaos Spawn in the unit adds 2 to its Attacks characteristic until the end of the Fight phase.&lt;/td&gt;&lt;/tr&gt; &lt;tr&gt;&lt;td&gt;3&lt;/td&gt;&lt;td&gt;Toxic Haemorrhage: You can re-roll failed wound rolls for this unit until the end of the Fight phase.&lt;/td&gt;&lt;/tr&gt;&lt;/table&gt;"/>
+            <characteristic name="Description" characteristicTypeId="21befb24-fc85-4f52-a745-64b2e48f8228" value="When a unit of Chaos Spawn makes its close combat attacks, roll a D3 and consult the table below."/>
+          </characteristics>
+        </profile>
+        <profile id="2588-7f59-51a1-dec9" name="Mutated Beyond Reason 1" hidden="false" profileTypeId="ab9e-0e23-5699-9d71" profileTypeName="Mutated beyond reason">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="D3 Roll" characteristicTypeId="7e36-5885-a0e4-79c0" value="1"/>
+            <characteristic name="Result" characteristicTypeId="7911-8c44-6fa5-a910" value="Razor Claws: The hideous mutations of all Chaos Spawn in the unit have an AP of -4 until the end of the Fight phase."/>
+          </characteristics>
+        </profile>
+        <profile id="31a9-7352-70cd-27c2" name="Mutated Beyond Reason 2" hidden="false" profileTypeId="ab9e-0e23-5699-9d71" profileTypeName="Mutated beyond reason">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="D3 Roll" characteristicTypeId="7e36-5885-a0e4-79c0" value="2"/>
+            <characteristic name="Result" characteristicTypeId="7911-8c44-6fa5-a910" value="Grasping Pseudopods: Each Chaos Spawn in the unit adds 2 to its Attacks characteristic until the end of the Fight phase."/>
+          </characteristics>
+        </profile>
+        <profile id="05e4-d9ca-075f-3336" name="Mutated Beyond Reason 3" hidden="false" profileTypeId="ab9e-0e23-5699-9d71" profileTypeName="Mutated beyond reason">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="D3 Roll" characteristicTypeId="7e36-5885-a0e4-79c0" value="3"/>
+            <characteristic name="Result" characteristicTypeId="7911-8c44-6fa5-a910" value="Toxic Haemorrhage: You can re-roll failed wound rolls for this unit until the end of the Fight phase."/>
           </characteristics>
         </profile>
       </profiles>
@@ -15203,7 +16446,7 @@ D3   Bonus
           <modifiers/>
           <constraints/>
         </categoryLink>
-        <categoryLink id="a849-9c1c-dfe7-5a78" name="New CategoryLink" hidden="false" targetId="717b-8863-9d25-5e2a" primary="false">
+        <categoryLink id="a849-9c1c-dfe7-5a78" name="New CategoryLink" hidden="false" targetId="5cf1-acf2-ca3b-c2e5" primary="false">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -15337,13 +16580,13 @@ D3   Bonus
       <profiles/>
       <rules/>
       <infoLinks>
-        <infoLink id="135a-84a3-29ce-1889" name="New InfoLink" hidden="false" targetId="6349-022a-cea9-524c" type="rule">
+        <infoLink id="135a-84a3-29ce-1889" name="Death to the False Emperor" hidden="false" targetId="37a4-1d84-4ef0-c4f6" type="profile">
           <profiles/>
           <rules/>
           <infoLinks/>
           <modifiers/>
         </infoLink>
-        <infoLink id="f8cb-b9a0-602f-c5bf" name="New InfoLink" hidden="false" targetId="e008-161d-80a5-aef1" type="rule">
+        <infoLink id="f8cb-b9a0-602f-c5bf" name="Turbo-boost" hidden="false" targetId="3923-a411-2e7b-dc9c" type="profile">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -15380,13 +16623,6 @@ D3   Bonus
       </modifiers>
       <constraints/>
       <categoryLinks>
-        <categoryLink id="67cd-bef6-037b-e179" name="New CategoryLink" hidden="false" targetId="717b-8863-9d25-5e2a" primary="false">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints/>
-        </categoryLink>
         <categoryLink id="19e6-6333-b68c-8c49" name="New CategoryLink" hidden="false" targetId="ca10-a5dd-f54f-0ed5" primary="false">
           <profiles/>
           <rules/>
@@ -15416,6 +16652,13 @@ D3   Bonus
           <constraints/>
         </categoryLink>
         <categoryLink id="1902-7644-23f4-a7ab" name="New CategoryLink" hidden="false" targetId="c274d0b0-5866-44bc-9810-91c136ae7438" primary="true">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
+        <categoryLink id="7d87-f7bf-99bb-00ea" name="New CategoryLink" hidden="false" targetId="5cf1-acf2-ca3b-c2e5" primary="false">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -15581,28 +16824,20 @@ D3   Bonus
           <categoryLinks/>
           <selectionEntries/>
           <selectionEntryGroups>
-            <selectionEntryGroup id="4998-0415-bff3-f209" name="Bolt pistol options" hidden="false" collective="false" defaultSelectionEntryId="0cd5-327f-69e7-8743">
+            <selectionEntryGroup id="803e-2b8c-7f6f-959a" name="Bolt pistol options" hidden="false" collective="false">
               <profiles/>
               <rules/>
               <infoLinks/>
               <modifiers/>
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0151-ac89-cb19-f261" type="max"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8f4f-4bcd-4dd4-06a8" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3302-58dd-7984-511a" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="28db-b0d8-f63a-8467" type="min"/>
               </constraints>
               <categoryLinks/>
               <selectionEntries/>
               <selectionEntryGroups/>
               <entryLinks>
-                <entryLink id="0cd5-327f-69e7-8743" name="New EntryLink" hidden="false" targetId="0334-f487-8229-0c1a" type="selectionEntry">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                  <constraints/>
-                  <categoryLinks/>
-                </entryLink>
-                <entryLink id="9e3c-bc26-4513-0dc0" name="New EntryLink" hidden="false" targetId="1912-576e-6a2b-5c6e" type="selectionEntryGroup">
+                <entryLink id="889c-d040-21e7-8c22" name="Champion Equipment" hidden="false" targetId="ad90-3560-ea09-82ef" type="selectionEntryGroup">
                   <profiles/>
                   <rules/>
                   <infoLinks/>
@@ -15625,18 +16860,7 @@ D3   Bonus
               </constraints>
               <categoryLinks/>
             </entryLink>
-            <entryLink id="76df-2bc5-ea7c-060f" name="New EntryLink" hidden="false" targetId="183a-a319-9ba3-541e" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7d2c-a13c-cae7-c4aa" type="max"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="714f-2bc4-7e5d-c9d6" type="min"/>
-              </constraints>
-              <categoryLinks/>
-            </entryLink>
-            <entryLink id="a240-aa11-ba60-bbbe" name="New EntryLink" hidden="false" targetId="7dab-d7fa-7d63-dcd7" type="selectionEntry">
+            <entryLink id="a240-aa11-ba60-bbbe" name="Combi-bolter" hidden="false" targetId="7dab-d7fa-7d63-dcd7" type="selectionEntry">
               <profiles/>
               <rules/>
               <infoLinks/>
@@ -15690,10 +16914,27 @@ D3   Bonus
             <characteristic name="Description" characteristicTypeId="21befb24-fc85-4f52-a745-64b2e48f8228" value="During deployment, you can set up this unit high in the skies instead of placing it on the battlefield. At the end of any of your Movement phases the unit can use a Raptor strike to arrive on the battlefield - set it up anywhere on the battlefield that is more than 9&quot; away from any enemy models."/>
           </characteristics>
         </profile>
+        <profile id="465f-44cc-6ff7-e259" name="Raptor" hidden="false" profileTypeId="800f-21d0-4387-c943" profileTypeName="Unit">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="M" characteristicTypeId="0bdf-a96e-9e38-7779" value="12&quot;"/>
+            <characteristic name="WS" characteristicTypeId="e7f0-1278-0250-df0c" value="3+"/>
+            <characteristic name="BS" characteristicTypeId="381b-eb28-74c3-df5f" value="3+"/>
+            <characteristic name="S" characteristicTypeId="2218-aa3c-265f-2939" value="4"/>
+            <characteristic name="T" characteristicTypeId="9c9f-9774-a358-3a39" value="4"/>
+            <characteristic name="W" characteristicTypeId="f330-5e6e-4110-0978" value="1"/>
+            <characteristic name="A" characteristicTypeId="13fc-b29b-31f2-ab9f" value="1"/>
+            <characteristic name="Ld" characteristicTypeId="00ca-f8b8-876d-b705" value="7"/>
+            <characteristic name="Save" characteristicTypeId="c0df-df94-abd7-e8d3" value="3+"/>
+          </characteristics>
+        </profile>
       </profiles>
       <rules/>
       <infoLinks>
-        <infoLink id="f83c-6332-18b7-1896" name="New InfoLink" hidden="false" targetId="6349-022a-cea9-524c" type="rule">
+        <infoLink id="f83c-6332-18b7-1896" name="Death to the False Emperor" hidden="false" targetId="37a4-1d84-4ef0-c4f6" type="profile">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -15718,7 +16959,7 @@ D3   Bonus
       </modifiers>
       <constraints/>
       <categoryLinks>
-        <categoryLink id="5a05-c858-c8b4-0b7f" name="New CategoryLink" hidden="false" targetId="717b-8863-9d25-5e2a" primary="false">
+        <categoryLink id="5a05-c858-c8b4-0b7f" name="New CategoryLink" hidden="false" targetId="5cf1-acf2-ca3b-c2e5" primary="false">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -15769,76 +17010,6 @@ D3   Bonus
         </categoryLink>
       </categoryLinks>
       <selectionEntries>
-        <selectionEntry id="2932-d5cf-2403-a4ea" name="Raptor" hidden="false" collective="false" type="model">
-          <profiles>
-            <profile id="591c-9c07-251f-26b1" name="Raptor" hidden="false" profileTypeId="800f-21d0-4387-c943" profileTypeName="Unit">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <characteristics>
-                <characteristic name="M" characteristicTypeId="0bdf-a96e-9e38-7779" value="12&quot;"/>
-                <characteristic name="WS" characteristicTypeId="e7f0-1278-0250-df0c" value="3+"/>
-                <characteristic name="BS" characteristicTypeId="381b-eb28-74c3-df5f" value="3+"/>
-                <characteristic name="S" characteristicTypeId="2218-aa3c-265f-2939" value="4"/>
-                <characteristic name="T" characteristicTypeId="9c9f-9774-a358-3a39" value="4"/>
-                <characteristic name="W" characteristicTypeId="f330-5e6e-4110-0978" value="1"/>
-                <characteristic name="A" characteristicTypeId="13fc-b29b-31f2-ab9f" value="1"/>
-                <characteristic name="Ld" characteristicTypeId="00ca-f8b8-876d-b705" value="7"/>
-                <characteristic name="Save" characteristicTypeId="c0df-df94-abd7-e8d3" value="3+"/>
-              </characteristics>
-            </profile>
-          </profiles>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints>
-            <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a17a-b603-bd4c-be83" type="min"/>
-            <constraint field="selections" scope="parent" value="14.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="04fa-aaf9-a4fc-ad13" type="max"/>
-          </constraints>
-          <categoryLinks/>
-          <selectionEntries/>
-          <selectionEntryGroups/>
-          <entryLinks>
-            <entryLink id="cb33-20e1-7eb7-147b" name="New EntryLink" hidden="false" targetId="cddf-945e-1335-e681" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2ce1-7c2c-870b-390e" type="max"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e558-fb35-5d75-50a9" type="min"/>
-              </constraints>
-              <categoryLinks/>
-            </entryLink>
-            <entryLink id="9e60-14cf-bdc4-e6f3" name="Chainsword" hidden="false" targetId="704f-026f-22fd-89d5" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d862-a8c3-92d0-89a4" type="max"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9cba-ec22-c408-c55f" type="min"/>
-              </constraints>
-              <categoryLinks/>
-            </entryLink>
-            <entryLink id="5026-1e07-3e5e-68b6" name="Bolt pistol" hidden="false" targetId="37d3-7098-d596-9948" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5109-3437-71e1-19a5" type="max"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="75d8-4e12-370b-0025" type="min"/>
-              </constraints>
-              <categoryLinks/>
-            </entryLink>
-          </entryLinks>
-          <costs>
-            <cost name="pts" costTypeId="points" value="17.0"/>
-            <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="0.0"/>
-          </costs>
-        </selectionEntry>
         <selectionEntry id="d4a0-d7d9-64b4-3969" name="Raptor Champion" hidden="false" collective="false" type="model">
           <profiles>
             <profile id="aaab-a4a1-60ff-f018" name="Raptor Champion" hidden="false" profileTypeId="800f-21d0-4387-c943" profileTypeName="Unit">
@@ -15882,32 +17053,12 @@ D3   Bonus
               <selectionEntries/>
               <selectionEntryGroups/>
               <entryLinks>
-                <entryLink id="6102-2d45-c686-179e" name="New EntryLink" hidden="false" targetId="1912-576e-6a2b-5c6e" type="selectionEntryGroup">
+                <entryLink id="6102-2d45-c686-179e" name="Champion Equipment" hidden="false" targetId="ad90-3560-ea09-82ef" type="selectionEntryGroup">
                   <profiles/>
                   <rules/>
                   <infoLinks/>
                   <modifiers/>
                   <constraints/>
-                  <categoryLinks/>
-                </entryLink>
-                <entryLink id="e76c-495a-e19b-0ed9" name="New EntryLink" hidden="false" targetId="0334-f487-8229-0c1a" type="selectionEntry">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                  <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="540f-19ab-a637-fb02" type="max"/>
-                  </constraints>
-                  <categoryLinks/>
-                </entryLink>
-                <entryLink id="8099-9ab1-94ff-7b9e" name="New EntryLink" hidden="false" targetId="704f-026f-22fd-89d5" type="selectionEntry">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                  <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="c538-d349-4908-274c" type="max"/>
-                  </constraints>
                   <categoryLinks/>
                 </entryLink>
               </entryLinks>
@@ -15933,68 +17084,177 @@ D3   Bonus
         </selectionEntry>
       </selectionEntries>
       <selectionEntryGroups>
-        <selectionEntryGroup id="d87e-90f7-9ff4-f631" name="Up to two weapon swaps" hidden="false" collective="false">
+        <selectionEntryGroup id="1f4d-3e80-9650-e93b" name="Raptors" hidden="false" collective="false" defaultSelectionEntryId="f032-104c-ca73-2ab6">
           <profiles/>
           <rules/>
           <infoLinks/>
           <modifiers/>
           <constraints>
-            <constraint field="selections" scope="350d-676c-02cd-7ac2" value="2.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="7a5d-c9b4-eeb6-9335" type="max"/>
+            <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="acd4-0525-fadb-7e5d" type="min"/>
+            <constraint field="selections" scope="parent" value="14.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d40b-bb16-6489-2953" type="max"/>
           </constraints>
           <categoryLinks/>
           <selectionEntries>
-            <selectionEntry id="e631-7a8c-a18b-5dbd" name="Plasma pistol and chainsword" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="f032-104c-ca73-2ab6" name="Raptor" hidden="false" collective="false" type="model">
               <profiles/>
               <rules/>
-              <infoLinks>
-                <infoLink id="ac23-495c-a155-d3fd" name="New InfoLink" hidden="false" targetId="9b1e-61f9-4a5b-0044" type="profile">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                </infoLink>
-                <infoLink id="93aa-c250-3966-d1f9" name="New InfoLink" hidden="false" targetId="5779-2931-fe17-2b27" type="profile">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                </infoLink>
-                <infoLink id="7792-237d-74e0-bddb" name="New InfoLink" hidden="false" targetId="ff12-161a-ca85-339f" type="profile">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                </infoLink>
-              </infoLinks>
+              <infoLinks/>
               <modifiers/>
-              <constraints/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="14.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="03b6-d605-d608-aa87" type="max"/>
+              </constraints>
               <categoryLinks/>
               <selectionEntries/>
               <selectionEntryGroups/>
-              <entryLinks/>
+              <entryLinks>
+                <entryLink id="9dcb-448b-3e84-b504" name="Frag &amp; Krak grenades" hidden="false" targetId="cddf-945e-1335-e681" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e1a1-4f3b-2cce-6963" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8ae3-e544-0f15-2b6b" type="min"/>
+                  </constraints>
+                  <categoryLinks/>
+                </entryLink>
+                <entryLink id="e21d-415e-85cd-119b" name="Chainsword" hidden="false" targetId="704f-026f-22fd-89d5" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8359-17ea-718b-a791" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6888-5714-47ec-f9f3" type="min"/>
+                  </constraints>
+                  <categoryLinks/>
+                </entryLink>
+                <entryLink id="71cf-b69d-7621-b85e" name="Bolt pistol" hidden="false" targetId="37d3-7098-d596-9948" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2269-7101-95fc-0073" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6ea9-7f92-f3ef-9bab" type="min"/>
+                  </constraints>
+                  <categoryLinks/>
+                </entryLink>
+              </entryLinks>
               <costs>
-                <cost name="pts" costTypeId="points" value="7.0"/>
+                <cost name="pts" costTypeId="points" value="17.0"/>
+                <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="0068-a64d-15c5-2b8d" name="Raptor w/ plasma pistol" hidden="false" collective="false" type="model">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers>
+                <modifier type="decrement" field="7898-20a5-fcfc-3cca" value="1">
+                  <repeats>
+                    <repeat field="selections" scope="350d-676c-02cd-7ac2" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="9dcb-448b-3e84-b504" repeats="1" roundUp="false"/>
+                  </repeats>
+                  <conditions/>
+                  <conditionGroups/>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7898-20a5-fcfc-3cca" type="max"/>
+              </constraints>
+              <categoryLinks/>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks>
+                <entryLink id="0cff-1f96-0ed6-ec1c" name="Frag &amp; Krak grenades" hidden="false" targetId="bb78-534a-7b77-edbc" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e91d-fd0d-ef85-0e6a" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c5bf-5e7c-3f24-dc1e" type="min"/>
+                  </constraints>
+                  <categoryLinks/>
+                </entryLink>
+                <entryLink id="2455-8bc4-711e-b3ff" name="Chainsword" hidden="false" targetId="0dd1-2e2b-7dd1-5495" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="70fa-3808-acf1-ce1a" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0ef9-bbfb-1407-978c" type="min"/>
+                  </constraints>
+                  <categoryLinks/>
+                </entryLink>
+                <entryLink id="dfe3-c0fd-3d5e-511e" name="Plasma pistol" hidden="false" targetId="83be-1ba9-c326-4760" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ae1e-8f64-b559-9c77" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d40a-354d-842a-688e" type="min"/>
+                  </constraints>
+                  <categoryLinks/>
+                </entryLink>
+              </entryLinks>
+              <costs>
+                <cost name="pts" costTypeId="points" value="17.0"/>
+                <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="0dad-680c-ae93-00c6" name="Raptor w/ special weapon" hidden="false" collective="false" type="model">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers>
+                <modifier type="decrement" field="dae7-104a-e0a4-123b" value="1">
+                  <repeats>
+                    <repeat field="selections" scope="350d-676c-02cd-7ac2" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="0068-a64d-15c5-2b8d" repeats="1" roundUp="false"/>
+                  </repeats>
+                  <conditions/>
+                  <conditionGroups/>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="dae7-104a-e0a4-123b" type="max"/>
+              </constraints>
+              <categoryLinks/>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks>
+                <entryLink id="c8b8-9251-16b0-2900" name="Frag &amp; Krak grenades" hidden="false" targetId="cddf-945e-1335-e681" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9c4d-d36e-4959-f406" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="75af-b503-4783-e4c3" type="min"/>
+                  </constraints>
+                  <categoryLinks/>
+                </entryLink>
+                <entryLink id="31b8-9f75-babe-271d" name="Special Weapons" hidden="false" targetId="a44b-4b4d-46b5-d3a6" type="selectionEntryGroup">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="29d9-eaa5-ae72-d849" type="min"/>
+                  </constraints>
+                  <categoryLinks/>
+                </entryLink>
+              </entryLinks>
+              <costs>
+                <cost name="pts" costTypeId="points" value="17.0"/>
                 <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
           <selectionEntryGroups/>
-          <entryLinks>
-            <entryLink id="f89b-fed0-39a4-d816" name="Special Weapons" hidden="false" targetId="a44b-4b4d-46b5-d3a6" type="selectionEntryGroup">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers>
-                <modifier type="set" field="5154-f7a1-21fa-cf7f" value="2">
-                  <repeats/>
-                  <conditions/>
-                  <conditionGroups/>
-                </modifier>
-              </modifiers>
-              <constraints/>
-              <categoryLinks/>
-            </entryLink>
-          </entryLinks>
+          <entryLinks/>
         </selectionEntryGroup>
       </selectionEntryGroups>
       <entryLinks>
@@ -16104,13 +17364,6 @@ D3   Bonus
       <modifiers/>
       <constraints/>
       <categoryLinks>
-        <categoryLink id="b40d-4a02-2f4f-f509" name="New CategoryLink" hidden="false" targetId="717b-8863-9d25-5e2a" primary="false">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints/>
-        </categoryLink>
         <categoryLink id="58d3-004c-5c81-259f" name="New CategoryLink" hidden="false" targetId="53cd-314c-599b-8616" primary="false">
           <profiles/>
           <rules/>
@@ -16133,6 +17386,13 @@ D3   Bonus
           <constraints/>
         </categoryLink>
         <categoryLink id="d0b4-46ae-1d07-f0c9" name="New CategoryLink" hidden="false" targetId="6cc4-1b62-8e8a-05cd" primary="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
+        <categoryLink id="59f6-4388-a2ae-3c38" name="New CategoryLink" hidden="false" targetId="5cf1-acf2-ca3b-c2e5" primary="false">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -16215,6 +17475,191 @@ D3   Bonus
         <cost name="pts" costTypeId="points" value="0.0"/>
       </costs>
     </selectionEntry>
+    <selectionEntry id="8561-c524-f380-e5a5" name="Infernal Gaze" hidden="false" collective="false" type="upgrade">
+      <profiles>
+        <profile id="883f-ed94-771c-bc96" name="Infernal Gaze" hidden="false" profileTypeId="ae70-4738-0161-bec0" profileTypeName="Psychic Power">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Warp Charge" characteristicTypeId="5ffd-b800-c317-532a" value="5"/>
+            <characteristic name="Range" characteristicTypeId="fd64-cbc4-94de-24cc" value="18&quot;"/>
+            <characteristic name="Details" characteristicTypeId="ad96-dfa4-b4ed-656d" value="If manifested, select a visible enemy unit within 18&quot; of the psyker and roll 3 dice. The target suffers one mortal wound for each roll of 4+."/>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="019f-b282-830f-3b7b" type="max"/>
+      </constraints>
+      <categoryLinks/>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="0.0"/>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="4a71-53c2-2d9c-3693" name="Prescience" hidden="false" collective="false" type="upgrade">
+      <profiles>
+        <profile id="5eb3-9864-f351-3753" name="Prescience" hidden="false" profileTypeId="ae70-4738-0161-bec0" profileTypeName="Psychic Power">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Warp Charge" characteristicTypeId="5ffd-b800-c317-532a" value="7"/>
+            <characteristic name="Range" characteristicTypeId="fd64-cbc4-94de-24cc" value="18&quot;"/>
+            <characteristic name="Details" characteristicTypeId="ad96-dfa4-b4ed-656d" value="If manifested, select a HERETIC ASTARTES unit within 18&quot; of the psyker. You can add 1 to all hit rolls made for that unit until the start of your next Psychic phase."/>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1ef7-17a6-7d1d-e244" type="max"/>
+      </constraints>
+      <categoryLinks/>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="0.0"/>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="9dd3-90bb-ef37-5728" name="Warptime" hidden="false" collective="false" type="upgrade">
+      <profiles>
+        <profile id="9e74-f5b6-9e27-58d9" name="Warptime" hidden="false" profileTypeId="ae70-4738-0161-bec0" profileTypeName="Psychic Power">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Warp Charge" characteristicTypeId="5ffd-b800-c317-532a" value="6"/>
+            <characteristic name="Range" characteristicTypeId="fd64-cbc4-94de-24cc" value="3&quot;"/>
+            <characteristic name="Details" characteristicTypeId="ad96-dfa4-b4ed-656d" value="If manifested, pick a friendly HERETIC ASTARTES unit within 3&quot; of the psyker. That unit can immediately move as if it were its Movement phase. You cannot use Warptime on a unit more than once in each Psychic phase."/>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="268e-9a76-eca1-46bc" type="max"/>
+      </constraints>
+      <categoryLinks/>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="0.0"/>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="69a9-e421-f588-79bc" name="Chainaxe" hidden="false" collective="true" type="upgrade">
+      <profiles/>
+      <rules/>
+      <infoLinks>
+        <infoLink id="8cf8-4e45-1307-0fa2" name="New InfoLink" hidden="false" targetId="fc56-4e98-3cdc-3659" type="profile">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints/>
+      <categoryLinks/>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="1.0"/>
+        <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="986e-f410-9c9a-a973" name="Blight Grenades" hidden="false" collective="false" type="upgrade">
+      <profiles/>
+      <rules/>
+      <infoLinks>
+        <infoLink id="b698-82c1-2932-1ce6" name="Blight Grenades" hidden="false" targetId="1287-6659-b04f-fe37" type="profile">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints/>
+      <categoryLinks/>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="0.0"/>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="fe40-0ecc-37e1-e5dd" name="Blight Grenades" hidden="false" collective="true" type="upgrade">
+      <profiles/>
+      <rules/>
+      <infoLinks>
+        <infoLink id="062d-1075-5411-4011" name="Blight Grenades" hidden="false" targetId="1287-6659-b04f-fe37" type="profile">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints/>
+      <categoryLinks/>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="0.0"/>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="bbb0-94d7-d83a-bf45" name="Doom siren" hidden="false" collective="false" type="upgrade">
+      <profiles>
+        <profile id="5a7f-7f5f-3417-9ef9" name="Doom siren" hidden="false" profileTypeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" profileTypeName="Weapon">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Range" characteristicTypeId="6fa97fa8-ea74-4a27-a0fb-bc4e5f367464" value="8&quot;"/>
+            <characteristic name="Type" characteristicTypeId="077c342f-d7b9-45c6-b8af-88e97cafd3a2" value="Assault D3"/>
+            <characteristic name="S" characteristicTypeId="59b1-319e-ec13-d466" value="5"/>
+            <characteristic name="AP" characteristicTypeId="75aa-a838-b675-6484" value="-2"/>
+            <characteristic name="D" characteristicTypeId="ae8a-3137-d65b-4ca7" value="1"/>
+            <characteristic name="Abilities" characteristicTypeId="837d-5e63-aeb7-1410" value="This weapon automatically hits its target. Units targeted by this weapon do not gain any bonus to their saving throws for being in cover."/>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a7ce-2ff3-e1e0-f6a2" type="max"/>
+      </constraints>
+      <categoryLinks/>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="22.0"/>
+        <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="0.0"/>
+      </costs>
+    </selectionEntry>
   </sharedSelectionEntries>
   <sharedSelectionEntryGroups>
     <selectionEntryGroup id="381f-857d-2846-7c2f" name="Chaos Icons" hidden="false" collective="false">
@@ -16240,155 +17685,6 @@ D3   Bonus
               <conditionGroups/>
             </modifier>
           </modifiers>
-          <constraints/>
-          <categoryLinks/>
-        </entryLink>
-      </entryLinks>
-    </selectionEntryGroup>
-    <selectionEntryGroup id="1912-576e-6a2b-5c6e" name="Champion Equipment" hidden="false" collective="false">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <constraints>
-        <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0593-89c5-25e7-d094" type="max"/>
-      </constraints>
-      <categoryLinks/>
-      <selectionEntries/>
-      <selectionEntryGroups>
-        <selectionEntryGroup id="ebcd-6686-79ac-cef3" name="Max 1 of these" hidden="false" collective="false">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="282c-cdb6-c6b8-e5c1" type="max"/>
-          </constraints>
-          <categoryLinks/>
-          <selectionEntries/>
-          <selectionEntryGroups/>
-          <entryLinks>
-            <entryLink id="b481-1346-1afb-7c14" name="New EntryLink" hidden="false" targetId="b61f-a3c1-827d-c5b6" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints/>
-              <categoryLinks/>
-            </entryLink>
-            <entryLink id="9e81-ffbd-ad20-9844" name="New EntryLink" hidden="false" targetId="eba0-9fc6-5334-a390" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints/>
-              <categoryLinks/>
-            </entryLink>
-            <entryLink id="505e-95b8-cc86-e92f" name="New EntryLink" hidden="false" targetId="c6a1-e0c4-c1b1-dce1" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints/>
-              <categoryLinks/>
-            </entryLink>
-            <entryLink id="2c08-0ba1-5831-489e" name="New EntryLink" hidden="false" targetId="c445-e211-f316-5d83" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints/>
-              <categoryLinks/>
-            </entryLink>
-            <entryLink id="a2e5-1d11-03c9-09c2" name="New EntryLink" hidden="false" targetId="fdce-cdf7-21a9-f9ac" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints/>
-              <categoryLinks/>
-            </entryLink>
-            <entryLink id="4dff-62e5-acb7-90f5" name="Lightning Claw (Pair)" hidden="false" targetId="7603-6241-ab8b-4603" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints/>
-              <categoryLinks/>
-            </entryLink>
-          </entryLinks>
-        </selectionEntryGroup>
-      </selectionEntryGroups>
-      <entryLinks>
-        <entryLink id="fdb4-16ca-f677-e192" name="New EntryLink" hidden="false" targetId="0334-f487-8229-0c1a" type="selectionEntry">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints/>
-          <categoryLinks/>
-        </entryLink>
-        <entryLink id="832c-1241-1062-c449" name="New EntryLink" hidden="false" targetId="262d-dbbf-8474-791c" type="selectionEntry">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints/>
-          <categoryLinks/>
-        </entryLink>
-        <entryLink id="f521-7725-aa0f-c6e5" name="New EntryLink" hidden="false" targetId="0dd1-2e2b-7dd1-5495" type="selectionEntry">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints/>
-          <categoryLinks/>
-        </entryLink>
-        <entryLink id="f0c8-636d-8eae-04b6" name="New EntryLink" hidden="false" targetId="0d37-6229-c7e7-54a7" type="selectionEntry">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints/>
-          <categoryLinks/>
-        </entryLink>
-        <entryLink id="5b84-171e-ab4d-cd49" name="New EntryLink" hidden="false" targetId="83be-1ba9-c326-4760" type="selectionEntry">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints/>
-          <categoryLinks/>
-        </entryLink>
-        <entryLink id="b850-bb20-fc16-c337" name="New EntryLink" hidden="false" targetId="3292-34e6-f679-d5b9" type="selectionEntry">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints/>
-          <categoryLinks/>
-        </entryLink>
-        <entryLink id="550d-ac84-1d61-21b2" name="New EntryLink" hidden="false" targetId="f122-3720-fa32-4215" type="selectionEntry">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints/>
-          <categoryLinks/>
-        </entryLink>
-        <entryLink id="cb09-3cfe-9797-fa97" name="New EntryLink" hidden="false" targetId="6ea7-1195-7144-438e" type="selectionEntry">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints/>
-          <categoryLinks/>
-        </entryLink>
-        <entryLink id="ba0d-4316-d707-7eda" name="New EntryLink" hidden="false" targetId="bc9e-551d-9afb-78d5" type="selectionEntry">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
           <constraints/>
           <categoryLinks/>
         </entryLink>
@@ -17047,28 +18343,226 @@ D3   Bonus
       <selectionEntryGroups/>
       <entryLinks/>
     </selectionEntryGroup>
+    <selectionEntryGroup id="0246-3399-3b88-44aa" name="Dark Hereticus discipline" hidden="false" collective="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints/>
+      <categoryLinks/>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks>
+        <entryLink id="75b1-a3b9-610a-d9ac" name="Infernal Gaze" hidden="false" targetId="8561-c524-f380-e5a5" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+          <categoryLinks/>
+        </entryLink>
+        <entryLink id="777a-5352-ff83-d825" name="Warptime" hidden="false" targetId="9dd3-90bb-ef37-5728" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+          <categoryLinks/>
+        </entryLink>
+        <entryLink id="780a-6e39-e385-ee7d" name="Prescience" hidden="false" targetId="4a71-53c2-2d9c-3693" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+          <categoryLinks/>
+        </entryLink>
+      </entryLinks>
+    </selectionEntryGroup>
+    <selectionEntryGroup id="ad90-3560-ea09-82ef" name="Champion Equipment" hidden="false" collective="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6788-0de9-fe7a-4496" type="max"/>
+      </constraints>
+      <categoryLinks/>
+      <selectionEntries>
+        <selectionEntry id="951a-9211-69c6-b360" name="Chainaxe" hidden="false" collective="false" type="upgrade">
+          <profiles>
+            <profile id="c219-9dbb-584c-15c3" name="Chainaxe" hidden="false" profileTypeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" profileTypeName="Weapon">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <characteristics>
+                <characteristic name="Range" characteristicTypeId="6fa97fa8-ea74-4a27-a0fb-bc4e5f367464" value="Melee"/>
+                <characteristic name="Type" characteristicTypeId="077c342f-d7b9-45c6-b8af-88e97cafd3a2" value="Melee"/>
+                <characteristic name="S" characteristicTypeId="59b1-319e-ec13-d466" value="+1"/>
+                <characteristic name="AP" characteristicTypeId="75aa-a838-b675-6484" value="-1"/>
+                <characteristic name="D" characteristicTypeId="ae8a-3137-d65b-4ca7" value="1"/>
+                <characteristic name="Abilities" characteristicTypeId="837d-5e63-aeb7-1410" value="-"/>
+              </characteristics>
+            </profile>
+          </profiles>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d34c-2826-3644-893f" type="max"/>
+          </constraints>
+          <categoryLinks/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="1.0"/>
+            <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="0.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="e47b-8193-ff5b-4d68" name="Max 1 of these" hidden="false" collective="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="876e-2089-ac7b-19dc" type="max"/>
+          </constraints>
+          <categoryLinks/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="cb6d-599e-51f3-8f2f" name="Boltgun" hidden="false" targetId="b61f-a3c1-827d-c5b6" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+              <categoryLinks/>
+            </entryLink>
+            <entryLink id="a723-c7c5-af77-5edf" name="Combi-bolter" hidden="false" targetId="eba0-9fc6-5334-a390" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+              <categoryLinks/>
+            </entryLink>
+            <entryLink id="0228-4efa-e66b-c317" name="Combi-flamer" hidden="false" targetId="c6a1-e0c4-c1b1-dce1" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+              <categoryLinks/>
+            </entryLink>
+            <entryLink id="f19d-c7e5-046c-6e0c" name="Combi-melta" hidden="false" targetId="c445-e211-f316-5d83" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+              <categoryLinks/>
+            </entryLink>
+            <entryLink id="d90d-154e-47a7-4102" name="Combi-plasma" hidden="false" targetId="fdce-cdf7-21a9-f9ac" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+              <categoryLinks/>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <entryLinks>
+        <entryLink id="2fe8-b3bc-e328-0624" name="Bolt pistol" hidden="false" targetId="0334-f487-8229-0c1a" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="290a-9507-72aa-a500" type="max"/>
+          </constraints>
+          <categoryLinks/>
+        </entryLink>
+        <entryLink id="76d7-2522-d218-09bd" name="Chainsword" hidden="false" targetId="0dd1-2e2b-7dd1-5495" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c7ed-c6e7-350a-5152" type="max"/>
+          </constraints>
+          <categoryLinks/>
+        </entryLink>
+        <entryLink id="587a-8ffc-e04e-fb28" name="Plasma pistol" hidden="false" targetId="83be-1ba9-c326-4760" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5f1d-ede4-fb4f-8179" type="max"/>
+          </constraints>
+          <categoryLinks/>
+        </entryLink>
+        <entryLink id="142b-9419-7328-0eda" name="Power axe" hidden="false" targetId="3292-34e6-f679-d5b9" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4b79-4886-b57f-37bb" type="max"/>
+          </constraints>
+          <categoryLinks/>
+        </entryLink>
+        <entryLink id="dd9c-0844-2888-f3ea" name="Power fist" hidden="false" targetId="f122-3720-fa32-4215" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8a51-8727-376c-3cf5" type="max"/>
+          </constraints>
+          <categoryLinks/>
+        </entryLink>
+        <entryLink id="4468-3110-c1c8-0495" name="Power maul" hidden="false" targetId="6ea7-1195-7144-438e" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7cb4-d0e2-e185-e0b2" type="max"/>
+          </constraints>
+          <categoryLinks/>
+        </entryLink>
+        <entryLink id="9f1f-9636-a6ce-2ad5" name="Power sword" hidden="false" targetId="bc9e-551d-9afb-78d5" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7793-e507-6e3d-25c8" type="max"/>
+          </constraints>
+          <categoryLinks/>
+        </entryLink>
+        <entryLink id="1dce-b199-53f2-6786" name="Lightning Claw" hidden="false" targetId="90de-7b01-e401-888b" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ac67-f35d-7745-8e01" type="max"/>
+          </constraints>
+          <categoryLinks/>
+        </entryLink>
+      </entryLinks>
+    </selectionEntryGroup>
   </sharedSelectionEntryGroups>
   <sharedRules>
-    <rule id="b962-c13b-7edc-556d" name="Mindless" hidden="false">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <description>This unit never has to take Morale tests.</description>
-    </rule>
-    <rule id="e915-bbff-dc8e-5212" name="Disgustingly Resilient" hidden="false">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <description>Each time this model loses a wound, roll a D6; on a 5-6, it does not lose that wound.</description>
-    </rule>
-    <rule id="6349-022a-cea9-524c" name="Death to the False Emperor" hidden="false">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-    </rule>
     <rule id="ae9c-d115-d4a9-ba02" name="Teleport Strike" hidden="false">
       <profiles/>
       <rules/>
@@ -17076,88 +18570,18 @@ D3   Bonus
       <modifiers/>
       <description>During deployment, you can set up this model in a teleportarium chamber instead of placing it on the battlefield. At the end of any of your Movement phases the model can use a teleport strike to arrive on the battlefield - set it up anywhere on the battlefield that is more than 9&quot; away from any enemy models.</description>
     </rule>
-    <rule id="2946-510b-88fb-5c9c" name="Daemonic" hidden="false">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <description>This model has a 5++.</description>
-    </rule>
-    <rule id="b4eb-f3f5-d439-1834" name="Daemonic Machine Spirit" hidden="false">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <description>Ignore the -1 to hit modifier for moving and shooting Heavy weapons for this model.</description>
-    </rule>
-    <rule id="728f-90eb-c466-9e70" name="Blood for the Blood God" hidden="false">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <description>This model can fight twice in each Fight phase, instead of only once.</description>
-    </rule>
-    <rule id="94d8-b556-103a-36ec" name="Sigil of Corruption" hidden="false">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <description>This model has a 4++ save.</description>
-    </rule>
     <rule id="224f-2c86-454d-54aa" name="Daemonic Ritual" hidden="false">
       <profiles/>
       <rules/>
       <infoLinks/>
       <modifiers/>
     </rule>
-    <rule id="3615-ebc3-9b1e-7bea" name="Greater Daemon (Khorne)" hidden="false">
+    <rule id="3a84-0b71-5f8f-5b9c" name="Jump Pack Assault" hidden="false">
       <profiles/>
       <rules/>
       <infoLinks/>
       <modifiers/>
-      <description>Friendly Khorne Daemon units within 6&quot; of this model when they take a Morale test can use this model&apos;s Ld instead of their own.</description>
-    </rule>
-    <rule id="8ce7-b46b-12bd-dbb8" name="Lord of Chaos" hidden="false">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <description>You can re-roll hit rolls of 1 made for friendly (Legion) units within 6&quot; of this model.</description>
-    </rule>
-    <rule id="e008-161d-80a5-aef1" name="Turbo-boost" hidden="false">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <description>When this model Advances, add 6&quot; to its Move characteristic for that Movement phase instead of rolling a dice.</description>
-    </rule>
-    <rule id="e2cc-3e10-f4a9-d911" name="Terminator Armour" hidden="false">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <description>This model has a 5++.</description>
-    </rule>
-    <rule id="2e27-dff9-3ed4-0d72" name="Unstoppable Ferocity" hidden="false">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <description>If a Khorne Daemon unit with this ability either charges, is charged, or performs a Heroic Intervention, add +1 S and +1 A to all models in the unit until the end of the turn.</description>
-    </rule>
-    <rule id="707b-0cd4-1288-86e0" name="Quicksilver Swiftness" hidden="false">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <description>Slaanesh Daemon units with this ability always fight first in the Fight phase, even if they didn&apos;t charge. If the enemy has units that have charged, or that have a similar ability, then alternate choosing units to fight with, starting with the player whose turn is taking place.</description>
-    </rule>
-    <rule id="afd3-a04b-c770-90c1" name="Infernal Regeneration" hidden="false">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <description>At the beginning of each of your turns, this model heals one wound.</description>
+      <description>During deployment you can set this unit up high in the skies instead of placing it on the battlefield. At the end of any of your Movement phases this unit can assault from above - set it up anywhere on the battlefield that is more than 9&quot; away from any enemy models.</description>
     </rule>
   </sharedRules>
   <sharedProfiles>
@@ -17517,7 +18941,7 @@ D3   Bonus
       <infoLinks/>
       <modifiers/>
       <characteristics>
-        <characteristic name="Description" characteristicTypeId="21befb24-fc85-4f52-a745-64b2e48f8228" value="This model has a 5++."/>
+        <characteristic name="Description" characteristicTypeId="21befb24-fc85-4f52-a745-64b2e48f8228" value="This model has a 5+ invulnerable save."/>
       </characteristics>
     </profile>
     <profile id="4e93-ccd6-c332-0eeb" name="Brutal assault weapon" hidden="false" profileTypeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" profileTypeName="Weapon">
@@ -17532,6 +18956,173 @@ D3   Bonus
         <characteristic name="AP" characteristicTypeId="75aa-a838-b675-6484" value="0"/>
         <characteristic name="D" characteristicTypeId="ae8a-3137-d65b-4ca7" value="1"/>
         <characteristic name="Abilities" characteristicTypeId="837d-5e63-aeb7-1410" value="Each time the bearer fights, it can make 1 additional attack with this weapon. This extra attack is included in its profile."/>
+      </characteristics>
+    </profile>
+    <profile id="b0a9-4ba4-c487-01b9" name="Blood for the Blood God" hidden="false" profileTypeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" profileTypeName="Abilities">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <characteristics>
+        <characteristic name="Description" characteristicTypeId="21befb24-fc85-4f52-a745-64b2e48f8228" value="This model can fight twice in each Fight phase, instead of only once."/>
+      </characteristics>
+    </profile>
+    <profile id="94f5-82c3-bb66-ac0c" name="Daemonic" hidden="false" profileTypeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" profileTypeName="Abilities">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <characteristics>
+        <characteristic name="Description" characteristicTypeId="21befb24-fc85-4f52-a745-64b2e48f8228" value="This model has a 5+ invulnerable save."/>
+      </characteristics>
+    </profile>
+    <profile id="9676-5c4d-7ae8-461b" name="Daemonic Machine Spirit" hidden="false" profileTypeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" profileTypeName="Abilities">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <characteristics>
+        <characteristic name="Description" characteristicTypeId="21befb24-fc85-4f52-a745-64b2e48f8228" value="Ignore the -1 to hit modifier for moving and shooting Heavy weapons for this model."/>
+      </characteristics>
+    </profile>
+    <profile id="37a4-1d84-4ef0-c4f6" name="Death to the False Emperor" hidden="false" profileTypeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" profileTypeName="Abilities">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <characteristics>
+        <characteristic name="Description" characteristicTypeId="21befb24-fc85-4f52-a745-64b2e48f8228" value="Each time you roll a hit roll of 6+ for a model with this ability in the Fight phase, it can, if it was targeting an IMPERIUM unit, immediately make an extra attack against the same unit using the same weapon. These extra attacks cannot themselves generate any further attacks."/>
+      </characteristics>
+    </profile>
+    <profile id="a46b-e84f-ab7b-a4e4" name="Infernal Regeneration" hidden="false" profileTypeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" profileTypeName="Abilities">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <characteristics>
+        <characteristic name="Description" characteristicTypeId="21befb24-fc85-4f52-a745-64b2e48f8228" value="At the beginning of each of your turns, this model heals one wound."/>
+      </characteristics>
+    </profile>
+    <profile id="69a2-f63e-3d27-5c09" name="Lord of Chaos" hidden="false" profileTypeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" profileTypeName="Abilities">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <characteristics>
+        <characteristic name="Description" characteristicTypeId="21befb24-fc85-4f52-a745-64b2e48f8228" value="You can re-roll hit rolls of 1 made for friendly &lt;LEGION&gt; units within 6&quot; of this model."/>
+      </characteristics>
+    </profile>
+    <profile id="c237-7aca-a961-6c59" name="Sigil of Corruption" hidden="false" profileTypeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" profileTypeName="Abilities">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <characteristics>
+        <characteristic name="Description" characteristicTypeId="21befb24-fc85-4f52-a745-64b2e48f8228" value="This model has a 4+ invulnerable save."/>
+      </characteristics>
+    </profile>
+    <profile id="aa2e-f0e5-04d3-aae3" name="Terminator Armour" hidden="false" profileTypeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" profileTypeName="Abilities">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <characteristics>
+        <characteristic name="Description" characteristicTypeId="21befb24-fc85-4f52-a745-64b2e48f8228" value="Models in this unit have a 5+ invulnerable save."/>
+      </characteristics>
+    </profile>
+    <profile id="649e-7454-0be4-7a71" name="Disgustingly Resilient" hidden="false" profileTypeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" profileTypeName="Abilities">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <characteristics>
+        <characteristic name="Description" characteristicTypeId="21befb24-fc85-4f52-a745-64b2e48f8228" value="Each time this model loses a wound, roll a D6; on a 5-6, it does not lose that wound."/>
+      </characteristics>
+    </profile>
+    <profile id="3923-a411-2e7b-dc9c" name="Turbo-boost" hidden="false" profileTypeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" profileTypeName="Abilities">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <characteristics>
+        <characteristic name="Description" characteristicTypeId="21befb24-fc85-4f52-a745-64b2e48f8228" value="When this model Advances, add 6&quot; to its Move characteristic for that Movement phase instead of rolling a dice."/>
+      </characteristics>
+    </profile>
+    <profile id="0d99-a301-149f-4537" name="Unstoppable Ferocity" hidden="false" profileTypeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" profileTypeName="Abilities">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <characteristics>
+        <characteristic name="Description" characteristicTypeId="21befb24-fc85-4f52-a745-64b2e48f8228" value="If a KHORNE DAEMON unit with this ability either charges, is charged, or performs a Heroic Intervention, add +1 S and +1 A to all models in the unit until the end of the turn."/>
+      </characteristics>
+    </profile>
+    <profile id="b623-8135-5aa4-d13e" name="Quicksilver Swiftness" hidden="false" profileTypeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" profileTypeName="Abilities">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <characteristics>
+        <characteristic name="Description" characteristicTypeId="21befb24-fc85-4f52-a745-64b2e48f8228" value="SLAANESH DAEMON units with this ability always fight first in the Fight phase, even if they didn&apos;t charge. If the enemy has units that have charged, or that have a similar ability, then alternate choosing units to fight with, starting with the player whose turn is taking place."/>
+      </characteristics>
+    </profile>
+    <profile id="95ad-c89a-501a-6c76" name="Might over Magic" hidden="false" profileTypeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" profileTypeName="Abilities">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <characteristics>
+        <characteristic name="Description" characteristicTypeId="21befb24-fc85-4f52-a745-64b2e48f8228" value="A Daemon Prince of KHORNE increases its Attacks characteristic by 1 (this attack is already included in its profile)."/>
+      </characteristics>
+    </profile>
+    <profile id="cb03-ddea-2ac5-9879" name="Ephemeral Form" hidden="false" profileTypeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" profileTypeName="Abilities">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <characteristics>
+        <characteristic name="Description" characteristicTypeId="21befb24-fc85-4f52-a745-64b2e48f8228" value="Add 1 to any invulnerable saving throws made for a TZEENTCH DAEMON with this ability."/>
+      </characteristics>
+    </profile>
+    <profile id="e4c7-f469-f22d-f31b" name="Unholy Speed" hidden="false" profileTypeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" profileTypeName="Abilities">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <characteristics>
+        <characteristic name="Description" characteristicTypeId="21befb24-fc85-4f52-a745-64b2e48f8228" value="This model can Advance and charge in the same turn."/>
+      </characteristics>
+    </profile>
+    <profile id="11c7-1054-a93c-c0b5" name="All is Dust" hidden="false" profileTypeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" profileTypeName="Abilities">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <characteristics>
+        <characteristic name="Description" characteristicTypeId="21befb24-fc85-4f52-a745-64b2e48f8228" value="Add 1 to the saving throws for Rubric Marines if the attack has a Damage characteristic of 1. In addition, the -1 modifier to hit rolls for moving and shooting with a Heavy weapon does not apply to Rubric Marines."/>
+      </characteristics>
+    </profile>
+    <profile id="2dba-f58f-2639-301e" name="Crash and Burn" hidden="false" profileTypeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" profileTypeName="Abilities">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <characteristics>
+        <characteristic name="Description" characteristicTypeId="21befb24-fc85-4f52-a745-64b2e48f8228" value="if this model is reduced to 0 wounds, roll a D6 before removing the model from the battlefield; on a 6 it crashes in a fiery explosion and each unit within 6&quot; suffers D3 mortal wounds."/>
+      </characteristics>
+    </profile>
+    <profile id="ba8c-82d5-79c0-d0d9" name="Ectoplasma cannon" hidden="false" profileTypeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" profileTypeName="Weapon">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <characteristics>
+        <characteristic name="Range" characteristicTypeId="6fa97fa8-ea74-4a27-a0fb-bc4e5f367464" value="24&quot;"/>
+        <characteristic name="Type" characteristicTypeId="077c342f-d7b9-45c6-b8af-88e97cafd3a2" value="Heavy D3"/>
+        <characteristic name="S" characteristicTypeId="59b1-319e-ec13-d466" value="7"/>
+        <characteristic name="AP" characteristicTypeId="75aa-a838-b675-6484" value="-3"/>
+        <characteristic name="D" characteristicTypeId="ae8a-3137-d65b-4ca7" value="D3"/>
+        <characteristic name="Abilities" characteristicTypeId="837d-5e63-aeb7-1410" value="-"/>
       </characteristics>
     </profile>
   </sharedProfiles>

--- a/Chaos - Death Guard.cat
+++ b/Chaos - Death Guard.cat
@@ -4,7 +4,14 @@
   <rules/>
   <infoLinks/>
   <costTypes/>
-  <profileTypes/>
+  <profileTypes>
+    <profileType id="df7f-89aa-8f5b-9d81" name="Gift of Contagion table">
+      <characteristicTypes>
+        <characteristicType id="cd06-e404-83c7-28c2" name="D3 Roll"/>
+        <characteristicType id="04da-4341-1718-541a" name="Effect"/>
+      </characteristicTypes>
+    </profileType>
+  </profileTypes>
   <categoryEntries>
     <categoryEntry id="848a6ff2-0def-4c72-8433-ff7da70e6bc7" name="HQ" hidden="false">
       <profiles/>
@@ -332,19 +339,19 @@
       </profiles>
       <rules/>
       <infoLinks>
-        <infoLink id="a271-ad31-2800-23e0" name="New InfoLink" hidden="false" targetId="6349-022a-cea9-524c" type="rule">
+        <infoLink id="a271-ad31-2800-23e0" name="Death to the False Emperor" hidden="false" targetId="c365-8ca4-3ee1-1677" type="profile">
           <profiles/>
           <rules/>
           <infoLinks/>
           <modifiers/>
         </infoLink>
-        <infoLink id="4da1-37f8-a2e0-faf8" name="New InfoLink" hidden="false" targetId="94d8-b556-103a-36ec" type="rule">
+        <infoLink id="4da1-37f8-a2e0-faf8" name="Sigil of Corruption" hidden="false" targetId="88cc-1fee-7767-1ab4" type="profile">
           <profiles/>
           <rules/>
           <infoLinks/>
           <modifiers/>
         </infoLink>
-        <infoLink id="6a3d-307f-ee7b-0a4d" name="New InfoLink" hidden="false" targetId="8ce7-b46b-12bd-dbb8" type="rule">
+        <infoLink id="6a3d-307f-ee7b-0a4d" name="Lord of Chaos" hidden="false" targetId="766d-c385-bb6c-01a3" type="profile">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -1022,13 +1029,13 @@
         </rule>
       </rules>
       <infoLinks>
-        <infoLink id="2c65-43c6-922d-0004" name="New InfoLink" hidden="false" targetId="6349-022a-cea9-524c" type="rule">
+        <infoLink id="2c65-43c6-922d-0004" name="Death to the False Emperor" hidden="false" targetId="c365-8ca4-3ee1-1677" type="profile">
           <profiles/>
           <rules/>
           <infoLinks/>
           <modifiers/>
         </infoLink>
-        <infoLink id="a861-3c9c-1034-761d" name="New InfoLink" hidden="false" targetId="2946-510b-88fb-5c9c" type="rule">
+        <infoLink id="a861-3c9c-1034-761d" name="Daemonic" hidden="false" targetId="5511-cb37-e1c1-5391" type="profile">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -1155,13 +1162,35 @@
           </constraints>
           <categoryLinks/>
         </entryLink>
-        <entryLink id="22dc-edf2-eeb9-6549" name="New EntryLink" hidden="false" targetId="7aa9-b4b1-f87b-6ef6" type="selectionEntry">
+        <entryLink id="22dc-edf2-eeb9-6549" name="Warp bolter" hidden="false" targetId="7aa9-b4b1-f87b-6ef6" type="selectionEntry">
           <profiles/>
           <rules/>
           <infoLinks/>
           <modifiers/>
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f03d-8095-182f-bf4b" type="max"/>
+          </constraints>
+          <categoryLinks/>
+        </entryLink>
+        <entryLink id="e98f-3b79-e43f-f60d" name="Smite" hidden="false" targetId="03fd-db47-5333-1e1f" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0684-bc32-8d52-17b4" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c001-af7e-9514-9e9d" type="min"/>
+          </constraints>
+          <categoryLinks/>
+        </entryLink>
+        <entryLink id="225c-14a1-014c-4fe8" name="Dark Hereticus Discipline" hidden="false" targetId="d915-3880-41c0-e9a8" type="selectionEntryGroup">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6431-96e1-8316-2c15" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="556b-3480-6b49-751c" type="min"/>
           </constraints>
           <categoryLinks/>
         </entryLink>
@@ -1241,19 +1270,19 @@
       </profiles>
       <rules/>
       <infoLinks>
-        <infoLink id="5ab5-00ee-f312-6033" name="New InfoLink" hidden="false" targetId="3541-94a7-a138-358b" type="rule">
+        <infoLink id="5ab5-00ee-f312-6033" name="Explodes" hidden="false" targetId="3541-94a7-a138-358b" type="rule">
           <profiles/>
           <rules/>
           <infoLinks/>
           <modifiers/>
         </infoLink>
-        <infoLink id="c736-96a1-f303-347b" name="New InfoLink" hidden="false" targetId="2946-510b-88fb-5c9c" type="rule">
+        <infoLink id="c736-96a1-f303-347b" name="Daemonic" hidden="false" targetId="5511-cb37-e1c1-5391" type="profile">
           <profiles/>
           <rules/>
           <infoLinks/>
           <modifiers/>
         </infoLink>
-        <infoLink id="7890-822a-4a71-8c31" name="New InfoLink" hidden="false" targetId="afd3-a04b-c770-90c1" type="rule">
+        <infoLink id="7890-822a-4a71-8c31" name="Infernal Regeneration" hidden="false" targetId="5528-f83b-71b3-0383" type="profile">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -1550,13 +1579,13 @@
       <profiles/>
       <rules/>
       <infoLinks>
-        <infoLink id="494f-4cfd-8a8f-a694" name="New InfoLink" hidden="false" targetId="e915-bbff-dc8e-5212" type="rule">
+        <infoLink id="494f-4cfd-8a8f-a694" name="Disgustingly Resilient" hidden="false" targetId="8f11-6c2b-25e0-d130" type="profile">
           <profiles/>
           <rules/>
           <infoLinks/>
           <modifiers/>
         </infoLink>
-        <infoLink id="68c3-ec7a-d237-9e72" name="New InfoLink" hidden="false" targetId="6349-022a-cea9-524c" type="rule">
+        <infoLink id="68c3-ec7a-d237-9e72" name="Death to the False Emperor" hidden="false" targetId="c365-8ca4-3ee1-1677" type="profile">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -1639,143 +1668,6 @@
         </categoryLink>
       </categoryLinks>
       <selectionEntries>
-        <selectionEntry id="8d5f-fd5a-e5d1-8033" name="Plague Marines" hidden="false" collective="false" type="model">
-          <profiles>
-            <profile id="3a1f-7b96-fa86-dc65" name="Plague Marine" hidden="false" profileTypeId="800f-21d0-4387-c943" profileTypeName="Unit">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <characteristics>
-                <characteristic name="M" characteristicTypeId="0bdf-a96e-9e38-7779" value="5&quot;"/>
-                <characteristic name="WS" characteristicTypeId="e7f0-1278-0250-df0c" value="3+"/>
-                <characteristic name="BS" characteristicTypeId="381b-eb28-74c3-df5f" value="3+"/>
-                <characteristic name="S" characteristicTypeId="2218-aa3c-265f-2939" value="4"/>
-                <characteristic name="T" characteristicTypeId="9c9f-9774-a358-3a39" value="5"/>
-                <characteristic name="W" characteristicTypeId="f330-5e6e-4110-0978" value="1"/>
-                <characteristic name="A" characteristicTypeId="13fc-b29b-31f2-ab9f" value="1"/>
-                <characteristic name="Ld" characteristicTypeId="00ca-f8b8-876d-b705" value="7"/>
-                <characteristic name="Save" characteristicTypeId="c0df-df94-abd7-e8d3" value="3+"/>
-              </characteristics>
-            </profile>
-          </profiles>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints>
-            <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="16be-f986-4901-613e" type="min"/>
-            <constraint field="selections" scope="parent" value="19.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0359-c2b7-f9a3-1779" type="max"/>
-          </constraints>
-          <categoryLinks/>
-          <selectionEntries>
-            <selectionEntry id="6d16-5a5e-1fa8-fa84" name="Plague knife" hidden="false" collective="true" type="upgrade">
-              <profiles/>
-              <rules/>
-              <infoLinks>
-                <infoLink id="b758-63ff-5b60-b887" name="Plague knife" hidden="false" targetId="b62d-7cc2-1b2a-ca61" type="profile">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                </infoLink>
-              </infoLinks>
-              <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2c68-1a4e-726d-f257" type="max"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" id="7571-41b3-62f1-004b" type="min"/>
-              </constraints>
-              <categoryLinks/>
-              <selectionEntries/>
-              <selectionEntryGroups/>
-              <entryLinks/>
-              <costs>
-                <cost name="pts" costTypeId="points" value="0.0"/>
-                <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="0.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="0175-1a5a-1f29-03df" name="Boltgun" hidden="false" collective="true" type="upgrade">
-              <profiles/>
-              <rules/>
-              <infoLinks>
-                <infoLink id="025b-f78c-6145-d217" hidden="false" targetId="3d4b-95ea-f860-dd22" type="profile">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                </infoLink>
-              </infoLinks>
-              <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="a3e7-c27e-0fef-9957" type="min"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="adff-e5cf-0e26-0072" type="max"/>
-              </constraints>
-              <categoryLinks/>
-              <selectionEntries/>
-              <selectionEntryGroups/>
-              <entryLinks/>
-              <costs>
-                <cost name="pts" costTypeId="points" value="0.0"/>
-                <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="0.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="8b05-47a8-16d4-62c3" name="Krak Grenades" hidden="false" collective="true" type="upgrade">
-              <profiles/>
-              <rules/>
-              <infoLinks>
-                <infoLink id="3ce4-1d3d-11b7-66d6" hidden="false" targetId="3bf6-b4f7-6b2f-bb7b" type="profile">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                </infoLink>
-              </infoLinks>
-              <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="29ee-52ee-80ab-e974" type="min"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="a268-5b83-be37-fe47" type="max"/>
-              </constraints>
-              <categoryLinks/>
-              <selectionEntries/>
-              <selectionEntryGroups/>
-              <entryLinks/>
-              <costs>
-                <cost name="pts" costTypeId="points" value="0.0"/>
-                <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="0.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="e891-0e6c-0056-80b7" name="Blight Grenades" hidden="false" collective="true" type="upgrade">
-              <profiles/>
-              <rules/>
-              <infoLinks>
-                <infoLink id="06e6-35ce-9d0a-7bd2" hidden="false" targetId="1287-6659-b04f-fe37" type="profile">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                </infoLink>
-              </infoLinks>
-              <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="2323-ccbc-0b91-a3d2" type="min"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="cca7-eb76-92fd-60e7" type="max"/>
-              </constraints>
-              <categoryLinks/>
-              <selectionEntries/>
-              <selectionEntryGroups/>
-              <entryLinks/>
-              <costs>
-                <cost name="pts" costTypeId="points" value="0.0"/>
-                <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="0.0"/>
-              </costs>
-            </selectionEntry>
-          </selectionEntries>
-          <selectionEntryGroups/>
-          <entryLinks/>
-          <costs>
-            <cost name="pts" costTypeId="points" value="21.0"/>
-            <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="0.0"/>
-          </costs>
-        </selectionEntry>
         <selectionEntry id="ccf9-1340-88d0-82d1" name="Plague Champion" page="" hidden="false" collective="false" type="model">
           <profiles>
             <profile id="9d49-6194-3b73-0e73" name="Plague Champion" page="0" hidden="false" profileTypeId="800f-21d0-4387-c943" profileTypeName="Unit">
@@ -1916,11 +1808,26 @@
               <selectionEntryGroups/>
               <entryLinks/>
             </selectionEntryGroup>
-            <selectionEntryGroup id="e279-57d0-ff6e-1fb3" name="Weapon Layout" hidden="false" collective="false">
+            <selectionEntryGroup id="e279-57d0-ff6e-1fb3" name="Weapon Layout" hidden="false" collective="false" defaultSelectionEntryId="be26-c46e-b32c-b557">
               <profiles/>
               <rules/>
               <infoLinks/>
-              <modifiers/>
+              <modifiers>
+                <modifier type="set" field="6ff5-3ac8-1419-e0b3" value="2">
+                  <repeats/>
+                  <conditions>
+                    <condition field="selections" scope="ccf9-1340-88d0-82d1" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7e02-404b-aa25-3e76" type="atLeast"/>
+                  </conditions>
+                  <conditionGroups/>
+                </modifier>
+                <modifier type="set" field="2f4c-6539-1300-00df" value="2">
+                  <repeats/>
+                  <conditions>
+                    <condition field="selections" scope="ccf9-1340-88d0-82d1" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7e02-404b-aa25-3e76" type="atLeast"/>
+                  </conditions>
+                  <conditionGroups/>
+                </modifier>
+              </modifiers>
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2f4c-6539-1300-00df" type="max"/>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6ff5-3ac8-1419-e0b3" type="min"/>
@@ -1931,8 +1838,18 @@
                   <profiles/>
                   <rules/>
                   <infoLinks/>
-                  <modifiers/>
-                  <constraints/>
+                  <modifiers>
+                    <modifier type="set" field="7bdb-6349-2f4b-c906" value="0.0">
+                      <repeats/>
+                      <conditions>
+                        <condition field="selections" scope="ccf9-1340-88d0-82d1" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7e02-404b-aa25-3e76" type="atLeast"/>
+                      </conditions>
+                      <conditionGroups/>
+                    </modifier>
+                  </modifiers>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7bdb-6349-2f4b-c906" type="max"/>
+                  </constraints>
                   <categoryLinks/>
                   <selectionEntries/>
                   <selectionEntryGroups/>
@@ -1969,8 +1886,18 @@
                   <profiles/>
                   <rules/>
                   <infoLinks/>
-                  <modifiers/>
-                  <constraints/>
+                  <modifiers>
+                    <modifier type="set" field="bd00-59c6-1ed8-edc2" value="0.0">
+                      <repeats/>
+                      <conditions>
+                        <condition field="selections" scope="ccf9-1340-88d0-82d1" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7e02-404b-aa25-3e76" type="atLeast"/>
+                      </conditions>
+                      <conditionGroups/>
+                    </modifier>
+                  </modifiers>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bd00-59c6-1ed8-edc2" type="max"/>
+                  </constraints>
                   <categoryLinks/>
                   <selectionEntries/>
                   <selectionEntryGroups/>
@@ -2003,185 +1930,15 @@
                     <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="0.0"/>
                   </costs>
                 </selectionEntry>
-                <selectionEntry id="2bc0-5da9-60ab-a649" name="Boltgun and other" hidden="false" collective="false" type="upgrade">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                  <constraints/>
-                  <categoryLinks/>
-                  <selectionEntries/>
-                  <selectionEntryGroups/>
-                  <entryLinks>
-                    <entryLink id="27cb-b7c9-26f0-8de8" name="Champion Equipment" hidden="false" targetId="1912-576e-6a2b-5c6e" type="selectionEntryGroup">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks/>
-                      <modifiers>
-                        <modifier type="set" field="0593-89c5-25e7-d094" value="1">
-                          <repeats/>
-                          <conditions/>
-                          <conditionGroups/>
-                        </modifier>
-                      </modifiers>
-                      <constraints>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f002-1572-fbe0-0018" type="max"/>
-                      </constraints>
-                      <categoryLinks/>
-                    </entryLink>
-                    <entryLink id="75e4-5d3c-ba82-bb02" name="Boltgun" hidden="false" targetId="b61f-a3c1-827d-c5b6" type="selectionEntry">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks/>
-                      <modifiers/>
-                      <constraints>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3206-0e47-7190-6d9e" type="max"/>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="92fc-c6a7-ed41-a306" type="min"/>
-                      </constraints>
-                      <categoryLinks/>
-                    </entryLink>
-                  </entryLinks>
-                  <costs>
-                    <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="0.0"/>
-                    <cost name="pts" costTypeId="points" value="0.0"/>
-                  </costs>
-                </selectionEntry>
-                <selectionEntry id="28d1-9fec-6982-c1bc" name="Bolt pistol and other" hidden="false" collective="false" type="upgrade">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                  <constraints/>
-                  <categoryLinks/>
-                  <selectionEntries/>
-                  <selectionEntryGroups/>
-                  <entryLinks>
-                    <entryLink id="b8e0-7d14-f816-0e34" name="Champion Equipment" hidden="false" targetId="1912-576e-6a2b-5c6e" type="selectionEntryGroup">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks/>
-                      <modifiers>
-                        <modifier type="set" field="0593-89c5-25e7-d094" value="1">
-                          <repeats/>
-                          <conditions/>
-                          <conditionGroups/>
-                        </modifier>
-                      </modifiers>
-                      <constraints/>
-                      <categoryLinks/>
-                    </entryLink>
-                    <entryLink id="8d8b-7107-fc9c-fac6" name="Bolt pistol" hidden="false" targetId="0334-f487-8229-0c1a" type="selectionEntry">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks/>
-                      <modifiers/>
-                      <constraints>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6726-480f-b4d2-1c58" type="max"/>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4ff2-f3ef-9006-674c" type="min"/>
-                      </constraints>
-                      <categoryLinks/>
-                    </entryLink>
-                  </entryLinks>
-                  <costs>
-                    <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="0.0"/>
-                    <cost name="pts" costTypeId="points" value="0.0"/>
-                  </costs>
-                </selectionEntry>
-                <selectionEntry id="e036-90f3-fb7f-0552" name="Replace bolt pistol and boltgun" hidden="false" collective="false" type="upgrade">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                  <constraints/>
-                  <categoryLinks/>
-                  <selectionEntries/>
-                  <selectionEntryGroups/>
-                  <entryLinks>
-                    <entryLink id="e1a5-15ed-c55b-175a" name="Champion Equipment" hidden="false" targetId="1912-576e-6a2b-5c6e" type="selectionEntryGroup">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks/>
-                      <modifiers/>
-                      <constraints/>
-                      <categoryLinks/>
-                    </entryLink>
-                  </entryLinks>
-                  <costs>
-                    <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="0.0"/>
-                    <cost name="pts" costTypeId="points" value="0.0"/>
-                  </costs>
-                </selectionEntry>
-              </selectionEntries>
-              <selectionEntryGroups/>
-              <entryLinks/>
-            </selectionEntryGroup>
-          </selectionEntryGroups>
-          <entryLinks/>
-          <costs>
-            <cost name="pts" costTypeId="points" value="21.0"/>
-            <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="0.0"/>
-          </costs>
-        </selectionEntry>
-      </selectionEntries>
-      <selectionEntryGroups>
-        <selectionEntryGroup id="ddf7-07d2-66ed-2444" name="Special Weapon" hidden="false" collective="false">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints>
-            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="b3ee-ded5-f080-8f44" type="max"/>
-          </constraints>
-          <categoryLinks/>
-          <selectionEntries/>
-          <selectionEntryGroups>
-            <selectionEntryGroup id="156d-34af-801d-6504" name="Replace boltgun with..." hidden="false" collective="false">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints/>
-              <categoryLinks/>
-              <selectionEntries>
-                <selectionEntry id="595b-0aab-93dd-68eb" name="Blight launcher" hidden="false" collective="false" type="upgrade">
-                  <profiles>
-                    <profile id="87ee-13c8-0794-26e8" name="Blight launcher" hidden="false" profileTypeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" profileTypeName="Weapon">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks/>
-                      <modifiers/>
-                      <characteristics>
-                        <characteristic name="Range" characteristicTypeId="6fa97fa8-ea74-4a27-a0fb-bc4e5f367464" value="24&quot;"/>
-                        <characteristic name="Type" characteristicTypeId="077c342f-d7b9-45c6-b8af-88e97cafd3a2" value="Assault 2"/>
-                        <characteristic name="S" characteristicTypeId="59b1-319e-ec13-d466" value="6"/>
-                        <characteristic name="AP" characteristicTypeId="75aa-a838-b675-6484" value="-2"/>
-                        <characteristic name="D" characteristicTypeId="ae8a-3137-d65b-4ca7" value="D3"/>
-                        <characteristic name="Abilities" characteristicTypeId="837d-5e63-aeb7-1410" value="You can re-roll wound rolls of 1 for this weapon."/>
-                      </characteristics>
-                    </profile>
-                  </profiles>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                  <constraints/>
-                  <categoryLinks/>
-                  <selectionEntries/>
-                  <selectionEntryGroups/>
-                  <entryLinks/>
-                  <costs>
-                    <cost name="pts" costTypeId="points" value="14.0"/>
-                    <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="0.0"/>
-                  </costs>
-                </selectionEntry>
               </selectionEntries>
               <selectionEntryGroups/>
               <entryLinks>
-                <entryLink id="5114-8e17-dcce-8963" name="New EntryLink" hidden="false" targetId="a44b-4b4d-46b5-d3a6" type="selectionEntryGroup">
+                <entryLink id="7e02-404b-aa25-3e76" name="Fallen Champion Equipment" hidden="false" targetId="891c-fbf0-e426-2c15" type="selectionEntryGroup">
                   <profiles/>
                   <rules/>
                   <infoLinks/>
                   <modifiers>
-                    <modifier type="set" field="26f5-f248-2126-fe15" value="2">
+                    <modifier type="set" field="name" value="Champion Equipment">
                       <repeats/>
                       <conditions/>
                       <conditionGroups/>
@@ -2193,20 +1950,284 @@
               </entryLinks>
             </selectionEntryGroup>
           </selectionEntryGroups>
-          <entryLinks>
-            <entryLink id="7934-b44d-cc39-f4fb" name="New EntryLink" hidden="false" targetId="83be-1ba9-c326-4760" type="selectionEntry">
-              <profiles/>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="21.0"/>
+            <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="0.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="d73a-9ef0-0902-0b1b" name="Plague Marines" hidden="false" collective="false" defaultSelectionEntryId="c854-b99e-1c40-532c">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2702-d0b5-1c59-745b" type="min"/>
+            <constraint field="selections" scope="parent" value="19.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b737-b35b-ad8a-48f9" type="max"/>
+          </constraints>
+          <categoryLinks/>
+          <selectionEntries>
+            <selectionEntry id="c854-b99e-1c40-532c" name="Plague Marines" hidden="false" collective="false" type="model">
+              <profiles>
+                <profile id="c327-f329-2032-388b" name="Plague Marine" hidden="false" profileTypeId="800f-21d0-4387-c943" profileTypeName="Unit">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <characteristics>
+                    <characteristic name="M" characteristicTypeId="0bdf-a96e-9e38-7779" value="5&quot;"/>
+                    <characteristic name="WS" characteristicTypeId="e7f0-1278-0250-df0c" value="3+"/>
+                    <characteristic name="BS" characteristicTypeId="381b-eb28-74c3-df5f" value="3+"/>
+                    <characteristic name="S" characteristicTypeId="2218-aa3c-265f-2939" value="4"/>
+                    <characteristic name="T" characteristicTypeId="9c9f-9774-a358-3a39" value="5"/>
+                    <characteristic name="W" characteristicTypeId="f330-5e6e-4110-0978" value="1"/>
+                    <characteristic name="A" characteristicTypeId="13fc-b29b-31f2-ab9f" value="1"/>
+                    <characteristic name="Ld" characteristicTypeId="00ca-f8b8-876d-b705" value="7"/>
+                    <characteristic name="Save" characteristicTypeId="c0df-df94-abd7-e8d3" value="3+"/>
+                  </characteristics>
+                </profile>
+              </profiles>
               <rules/>
               <infoLinks/>
               <modifiers/>
               <constraints/>
               <categoryLinks/>
-            </entryLink>
-          </entryLinks>
+              <selectionEntries>
+                <selectionEntry id="4922-26b6-b696-28f6" name="Plague knife" hidden="false" collective="true" type="upgrade">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks>
+                    <infoLink id="1013-7781-7164-8f13" name="Plague knife" hidden="false" targetId="b62d-7cc2-1b2a-ca61" type="profile">
+                      <profiles/>
+                      <rules/>
+                      <infoLinks/>
+                      <modifiers/>
+                    </infoLink>
+                  </infoLinks>
+                  <modifiers/>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6974-105b-4beb-e13b" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" id="817c-8f6a-0edb-c563" type="min"/>
+                  </constraints>
+                  <categoryLinks/>
+                  <selectionEntries/>
+                  <selectionEntryGroups/>
+                  <entryLinks/>
+                  <costs>
+                    <cost name="pts" costTypeId="points" value="0.0"/>
+                    <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="0.0"/>
+                  </costs>
+                </selectionEntry>
+                <selectionEntry id="b729-0d57-bd9c-ed50" name="Boltgun" hidden="false" collective="true" type="upgrade">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks>
+                    <infoLink id="908a-9a7c-f3ce-ce58" hidden="false" targetId="3d4b-95ea-f860-dd22" type="profile">
+                      <profiles/>
+                      <rules/>
+                      <infoLinks/>
+                      <modifiers/>
+                    </infoLink>
+                  </infoLinks>
+                  <modifiers/>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="5482-d3d3-0e5e-916b" type="min"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="082c-c959-5422-017d" type="max"/>
+                  </constraints>
+                  <categoryLinks/>
+                  <selectionEntries/>
+                  <selectionEntryGroups/>
+                  <entryLinks/>
+                  <costs>
+                    <cost name="pts" costTypeId="points" value="0.0"/>
+                    <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="0.0"/>
+                  </costs>
+                </selectionEntry>
+                <selectionEntry id="b1d2-4731-8049-8f98" name="Krak Grenades" hidden="false" collective="true" type="upgrade">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks>
+                    <infoLink id="486f-bbd7-59e9-b972" hidden="false" targetId="3bf6-b4f7-6b2f-bb7b" type="profile">
+                      <profiles/>
+                      <rules/>
+                      <infoLinks/>
+                      <modifiers/>
+                    </infoLink>
+                  </infoLinks>
+                  <modifiers/>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="8529-66e7-c143-b97a" type="min"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="fe61-4ef3-799c-aa1e" type="max"/>
+                  </constraints>
+                  <categoryLinks/>
+                  <selectionEntries/>
+                  <selectionEntryGroups/>
+                  <entryLinks/>
+                  <costs>
+                    <cost name="pts" costTypeId="points" value="0.0"/>
+                    <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="0.0"/>
+                  </costs>
+                </selectionEntry>
+              </selectionEntries>
+              <selectionEntryGroups/>
+              <entryLinks>
+                <entryLink id="1a01-3092-37dc-79da" name="Blight Grenades" hidden="false" targetId="e298-8e5d-be7f-e27d" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                  <categoryLinks/>
+                </entryLink>
+              </entryLinks>
+              <costs>
+                <cost name="pts" costTypeId="points" value="21.0"/>
+                <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="c134-4f01-36ce-bed5" name="Plague Marine w/ Special Weapon" hidden="false" collective="false" type="model">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8a31-cdba-ebfa-b758" type="max"/>
+              </constraints>
+              <categoryLinks/>
+              <selectionEntries/>
+              <selectionEntryGroups>
+                <selectionEntryGroup id="b08d-2ca3-f05a-64dd" name="Weapon option" hidden="false" collective="false">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="90b9-341f-d7f2-89d9" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="031c-457e-703a-8311" type="min"/>
+                  </constraints>
+                  <categoryLinks/>
+                  <selectionEntries>
+                    <selectionEntry id="6e2e-b57b-a7dc-1c78" name="Blight launcher" hidden="false" collective="false" type="upgrade">
+                      <profiles>
+                        <profile id="6ff6-cbc1-8889-038c" name="Blight launcher" hidden="false" profileTypeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" profileTypeName="Weapon">
+                          <profiles/>
+                          <rules/>
+                          <infoLinks/>
+                          <modifiers/>
+                          <characteristics>
+                            <characteristic name="Range" characteristicTypeId="6fa97fa8-ea74-4a27-a0fb-bc4e5f367464" value="24&quot;"/>
+                            <characteristic name="Type" characteristicTypeId="077c342f-d7b9-45c6-b8af-88e97cafd3a2" value="Assault 2"/>
+                            <characteristic name="S" characteristicTypeId="59b1-319e-ec13-d466" value="6"/>
+                            <characteristic name="AP" characteristicTypeId="75aa-a838-b675-6484" value="-2"/>
+                            <characteristic name="D" characteristicTypeId="ae8a-3137-d65b-4ca7" value="D3"/>
+                            <characteristic name="Abilities" characteristicTypeId="837d-5e63-aeb7-1410" value="You can re-roll wound rolls of 1 for this weapon."/>
+                          </characteristics>
+                        </profile>
+                      </profiles>
+                      <rules/>
+                      <infoLinks/>
+                      <modifiers/>
+                      <constraints>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c5c8-da0b-0e50-be1a" type="max"/>
+                      </constraints>
+                      <categoryLinks/>
+                      <selectionEntries/>
+                      <selectionEntryGroups/>
+                      <entryLinks/>
+                      <costs>
+                        <cost name="pts" costTypeId="points" value="14.0"/>
+                        <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="0.0"/>
+                      </costs>
+                    </selectionEntry>
+                    <selectionEntry id="8058-d9ed-fc63-c094" name="Boltgun and Plasma Pistol" hidden="false" collective="false" type="upgrade">
+                      <profiles/>
+                      <rules/>
+                      <infoLinks/>
+                      <modifiers/>
+                      <constraints>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="716b-4757-decf-92e6" type="max"/>
+                      </constraints>
+                      <categoryLinks/>
+                      <selectionEntries/>
+                      <selectionEntryGroups/>
+                      <entryLinks>
+                        <entryLink id="22ae-ca70-50a6-da2b" name="Boltgun" hidden="false" targetId="b61f-a3c1-827d-c5b6" type="selectionEntry">
+                          <profiles/>
+                          <rules/>
+                          <infoLinks/>
+                          <modifiers/>
+                          <constraints>
+                            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0a27-62fe-0f84-9144" type="max"/>
+                            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4b21-7d04-e5ca-f607" type="min"/>
+                          </constraints>
+                          <categoryLinks/>
+                        </entryLink>
+                        <entryLink id="4a01-d78c-9d32-7525" name="Plasma pistol" hidden="false" targetId="83be-1ba9-c326-4760" type="selectionEntry">
+                          <profiles/>
+                          <rules/>
+                          <infoLinks/>
+                          <modifiers/>
+                          <constraints>
+                            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0902-cde7-e944-afd9" type="max"/>
+                            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7b0f-1f96-0d5c-1cb7" type="min"/>
+                          </constraints>
+                          <categoryLinks/>
+                        </entryLink>
+                      </entryLinks>
+                      <costs/>
+                    </selectionEntry>
+                  </selectionEntries>
+                  <selectionEntryGroups/>
+                  <entryLinks>
+                    <entryLink id="3bbf-2560-4236-8c1b" name="Special Weapons" hidden="false" targetId="a44b-4b4d-46b5-d3a6" type="selectionEntryGroup">
+                      <profiles/>
+                      <rules/>
+                      <infoLinks/>
+                      <modifiers/>
+                      <constraints>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="df29-c1a1-f41d-51c8" type="max"/>
+                      </constraints>
+                      <categoryLinks/>
+                    </entryLink>
+                  </entryLinks>
+                </selectionEntryGroup>
+              </selectionEntryGroups>
+              <entryLinks>
+                <entryLink id="fd5e-b018-9a69-13cd" name="Blight Grenades" hidden="false" targetId="922e-5c7d-e439-842b" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5ac3-f596-742b-5b71" type="min"/>
+                  </constraints>
+                  <categoryLinks/>
+                </entryLink>
+                <entryLink id="eb86-8346-09b7-5be6" name="Krak grenade" hidden="false" targetId="0f23-cd69-d106-371e" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b4b7-02c4-28f4-d3dc" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b3a6-a9bc-b780-1f51" type="min"/>
+                  </constraints>
+                  <categoryLinks/>
+                </entryLink>
+              </entryLinks>
+              <costs>
+                <cost name="pts" costTypeId="points" value="21.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+          <selectionEntryGroups/>
+          <entryLinks/>
         </selectionEntryGroup>
       </selectionEntryGroups>
       <entryLinks>
-        <entryLink id="6a18-3425-6d7d-cb8d" name="New EntryLink" hidden="false" targetId="2551-97d8-11cb-d026" type="selectionEntry">
+        <entryLink id="6a18-3425-6d7d-cb8d" name="Icon of Despair" hidden="false" targetId="2551-97d8-11cb-d026" type="selectionEntry">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -2247,14 +2268,14 @@
           <characteristics>
             <characteristic name="Cast" characteristicTypeId="5afb-9914-904b-d3b3" value="2"/>
             <characteristic name="Deny" characteristicTypeId="b5ac-9c20-5d5a-6f9b" value="1"/>
-            <characteristic name="Powers Known" characteristicTypeId="69d7-b45e-00a2-7e46" value="2 Dark Hereticus"/>
+            <characteristic name="Powers Known" characteristicTypeId="69d7-b45e-00a2-7e46" value="Smite and two powers from the Dark Hereticus discipline"/>
             <characteristic name="Other" characteristicTypeId="c2e2-f115-0003-5d7b" value=""/>
           </characteristics>
         </profile>
       </profiles>
       <rules/>
       <infoLinks>
-        <infoLink id="e3a5-1035-6513-5ead" name="New InfoLink" hidden="false" targetId="6349-022a-cea9-524c" type="rule">
+        <infoLink id="e3a5-1035-6513-5ead" name="Death to the False Emperor" hidden="false" targetId="c365-8ca4-3ee1-1677" type="profile">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -2389,7 +2410,7 @@
         </selectionEntryGroup>
       </selectionEntryGroups>
       <entryLinks>
-        <entryLink id="e23b-6d34-74a6-f585" name="New EntryLink" hidden="false" targetId="cddf-945e-1335-e681" type="selectionEntry">
+        <entryLink id="e23b-6d34-74a6-f585" name="Frag &amp; Krak grenades" hidden="false" targetId="cddf-945e-1335-e681" type="selectionEntry">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -2400,6 +2421,28 @@
           </constraints>
           <categoryLinks/>
         </entryLink>
+        <entryLink id="393c-4d9f-4822-26b9" name="Smite" hidden="false" targetId="03fd-db47-5333-1e1f" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d651-5bf8-4789-8b1a" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b291-e196-d527-0e5b" type="min"/>
+          </constraints>
+          <categoryLinks/>
+        </entryLink>
+        <entryLink id="1106-8a65-12d0-957c" name="Dark Hereticus Discipline" hidden="false" targetId="d915-3880-41c0-e9a8" type="selectionEntryGroup">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a930-2014-9ad7-abfb" type="max"/>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="da56-6262-e167-92b4" type="min"/>
+          </constraints>
+          <categoryLinks/>
+        </entryLink>
       </entryLinks>
       <costs>
         <cost name="pts" costTypeId="points" value="90.0"/>
@@ -2407,31 +2450,35 @@
       </costs>
     </selectionEntry>
     <selectionEntry id="172a-9105-e028-28a8" name="Poxwalkers" hidden="false" collective="false" type="unit">
-      <profiles/>
-      <rules>
-        <rule id="b572-2962-c406-4e33" name="Curse of the Walking Pox" book="" hidden="false">
+      <profiles>
+        <profile id="d790-78b6-d5e7-1b4a" name="Curse of the Walking Pox" hidden="false" profileTypeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" profileTypeName="Abilities">
           <profiles/>
           <rules/>
           <infoLinks/>
           <modifiers/>
-          <description>Each time an enemy Infantry model is slain by a Poxwalker in the Fight phase, add one model to the Poxwalker&apos;s unit.</description>
-        </rule>
-        <rule id="6919-0703-fc51-ec33" name="Diseased Horde" hidden="false">
+          <characteristics>
+            <characteristic name="Description" characteristicTypeId="21befb24-fc85-4f52-a745-64b2e48f8228" value="Each time an enemy INFANTRY model is slain by a Poxwalker in the Fight phase, add one model to the Poxwalker&apos;s unit."/>
+          </characteristics>
+        </profile>
+        <profile id="2d7a-1e14-30ea-4f16" name="Diseased Horde" hidden="false" profileTypeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" profileTypeName="Abilities">
           <profiles/>
           <rules/>
           <infoLinks/>
           <modifiers/>
-          <description>You can add 1 to all hit rolls for this unit in the Fight phase if it contains more than 10 models.</description>
-        </rule>
-      </rules>
+          <characteristics>
+            <characteristic name="Description" characteristicTypeId="21befb24-fc85-4f52-a745-64b2e48f8228" value="You can add 1 to all hit rolls for this unit in the Fight phase if it contains more than 10 models."/>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules/>
       <infoLinks>
-        <infoLink id="637c-6286-0fb5-ce17" name="New InfoLink" hidden="false" targetId="b962-c13b-7edc-556d" type="rule">
+        <infoLink id="637c-6286-0fb5-ce17" name="Mindless" hidden="false" targetId="d147-d281-9501-00b9" type="profile">
           <profiles/>
           <rules/>
           <infoLinks/>
           <modifiers/>
         </infoLink>
-        <infoLink id="eeb9-93c7-49aa-e063" name="New InfoLink" hidden="false" targetId="e915-bbff-dc8e-5212" type="rule">
+        <infoLink id="eeb9-93c7-49aa-e063" name="Disgustingly Resilient" hidden="false" targetId="8f11-6c2b-25e0-d130" type="profile">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -2637,19 +2684,19 @@
           <infoLinks/>
           <modifiers/>
           <characteristics>
-            <characteristic name="Description" characteristicTypeId="21befb24-fc85-4f52-a745-64b2e48f8228" value="If this model is reduced to 0 wounds, roll a D6 before removing it from the battlefield; on a 4+ it explodes, and each unit within 7&quot; suffers 1 MW."/>
+            <characteristic name="Description" characteristicTypeId="21befb24-fc85-4f52-a745-64b2e48f8228" value="If this model is reduced to 0 wounds, roll a D6 before removing it from the battlefield; on a 4+ it explodes, and each unit within 7&quot; suffers 1 mortal wound."/>
           </characteristics>
         </profile>
       </profiles>
       <rules/>
       <infoLinks>
-        <infoLink id="ba63-d7c1-1129-2705" name="New InfoLink" hidden="false" targetId="e915-bbff-dc8e-5212" type="rule">
+        <infoLink id="ba63-d7c1-1129-2705" name="Disgustingly Resilient" hidden="false" targetId="8f11-6c2b-25e0-d130" type="profile">
           <profiles/>
           <rules/>
           <infoLinks/>
           <modifiers/>
         </infoLink>
-        <infoLink id="020a-3e9f-3c5b-4a8a" name="New InfoLink" hidden="false" targetId="2946-510b-88fb-5c9c" type="rule">
+        <infoLink id="020a-3e9f-3c5b-4a8a" name="Daemonic" hidden="false" targetId="5511-cb37-e1c1-5391" type="profile">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -2847,19 +2894,19 @@
       </profiles>
       <rules/>
       <infoLinks>
-        <infoLink id="071a-23a5-897d-ec72" name="New InfoLink" hidden="false" targetId="8ce7-b46b-12bd-dbb8" type="rule">
+        <infoLink id="071a-23a5-897d-ec72" name="Lord of Chaos" hidden="false" targetId="766d-c385-bb6c-01a3" type="profile">
           <profiles/>
           <rules/>
           <infoLinks/>
           <modifiers/>
         </infoLink>
-        <infoLink id="3fc8-d436-34a0-8ceb" name="New InfoLink" hidden="false" targetId="6349-022a-cea9-524c" type="rule">
+        <infoLink id="3fc8-d436-34a0-8ceb" name="Death to the False Emperor" hidden="false" targetId="c365-8ca4-3ee1-1677" type="profile">
           <profiles/>
           <rules/>
           <infoLinks/>
           <modifiers/>
         </infoLink>
-        <infoLink id="0cb3-227c-566d-b9e3" name="New InfoLink" hidden="false" targetId="94d8-b556-103a-36ec" type="rule">
+        <infoLink id="0cb3-227c-566d-b9e3" name="Sigil of Corruption" hidden="false" targetId="88cc-1fee-7767-1ab4" type="profile">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -3041,24 +3088,25 @@
             <characteristic name="Save" characteristicTypeId="c0df-df94-abd7-e8d3" value="3+"/>
           </characteristics>
         </profile>
-      </profiles>
-      <rules>
-        <rule id="0128-bf82-850d-bf76" name="Lord of Nurgle" hidden="false">
+        <profile id="0311-5d3a-c729-4220" name="Lord of Nurgle" hidden="false" profileTypeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" profileTypeName="Abilities">
           <profiles/>
           <rules/>
           <infoLinks/>
           <modifiers/>
-          <description>You can re-roll all hit rolls of 1 made for friendly Nurgle &lt;Legion&gt; units within 6&quot; of this model.</description>
-        </rule>
-      </rules>
+          <characteristics>
+            <characteristic name="Description" characteristicTypeId="21befb24-fc85-4f52-a745-64b2e48f8228" value="You can re-roll all hit rolls of 1 made for friendly Nurgle &lt;Legion&gt; units within 6&quot; of this model."/>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules/>
       <infoLinks>
-        <infoLink id="3714-95b3-8aba-37b4" name="New InfoLink" hidden="false" targetId="94d8-b556-103a-36ec" type="rule">
+        <infoLink id="3714-95b3-8aba-37b4" name="Sigil of Corruption" hidden="false" targetId="88cc-1fee-7767-1ab4" type="profile">
           <profiles/>
           <rules/>
           <infoLinks/>
           <modifiers/>
         </infoLink>
-        <infoLink id="61bb-67f7-e7e0-7a3c" name="New InfoLink" hidden="false" targetId="6349-022a-cea9-524c" type="rule">
+        <infoLink id="61bb-67f7-e7e0-7a3c" name="Death to the False Emperor" hidden="false" targetId="c365-8ca4-3ee1-1677" type="profile">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -3168,7 +3216,7 @@
         </selectionEntry>
       </selectionEntries>
       <selectionEntryGroups>
-        <selectionEntryGroup id="6a7f-0136-f237-79e9" name="Pistol options" hidden="false" collective="false">
+        <selectionEntryGroup id="6a7f-0136-f237-79e9" name="Pistol options" hidden="false" collective="false" defaultSelectionEntryId="3795-2a7b-cc30-0993">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -3232,7 +3280,7 @@
             </entryLink>
           </entryLinks>
         </selectionEntryGroup>
-        <selectionEntryGroup id="2605-3932-78c6-ef0f" name="Chainsword options" hidden="false" collective="false">
+        <selectionEntryGroup id="2605-3932-78c6-ef0f" name="Chainsword options" hidden="false" collective="false" defaultSelectionEntryId="8820-968e-bb33-3d73">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -3332,19 +3380,19 @@
         </rule>
       </rules>
       <infoLinks>
-        <infoLink id="d93a-8ea0-2820-fc3b" name="New InfoLink" hidden="false" targetId="6349-022a-cea9-524c" type="rule">
+        <infoLink id="d93a-8ea0-2820-fc3b" name="Death to the False Emperor" hidden="false" targetId="c365-8ca4-3ee1-1677" type="profile">
           <profiles/>
           <rules/>
           <infoLinks/>
           <modifiers/>
         </infoLink>
-        <infoLink id="a042-0bc1-8591-23f3" name="Sigil of Corruption" hidden="false" targetId="94d8-b556-103a-36ec" type="rule">
+        <infoLink id="a042-0bc1-8591-23f3" name="Sigil of Corruption" hidden="false" targetId="88cc-1fee-7767-1ab4" type="profile">
           <profiles/>
           <rules/>
           <infoLinks/>
           <modifiers/>
         </infoLink>
-        <infoLink id="9617-d732-bb4d-0435" name="New InfoLink" hidden="false" targetId="8ce7-b46b-12bd-dbb8" type="rule">
+        <infoLink id="9617-d732-bb4d-0435" name="Lord of Chaos" hidden="false" targetId="766d-c385-bb6c-01a3" type="profile">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -3448,12 +3496,14 @@
           <selectionEntries/>
           <selectionEntryGroups/>
           <entryLinks>
-            <entryLink id="2102-8c51-8e99-04ca" name="New EntryLink" hidden="false" targetId="0334-f487-8229-0c1a" type="selectionEntry">
+            <entryLink id="2102-8c51-8e99-04ca" name="Bolt pistol" hidden="false" targetId="0334-f487-8229-0c1a" type="selectionEntry">
               <profiles/>
               <rules/>
               <infoLinks/>
               <modifiers/>
-              <constraints/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="40b4-0f3f-a411-d1fe" type="max"/>
+              </constraints>
               <categoryLinks/>
             </entryLink>
             <entryLink id="fee1-cab1-3015-9768" name="New EntryLink" hidden="false" targetId="ce84-10ca-568c-5c48" type="selectionEntryGroup">
@@ -3482,7 +3532,7 @@
             </entryLink>
           </entryLinks>
         </selectionEntryGroup>
-        <selectionEntryGroup id="fb1a-7ac0-8bf9-f6fd" name="Chainsword options" hidden="false" collective="false">
+        <selectionEntryGroup id="fb1a-7ac0-8bf9-f6fd" name="Chainsword options" hidden="false" collective="false" defaultSelectionEntryId="3684-b249-8583-4167">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -3608,13 +3658,13 @@
         </rule>
       </rules>
       <infoLinks>
-        <infoLink id="4e39-3732-b1e1-220c" name="New InfoLink" hidden="false" targetId="6349-022a-cea9-524c" type="rule">
+        <infoLink id="4e39-3732-b1e1-220c" name="Death to the False Emperor" hidden="false" targetId="c365-8ca4-3ee1-1677" type="profile">
           <profiles/>
           <rules/>
           <infoLinks/>
           <modifiers/>
         </infoLink>
-        <infoLink id="53f2-1999-22d7-52e2" name="New InfoLink" hidden="false" targetId="2946-510b-88fb-5c9c" type="rule">
+        <infoLink id="53f2-1999-22d7-52e2" name="Daemonic" hidden="false" targetId="5511-cb37-e1c1-5391" type="profile">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -3758,6 +3808,28 @@
           </constraints>
           <categoryLinks/>
         </entryLink>
+        <entryLink id="4e8f-48a6-e3df-5f4d" name="Smite" hidden="false" targetId="03fd-db47-5333-1e1f" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e8df-2b8a-0065-8263" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0832-adf0-3602-37b1" type="min"/>
+          </constraints>
+          <categoryLinks/>
+        </entryLink>
+        <entryLink id="120e-430f-ed0c-d58e" name="Dark Hereticus Discipline" hidden="false" targetId="d915-3880-41c0-e9a8" type="selectionEntryGroup">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a2c1-fe39-ae88-000e" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="47ae-4608-6fb4-3ae4" type="min"/>
+          </constraints>
+          <categoryLinks/>
+        </entryLink>
       </entryLinks>
       <costs>
         <cost name="pts" costTypeId="points" value="170.0"/>
@@ -3791,14 +3863,14 @@
           <characteristics>
             <characteristic name="Cast" characteristicTypeId="5afb-9914-904b-d3b3" value="2"/>
             <characteristic name="Deny" characteristicTypeId="b5ac-9c20-5d5a-6f9b" value="1"/>
-            <characteristic name="Powers Known" characteristicTypeId="69d7-b45e-00a2-7e46" value="2 Dark Hereticus"/>
+            <characteristic name="Powers Known" characteristicTypeId="69d7-b45e-00a2-7e46" value="Smite and two powers from the Dark Hereticus discipline"/>
             <characteristic name="Other" characteristicTypeId="c2e2-f115-0003-5d7b" value=""/>
           </characteristics>
         </profile>
       </profiles>
       <rules/>
       <infoLinks>
-        <infoLink id="2370-ad7a-4106-a343" name="New InfoLink" hidden="false" targetId="6349-022a-cea9-524c" type="rule">
+        <infoLink id="2370-ad7a-4106-a343" name="Death to the False Emperor" hidden="false" targetId="c365-8ca4-3ee1-1677" type="profile">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -3810,7 +3882,7 @@
           <infoLinks/>
           <modifiers/>
         </infoLink>
-        <infoLink id="003d-95c4-1498-c261" name="New InfoLink" hidden="false" targetId="e2cc-3e10-f4a9-d911" type="rule">
+        <infoLink id="003d-95c4-1498-c261" name="Terminator Armour" hidden="false" targetId="3b9c-0848-e334-fcce" type="profile">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -3966,7 +4038,30 @@
           </entryLinks>
         </selectionEntryGroup>
       </selectionEntryGroups>
-      <entryLinks/>
+      <entryLinks>
+        <entryLink id="fd7d-5dee-c6f3-9585" name="Smite" hidden="false" targetId="03fd-db47-5333-1e1f" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8978-6dd2-5646-5f8f" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1375-d7a9-85fa-a644" type="min"/>
+          </constraints>
+          <categoryLinks/>
+        </entryLink>
+        <entryLink id="5f01-51f6-5738-653d" name="Dark Hereticus Discipline" hidden="false" targetId="d915-3880-41c0-e9a8" type="selectionEntryGroup">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="56b8-2c73-904b-1c8f" type="max"/>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="08fb-0e93-e9a9-2901" type="min"/>
+          </constraints>
+          <categoryLinks/>
+        </entryLink>
+      </entryLinks>
       <costs>
         <cost name="pts" costTypeId="points" value="140.0"/>
         <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="8.0"/>
@@ -3999,7 +4094,7 @@
           <characteristics>
             <characteristic name="Cast" characteristicTypeId="5afb-9914-904b-d3b3" value="2"/>
             <characteristic name="Deny" characteristicTypeId="b5ac-9c20-5d5a-6f9b" value="1"/>
-            <characteristic name="Powers Known" characteristicTypeId="69d7-b45e-00a2-7e46" value="2 Dark Hereticus"/>
+            <characteristic name="Powers Known" characteristicTypeId="69d7-b45e-00a2-7e46" value="Smite and two powers from the Dark Hereticus discipline"/>
             <characteristic name="Other" characteristicTypeId="c2e2-f115-0003-5d7b" value=""/>
           </characteristics>
         </profile>
@@ -4014,7 +4109,7 @@
         </rule>
       </rules>
       <infoLinks>
-        <infoLink id="b394-4dae-b58d-112c" name="Death to the False Emperor" hidden="false" targetId="6349-022a-cea9-524c" type="rule">
+        <infoLink id="b394-4dae-b58d-112c" name="Death to the False Emperor" hidden="false" targetId="c365-8ca4-3ee1-1677" type="profile">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -4192,6 +4287,28 @@
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d66b-a1c1-9b54-048b" type="max"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b096-aea9-7408-d16d" type="min"/>
+          </constraints>
+          <categoryLinks/>
+        </entryLink>
+        <entryLink id="8667-6ea4-6e3d-a6c7" name="Dark Hereticus Discipline" hidden="false" targetId="d915-3880-41c0-e9a8" type="selectionEntryGroup">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8f5a-1e61-3de3-d508" type="max"/>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e9e4-c7a1-8f3d-de4f" type="min"/>
+          </constraints>
+          <categoryLinks/>
+        </entryLink>
+        <entryLink id="f4f6-1acc-9b4f-9c7e" name="Smite" hidden="false" targetId="03fd-db47-5333-1e1f" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d50e-8287-533a-edda" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9144-283c-8763-5b28" type="min"/>
           </constraints>
           <categoryLinks/>
         </entryLink>
@@ -4457,19 +4574,19 @@
       </profiles>
       <rules/>
       <infoLinks>
-        <infoLink id="ba1b-47f4-2a1a-108d" name="New InfoLink" hidden="false" targetId="6349-022a-cea9-524c" type="rule">
+        <infoLink id="ba1b-47f4-2a1a-108d" name="Death to the False Emperor" hidden="false" targetId="c365-8ca4-3ee1-1677" type="profile">
           <profiles/>
           <rules/>
           <infoLinks/>
           <modifiers/>
         </infoLink>
-        <infoLink id="b3fe-34c0-9e85-3c13" name="New InfoLink" hidden="false" targetId="2946-510b-88fb-5c9c" type="rule">
+        <infoLink id="b3fe-34c0-9e85-3c13" name="Daemonic" hidden="false" targetId="5511-cb37-e1c1-5391" type="profile">
           <profiles/>
           <rules/>
           <infoLinks/>
           <modifiers/>
         </infoLink>
-        <infoLink id="fcae-f649-8083-0afb" name="New InfoLink" hidden="false" targetId="802b-8d1b-8b9f-41e2" type="profile">
+        <infoLink id="fcae-f649-8083-0afb" name="Wrist-mounted grenade launcher" hidden="false" targetId="802b-8d1b-8b9f-41e2" type="profile">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -5251,26 +5368,8 @@
           <characteristics>
             <characteristic name="Cast" characteristicTypeId="5afb-9914-904b-d3b3" value="2"/>
             <characteristic name="Deny" characteristicTypeId="b5ac-9c20-5d5a-6f9b" value="1"/>
-            <characteristic name="Powers Known" characteristicTypeId="69d7-b45e-00a2-7e46" value="2 Contagion"/>
+            <characteristic name="Powers Known" characteristicTypeId="69d7-b45e-00a2-7e46" value="Smite andtwo powers from the Contagion discipline"/>
             <characteristic name="Other" characteristicTypeId="c2e2-f115-0003-5d7b" value=""/>
-          </characteristics>
-        </profile>
-        <profile id="934f-baa4-f27f-c961" name="Cataphractii Armour" book="" hidden="false" profileTypeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" profileTypeName="Abilities">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <characteristics>
-            <characteristic name="Description" characteristicTypeId="21befb24-fc85-4f52-a745-64b2e48f8228" value="Typhus has a 4++ save, but you must halve the result of the dice rolled when determining how far he Advances."/>
-          </characteristics>
-        </profile>
-        <profile id="5e0b-b7cc-0d08-1ab5" name="Nurgle&apos;s Gift" hidden="false" profileTypeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" profileTypeName="Abilities">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <characteristics>
-            <characteristic name="Description" characteristicTypeId="21befb24-fc85-4f52-a745-64b2e48f8228" value="All Death Guard models within 7&quot; of Typhus are surrounded by a deadly aura of plague and disease. Roll a D6 for each enemy unit that is within 1&quot; of one or more such model at the start of your turn. On a 4+ that unit suffers a MW."/>
           </characteristics>
         </profile>
         <profile id="9deb-6cf4-69a7-ae42" name="Host of the Destroyer Hive" hidden="false" profileTypeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" profileTypeName="Abilities">
@@ -5285,19 +5384,31 @@
       </profiles>
       <rules/>
       <infoLinks>
-        <infoLink id="bc11-d143-ac94-df30" name="New InfoLink" hidden="false" targetId="6349-022a-cea9-524c" type="rule">
+        <infoLink id="bc11-d143-ac94-df30" name="Death to the False Emperor" hidden="false" targetId="c365-8ca4-3ee1-1677" type="profile">
           <profiles/>
           <rules/>
           <infoLinks/>
           <modifiers/>
         </infoLink>
-        <infoLink id="98c6-1081-5a47-f73f" name="New InfoLink" hidden="false" targetId="ae9c-d115-d4a9-ba02" type="rule">
+        <infoLink id="98c6-1081-5a47-f73f" name="Teleport Strike" hidden="false" targetId="ae9c-d115-d4a9-ba02" type="rule">
           <profiles/>
           <rules/>
           <infoLinks/>
           <modifiers/>
         </infoLink>
-        <infoLink id="5bf4-d26b-ba3b-8824" name="New InfoLink" hidden="false" targetId="e915-bbff-dc8e-5212" type="rule">
+        <infoLink id="5bf4-d26b-ba3b-8824" name="Disgustingly Resilient" hidden="false" targetId="8f11-6c2b-25e0-d130" type="profile">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="8dca-f49b-a261-e5ef" name="Cataphractii Armour" hidden="false" targetId="057a-5462-ce7c-192e" type="profile">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="b7b4-04bf-20f0-cfc0" name="Nurgle&apos;s Gift" hidden="false" targetId="c1eb-0be8-7b52-a516" type="profile">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -5372,31 +5483,6 @@
         </categoryLink>
       </categoryLinks>
       <selectionEntries>
-        <selectionEntry id="2116-64ca-6956-bf24" name="Blight Grenades" hidden="false" collective="true" type="upgrade">
-          <profiles/>
-          <rules/>
-          <infoLinks>
-            <infoLink id="2bbb-c44f-fd8f-3394" hidden="false" targetId="1287-6659-b04f-fe37" type="profile">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-            </infoLink>
-          </infoLinks>
-          <modifiers/>
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="8de0-9944-5a83-97d9" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="bd1e-47b5-ebf2-2c50" type="max"/>
-          </constraints>
-          <categoryLinks/>
-          <selectionEntries/>
-          <selectionEntryGroups/>
-          <entryLinks/>
-          <costs>
-            <cost name="pts" costTypeId="points" value="0.0"/>
-            <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="0.0"/>
-          </costs>
-        </selectionEntry>
         <selectionEntry id="380c-e574-d5e1-c206" name="The Destroyer Hive" hidden="false" collective="false" type="upgrade">
           <profiles>
             <profile id="31ba-3b52-4c6d-437a" name="The Destroyer Hive" hidden="false" profileTypeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" profileTypeName="Weapon">
@@ -5465,7 +5551,38 @@
         </selectionEntry>
       </selectionEntries>
       <selectionEntryGroups/>
-      <entryLinks/>
+      <entryLinks>
+        <entryLink id="1263-3574-5e3b-7f24" name="Smite" hidden="false" targetId="03fd-db47-5333-1e1f" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="da30-76ae-d27e-de08" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7298-1992-5242-8516" type="min"/>
+          </constraints>
+          <categoryLinks/>
+        </entryLink>
+        <entryLink id="76a4-c5bf-ba32-6aed" name="Contagion Discipline" hidden="false" targetId="51d0-6d01-4ab3-4953" type="selectionEntryGroup">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8a4d-86e3-d06f-7115" type="max"/>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3c91-ff74-6930-8655" type="min"/>
+          </constraints>
+          <categoryLinks/>
+        </entryLink>
+        <entryLink id="33b0-b9be-8eb7-aba4" name="Blight Grenades" hidden="false" targetId="922e-5c7d-e439-842b" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+          <categoryLinks/>
+        </entryLink>
+      </entryLinks>
       <costs>
         <cost name="pts" costTypeId="points" value="164.0"/>
         <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="9.0"/>
@@ -5490,28 +5607,10 @@
             <characteristic name="Save" characteristicTypeId="c0df-df94-abd7-e8d3" value="2+"/>
           </characteristics>
         </profile>
-        <profile id="21e2-9f93-e27c-15f4" name="Cataphractii Armour" book="" hidden="false" profileTypeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" profileTypeName="Abilities">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <characteristics>
-            <characteristic name="Description" characteristicTypeId="21befb24-fc85-4f52-a745-64b2e48f8228" value="This model has a 4++ save, but you must halve the result of the dice rolled when determining how far he Advances."/>
-          </characteristics>
-        </profile>
-        <profile id="7289-6730-9066-a67e" name="Nurgle&apos;s Gift" hidden="false" profileTypeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" profileTypeName="Abilities">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <characteristics>
-            <characteristic name="Description" characteristicTypeId="21befb24-fc85-4f52-a745-64b2e48f8228" value="All Death Guard models within 7&quot; of this model are surrounded by a deadly aura of plague and disease. Roll a D6 for each enemy unit that is within 1&quot; of one or more such model at the start of your turn. On a 4+ that unit suffers a MW."/>
-          </characteristics>
-        </profile>
       </profiles>
       <rules/>
       <infoLinks>
-        <infoLink id="d40a-56c4-c227-5878" name="New InfoLink" hidden="false" targetId="6349-022a-cea9-524c" type="rule">
+        <infoLink id="d40a-56c4-c227-5878" name="Death to the False Emperor" hidden="false" targetId="c365-8ca4-3ee1-1677" type="profile">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -5523,7 +5622,19 @@
           <infoLinks/>
           <modifiers/>
         </infoLink>
-        <infoLink id="68e6-537c-ca3a-ccae" name="New InfoLink" hidden="false" targetId="e915-bbff-dc8e-5212" type="rule">
+        <infoLink id="68e6-537c-ca3a-ccae" name="Disgustingly Resilient" hidden="false" targetId="8f11-6c2b-25e0-d130" type="profile">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="7c74-1ed6-7ee4-5db4" name="Cataphractii Armour" hidden="false" targetId="057a-5462-ce7c-192e" type="profile">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="48e5-d53d-99d8-23c2" name="Nurgle&apos;s Gift" hidden="false" targetId="c1eb-0be8-7b52-a516" type="profile">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -5664,7 +5775,7 @@
           <infoLinks/>
           <modifiers/>
           <characteristics>
-            <characteristic name="Description" characteristicTypeId="21befb24-fc85-4f52-a745-64b2e48f8228" value="Each time this model successfully manifests a psychic power with a Psychic test of 7 or more, the nearest enemy unit within 7&quot; suffers a MW after the effects of the psychic power have been resolved."/>
+            <characteristic name="Description" characteristicTypeId="21befb24-fc85-4f52-a745-64b2e48f8228" value="Each time this model successfully manifests a psychic power with a Psychic test of 7 or more, the nearest enemy unit within 7&quot; suffers a mortal wound after the effects of the psychic power have been resolved."/>
           </characteristics>
         </profile>
         <profile id="d4c4-089d-fc0a-eeb8" name="Malignant Plaguecaster" hidden="false" profileTypeId="bc97-dea9-9e88-bb7d" profileTypeName="Psyker">
@@ -5675,20 +5786,20 @@
           <characteristics>
             <characteristic name="Cast" characteristicTypeId="5afb-9914-904b-d3b3" value="2"/>
             <characteristic name="Deny" characteristicTypeId="b5ac-9c20-5d5a-6f9b" value="1"/>
-            <characteristic name="Powers Known" characteristicTypeId="69d7-b45e-00a2-7e46" value="2 Contagion"/>
+            <characteristic name="Powers Known" characteristicTypeId="69d7-b45e-00a2-7e46" value="Smite and 2 powers from the Contagion discipline"/>
             <characteristic name="Other" characteristicTypeId="c2e2-f115-0003-5d7b" value=""/>
           </characteristics>
         </profile>
       </profiles>
       <rules/>
       <infoLinks>
-        <infoLink id="e06a-2b3c-40b3-871d" name="New InfoLink" hidden="false" targetId="6349-022a-cea9-524c" type="rule">
+        <infoLink id="e06a-2b3c-40b3-871d" name="Death to the False Emperor" hidden="false" targetId="c365-8ca4-3ee1-1677" type="profile">
           <profiles/>
           <rules/>
           <infoLinks/>
           <modifiers/>
         </infoLink>
-        <infoLink id="1b35-1ed9-4133-cbff" name="New InfoLink" hidden="false" targetId="e915-bbff-dc8e-5212" type="rule">
+        <infoLink id="1b35-1ed9-4133-cbff" name="Disgustingly Resilient" hidden="false" targetId="8f11-6c2b-25e0-d130" type="profile">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -5789,60 +5900,10 @@
             <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="0.0"/>
           </costs>
         </selectionEntry>
-        <selectionEntry id="2068-3d73-5a9f-ddc5" name="Krak Grenades" hidden="false" collective="false" type="upgrade">
-          <profiles/>
-          <rules/>
-          <infoLinks>
-            <infoLink id="5ab7-c7dd-b653-42b5" hidden="false" targetId="3bf6-b4f7-6b2f-bb7b" type="profile">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-            </infoLink>
-          </infoLinks>
-          <modifiers/>
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="070b-0199-0aac-ffcd" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="e495-defa-edbe-c8d6" type="max"/>
-          </constraints>
-          <categoryLinks/>
-          <selectionEntries/>
-          <selectionEntryGroups/>
-          <entryLinks/>
-          <costs>
-            <cost name="pts" costTypeId="points" value="0.0"/>
-            <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="0.0"/>
-          </costs>
-        </selectionEntry>
-        <selectionEntry id="5719-ad58-6d55-0e94" name="Blight Grenades" hidden="false" collective="false" type="upgrade">
-          <profiles/>
-          <rules/>
-          <infoLinks>
-            <infoLink id="feae-d9e8-ef2c-8552" hidden="false" targetId="1287-6659-b04f-fe37" type="profile">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-            </infoLink>
-          </infoLinks>
-          <modifiers/>
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="aa61-6796-4bf4-0c74" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="4844-1139-d968-92e2" type="max"/>
-          </constraints>
-          <categoryLinks/>
-          <selectionEntries/>
-          <selectionEntryGroups/>
-          <entryLinks/>
-          <costs>
-            <cost name="pts" costTypeId="points" value="0.0"/>
-            <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="0.0"/>
-          </costs>
-        </selectionEntry>
       </selectionEntries>
       <selectionEntryGroups/>
       <entryLinks>
-        <entryLink id="b923-7525-e0c2-647a" name="New EntryLink" hidden="false" targetId="0334-f487-8229-0c1a" type="selectionEntry">
+        <entryLink id="b923-7525-e0c2-647a" name="Bolt pistol" hidden="false" targetId="0334-f487-8229-0c1a" type="selectionEntry">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -5850,6 +5911,44 @@
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="f1ed-e02f-3c08-a561" type="max"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="1548-9ea8-0e55-adf0" type="min"/>
+          </constraints>
+          <categoryLinks/>
+        </entryLink>
+        <entryLink id="fd37-33fb-6690-eb58" name="Smite" hidden="false" targetId="03fd-db47-5333-1e1f" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+          <categoryLinks/>
+        </entryLink>
+        <entryLink id="8bf0-7cd1-5502-5319" name="Blight Grenades" hidden="false" targetId="922e-5c7d-e439-842b" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+          <categoryLinks/>
+        </entryLink>
+        <entryLink id="fed4-d88a-e3c0-7a6f" name="Krak grenade" hidden="false" targetId="0f23-cd69-d106-371e" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a5fe-900a-b6ca-7225" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f2f4-8d54-4222-2ef4" type="min"/>
+          </constraints>
+          <categoryLinks/>
+        </entryLink>
+        <entryLink id="e964-1f78-4524-3e06" name="Contagion Discipline" hidden="false" targetId="51d0-6d01-4ab3-4953" type="selectionEntryGroup">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1521-e86c-703a-a39f" type="max"/>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="065c-b391-a31d-9065" type="min"/>
           </constraints>
           <categoryLinks/>
         </entryLink>
@@ -6195,19 +6294,19 @@
           <infoLinks/>
           <modifiers/>
           <characteristics>
-            <characteristic name="Description" characteristicTypeId="21befb24-fc85-4f52-a745-64b2e48f8228" value="Units must subtract 1 from their Ld whilst they are within 7&quot; of any enemy Noxious Blightbringers (Psykers must subtract 2 instead). In addition, if a Death Guard unit is within 7&quot; of any friendly Noxious Blightbringers when it Advances, roll two dice and discard the lowest result when determining how far that unit Advances."/>
+            <characteristic name="Description" characteristicTypeId="21befb24-fc85-4f52-a745-64b2e48f8228" value="Units must subtract 1 from their Leadership whilst they are within 7&quot; of any enemy Noxious Blightbringers (PSYKERS must subtract 2 instead). In addition, if a DEATH GUARD unit is within 7&quot; of any friendly Noxious Blightbringers when it Advances, roll two dice and discard the lowest result when determining how far that unit Advances."/>
           </characteristics>
         </profile>
       </profiles>
       <rules/>
       <infoLinks>
-        <infoLink id="ba3a-8726-0882-9bf6" name="New InfoLink" hidden="false" targetId="6349-022a-cea9-524c" type="rule">
+        <infoLink id="ba3a-8726-0882-9bf6" name="Death to the False Emperor" hidden="false" targetId="c365-8ca4-3ee1-1677" type="profile">
           <profiles/>
           <rules/>
           <infoLinks/>
           <modifiers/>
         </infoLink>
-        <infoLink id="c256-891c-7350-b2f0" name="New InfoLink" hidden="false" targetId="e915-bbff-dc8e-5212" type="rule">
+        <infoLink id="c256-891c-7350-b2f0" name="Disgustingly Resilient" hidden="false" targetId="8f11-6c2b-25e0-d130" type="profile">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -6308,35 +6407,10 @@
             <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="0.0"/>
           </costs>
         </selectionEntry>
-        <selectionEntry id="7125-0a8a-1fce-1f49" name="Blight Grenades" hidden="false" collective="false" type="upgrade">
-          <profiles/>
-          <rules/>
-          <infoLinks>
-            <infoLink id="076e-0d04-fdb5-9322" hidden="false" targetId="1287-6659-b04f-fe37" type="profile">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-            </infoLink>
-          </infoLinks>
-          <modifiers/>
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="148c-a695-0f8e-27ef" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="e941-250b-c148-bf78" type="max"/>
-          </constraints>
-          <categoryLinks/>
-          <selectionEntries/>
-          <selectionEntryGroups/>
-          <entryLinks/>
-          <costs>
-            <cost name="pts" costTypeId="points" value="0.0"/>
-            <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="0.0"/>
-          </costs>
-        </selectionEntry>
       </selectionEntries>
       <selectionEntryGroups/>
       <entryLinks>
-        <entryLink id="59a7-9f39-cdac-41b7" name="New EntryLink" hidden="false" targetId="83be-1ba9-c326-4760" type="selectionEntry">
+        <entryLink id="59a7-9f39-cdac-41b7" name="Plasma pistol" hidden="false" targetId="83be-1ba9-c326-4760" type="selectionEntry">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -6347,7 +6421,7 @@
           </constraints>
           <categoryLinks/>
         </entryLink>
-        <entryLink id="c0ef-e9fc-a587-0d87" name="New EntryLink" hidden="false" targetId="0f23-cd69-d106-371e" type="selectionEntry">
+        <entryLink id="c0ef-e9fc-a587-0d87" name="Krak grenade" hidden="false" targetId="0f23-cd69-d106-371e" type="selectionEntry">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -6355,6 +6429,17 @@
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="406f-7360-4cad-8cb8" type="max"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" id="d92c-36b6-5b52-f11b" type="min"/>
+          </constraints>
+          <categoryLinks/>
+        </entryLink>
+        <entryLink id="d0c8-d517-e1be-192f" name="Blight Grenades" hidden="false" targetId="922e-5c7d-e439-842b" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1846-30cd-8f33-ce2a" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d6f7-4679-f17e-ed8e" type="min"/>
           </constraints>
           <categoryLinks/>
         </entryLink>
@@ -6451,7 +6536,7 @@
         </rule>
       </rules>
       <infoLinks>
-        <infoLink id="aa8d-8a09-2e52-0ea3" name="New InfoLink" hidden="false" targetId="b4eb-f3f5-d439-1834" type="rule">
+        <infoLink id="aa8d-8a09-2e52-0ea3" name="Daemonic Machine Spirit" hidden="false" targetId="0a51-a58b-8738-a51f" type="profile">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -6611,14 +6696,14 @@
           <characteristics>
             <characteristic name="Cast" characteristicTypeId="5afb-9914-904b-d3b3" value="2"/>
             <characteristic name="Deny" characteristicTypeId="b5ac-9c20-5d5a-6f9b" value="1"/>
-            <characteristic name="Powers Known" characteristicTypeId="69d7-b45e-00a2-7e46" value="2 Dark Hereticus"/>
+            <characteristic name="Powers Known" characteristicTypeId="69d7-b45e-00a2-7e46" value="Smite and two powers from the Dark Hereticus discipline"/>
             <characteristic name="Other" characteristicTypeId="c2e2-f115-0003-5d7b" value=""/>
           </characteristics>
         </profile>
       </profiles>
       <rules/>
       <infoLinks>
-        <infoLink id="2bb5-390d-7100-fb2c" name="Death to the False Emperor" hidden="false" targetId="6349-022a-cea9-524c" type="rule">
+        <infoLink id="2bb5-390d-7100-fb2c" name="Death to the False Emperor" hidden="false" targetId="c365-8ca4-3ee1-1677" type="profile">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -6833,15 +6918,273 @@
           </constraints>
           <categoryLinks/>
         </entryLink>
+        <entryLink id="7678-c514-f4fa-bd4d" name="Dark Hereticus Discipline" hidden="false" targetId="d915-3880-41c0-e9a8" type="selectionEntryGroup">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e922-b9e4-88cf-1e38" type="max"/>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a5b1-ec14-9dee-2c5c" type="min"/>
+          </constraints>
+          <categoryLinks/>
+        </entryLink>
+        <entryLink id="396f-e628-f65f-31f7" name="Smite" hidden="false" targetId="03fd-db47-5333-1e1f" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a6ef-72a8-428c-44a8" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c512-63b5-08cd-0048" type="min"/>
+          </constraints>
+          <categoryLinks/>
+        </entryLink>
       </entryLinks>
       <costs>
         <cost name="pts" costTypeId="points" value="123.0"/>
         <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="8.0"/>
       </costs>
     </selectionEntry>
+    <selectionEntry id="7841-ab80-2a2a-9ee6" name="Plague Wind" hidden="false" collective="false" type="upgrade">
+      <profiles>
+        <profile id="c2d7-cf6f-02ee-79c8" name="Plague Wind" hidden="false" profileTypeId="ae70-4738-0161-bec0" profileTypeName="Psychic Power">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Warp Charge" characteristicTypeId="5ffd-b800-c317-532a" value="5"/>
+            <characteristic name="Range" characteristicTypeId="fd64-cbc4-94de-24cc" value="18&quot;"/>
+            <characteristic name="Details" characteristicTypeId="ad96-dfa4-b4ed-656d" value="If manifested, slect a visible enemy unit within 18&quot; of the psyker. Roll one dice for each model in that unit - the unit suffers a mortal wound for each roll of 6."/>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a085-c328-77f2-005e" type="max"/>
+      </constraints>
+      <categoryLinks/>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="0.0"/>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="f56c-5f04-53b5-93e5" name="Miasma of Pestilence" hidden="false" collective="false" type="upgrade">
+      <profiles>
+        <profile id="e5b8-6a57-647c-b258" name="Miasma of Pestilence" hidden="false" profileTypeId="ae70-4738-0161-bec0" profileTypeName="Psychic Power">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Warp Charge" characteristicTypeId="5ffd-b800-c317-532a" value="6"/>
+            <characteristic name="Range" characteristicTypeId="fd64-cbc4-94de-24cc" value="18&quot;"/>
+            <characteristic name="Details" characteristicTypeId="ad96-dfa4-b4ed-656d" value="If manifested, select a visible friendly DEATH GUARD unit withn 18&quot; of the psyker. Until the start of your next Psychic phase, your opponent must subtract 1 from all hit rolls which target that unit."/>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7a42-0d88-3dcc-1687" type="max"/>
+      </constraints>
+      <categoryLinks/>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="0.0"/>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="99bd-b1b2-e84c-a226" name="Gift of Contagion" hidden="false" collective="false" type="upgrade">
+      <profiles>
+        <profile id="3784-fa39-385f-ea4e" name="Gift of Contagion" hidden="false" profileTypeId="ae70-4738-0161-bec0" profileTypeName="Psychic Power">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Warp Charge" characteristicTypeId="5ffd-b800-c317-532a" value="7"/>
+            <characteristic name="Range" characteristicTypeId="fd64-cbc4-94de-24cc" value="18&quot;"/>
+            <characteristic name="Details" characteristicTypeId="ad96-dfa4-b4ed-656d" value="If manifested, select a visble enemy unit within 18&quot; of the psyker and roll a D3. Consult the table to discover what characteristic penalty all models in that unit suffer until the start of your next Psychic phase (this cannot reduce a characteristic to less than 1)."/>
+          </characteristics>
+        </profile>
+        <profile id="99ba-86d7-afd7-dc23" name="Gift of Contagion 1" hidden="false" profileTypeId="df7f-89aa-8f5b-9d81" profileTypeName="Gift of Contagion table">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="D3 Roll" characteristicTypeId="cd06-e404-83c7-28c2" value="1"/>
+            <characteristic name="Effect" characteristicTypeId="04da-4341-1718-541a" value="Flyblown Palsy: -1 Attack"/>
+          </characteristics>
+        </profile>
+        <profile id="0647-d548-277b-1b57" name="Gift of Contagion 2" hidden="false" profileTypeId="df7f-89aa-8f5b-9d81" profileTypeName="Gift of Contagion table">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="D3 Roll" characteristicTypeId="cd06-e404-83c7-28c2" value="2"/>
+            <characteristic name="Effect" characteristicTypeId="04da-4341-1718-541a" value="Muscular Atrophy: -1 Strength"/>
+          </characteristics>
+        </profile>
+        <profile id="c0c1-9c30-3a4c-f850" name="Gift of Contagion 3" hidden="false" profileTypeId="df7f-89aa-8f5b-9d81" profileTypeName="Gift of Contagion table">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="D3 Roll" characteristicTypeId="cd06-e404-83c7-28c2" value="3"/>
+            <characteristic name="Effect" characteristicTypeId="04da-4341-1718-541a" value="Liquefying Ague: -1 Toughness"/>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="50cd-fa0b-a41c-7cfa" type="max"/>
+      </constraints>
+      <categoryLinks/>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="0.0"/>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="922e-5c7d-e439-842b" name="Blight Grenades" hidden="false" collective="false" type="upgrade">
+      <profiles/>
+      <rules/>
+      <infoLinks>
+        <infoLink id="d9ae-6195-2590-c58b" name="Blight Grenades" hidden="false" targetId="1287-6659-b04f-fe37" type="profile">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7c78-e6e6-7817-26e8" type="max"/>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1dcf-5177-66df-85b2" type="min"/>
+      </constraints>
+      <categoryLinks/>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs/>
+    </selectionEntry>
+    <selectionEntry id="e298-8e5d-be7f-e27d" name="Blight Grenades" hidden="false" collective="true" type="upgrade">
+      <profiles/>
+      <rules/>
+      <infoLinks>
+        <infoLink id="019f-4807-568f-96e5" hidden="false" targetId="1287-6659-b04f-fe37" type="profile">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="6496-0fce-7c6a-47c5" type="min"/>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="0359-03b2-4dac-4b0d" type="max"/>
+      </constraints>
+      <categoryLinks/>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+        <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="b339-aeff-d933-715c" name="Infernal Gaze" hidden="false" collective="false" type="upgrade">
+      <profiles/>
+      <rules/>
+      <infoLinks>
+        <infoLink id="2e21-9a57-7311-5fbc" name="Infernal Gaze" hidden="false" targetId="3db4-da59-6233-9d52" type="profile">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="689e-372a-d2e0-f3d9" type="max"/>
+      </constraints>
+      <categoryLinks/>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="0.0"/>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="7879-4959-e68e-9cac" name="Warptime" hidden="false" collective="false" type="upgrade">
+      <profiles/>
+      <rules/>
+      <infoLinks>
+        <infoLink id="077e-cf97-3633-fdc8" name="Warptime" hidden="false" targetId="ed9e-f5b3-1d95-faaf" type="profile">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9a86-9c45-47fe-a1c4" type="max"/>
+      </constraints>
+      <categoryLinks/>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="0.0"/>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="0007-8465-9875-a29f" name="Prescience" hidden="false" collective="false" type="upgrade">
+      <profiles/>
+      <rules/>
+      <infoLinks>
+        <infoLink id="e0a9-92aa-282a-cbb6" name="Prescience" hidden="false" targetId="e0ef-08d9-8f70-b6b7" type="profile">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="766b-0ebd-5f0f-9198" type="max"/>
+      </constraints>
+      <categoryLinks/>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="0.0"/>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
   </sharedSelectionEntries>
   <sharedSelectionEntryGroups>
-    <selectionEntryGroup id="1912-576e-6a2b-5c6e" name="Champion Equipment" hidden="false" collective="false">
+    <selectionEntryGroup id="1912-576e-6a2b-5c6e" name="Champion Equipment" hidden="false" collective="false" defaultSelectionEntryId="fdb4-16ca-f677-e192">
       <profiles/>
       <rules/>
       <infoLinks/>
@@ -6852,7 +7195,7 @@
       <categoryLinks/>
       <selectionEntries/>
       <selectionEntryGroups>
-        <selectionEntryGroup id="d938-568f-c2e6-1f46" name="Max 1 of these" hidden="false" collective="false">
+        <selectionEntryGroup id="d938-568f-c2e6-1f46" name="Max 1 of these" hidden="false" collective="false" defaultSelectionEntryId="671d-ee8b-5a35-1534">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -6896,15 +7239,7 @@
               <constraints/>
               <categoryLinks/>
             </entryLink>
-            <entryLink id="bde6-035e-fbcf-5f94" name="New EntryLink" hidden="false" targetId="fdce-cdf7-21a9-f9ac" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints/>
-              <categoryLinks/>
-            </entryLink>
-            <entryLink id="99a1-3ebb-84ca-f1b6" name="Lightning Claw (Pair)" hidden="false" targetId="7603-6241-ab8b-4603" type="selectionEntry">
+            <entryLink id="bde6-035e-fbcf-5f94" name="Combi-plasma" hidden="false" targetId="fdce-cdf7-21a9-f9ac" type="selectionEntry">
               <profiles/>
               <rules/>
               <infoLinks/>
@@ -6940,7 +7275,7 @@
           <constraints/>
           <categoryLinks/>
         </entryLink>
-        <entryLink id="f0c8-636d-8eae-04b6" name="New EntryLink" hidden="false" targetId="90de-7b01-e401-888b" type="selectionEntry">
+        <entryLink id="f0c8-636d-8eae-04b6" name="Lightning Claw" hidden="false" targetId="90de-7b01-e401-888b" type="selectionEntry">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -6980,7 +7315,7 @@
           <constraints/>
           <categoryLinks/>
         </entryLink>
-        <entryLink id="ba0d-4316-d707-7eda" name="New EntryLink" hidden="false" targetId="bc9e-551d-9afb-78d5" type="selectionEntry">
+        <entryLink id="ba0d-4316-d707-7eda" name="Power sword" hidden="false" targetId="bc9e-551d-9afb-78d5" type="selectionEntry">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -7282,28 +7617,80 @@
         </entryLink>
       </entryLinks>
     </selectionEntryGroup>
+    <selectionEntryGroup id="51d0-6d01-4ab3-4953" name="Contagion Discipline" book="Index Chaos" page="57" hidden="false" collective="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints/>
+      <categoryLinks/>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks>
+        <entryLink id="c825-7273-0d36-0b41" name="Gift of Contagion" hidden="false" targetId="99bd-b1b2-e84c-a226" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+          <categoryLinks/>
+        </entryLink>
+        <entryLink id="0e99-fc84-ef12-39b5" name="Miasma of Pestilence" hidden="false" targetId="f56c-5f04-53b5-93e5" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+          <categoryLinks/>
+        </entryLink>
+        <entryLink id="f205-05a5-16b5-e897" name="Plague Wind" hidden="false" targetId="7841-ab80-2a2a-9ee6" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+          <categoryLinks/>
+        </entryLink>
+      </entryLinks>
+    </selectionEntryGroup>
+    <selectionEntryGroup id="d915-3880-41c0-e9a8" name="Dark Hereticus Discipline" hidden="false" collective="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints/>
+      <categoryLinks/>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks>
+        <entryLink id="684f-9386-afe2-9622" name="Infernal Gaze" hidden="false" targetId="b339-aeff-d933-715c" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+          <categoryLinks/>
+        </entryLink>
+        <entryLink id="a7ef-69d7-7180-2eca" name="Warptime" hidden="false" targetId="7879-4959-e68e-9cac" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+          <categoryLinks/>
+        </entryLink>
+        <entryLink id="5987-8d07-24d7-dc26" name="Prescience" hidden="false" targetId="0007-8465-9875-a29f" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+          <categoryLinks/>
+        </entryLink>
+      </entryLinks>
+    </selectionEntryGroup>
   </sharedSelectionEntryGroups>
   <sharedRules>
-    <rule id="b962-c13b-7edc-556d" name="Mindless" hidden="false">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <description>This unit never has to take Morale tests.</description>
-    </rule>
-    <rule id="e915-bbff-dc8e-5212" name="Disgustingly Resilient" hidden="false">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <description>Each time this model loses a wound, roll a D6; on a 5-6, it does not lose that wound.</description>
-    </rule>
-    <rule id="6349-022a-cea9-524c" name="Death to the False Emperor" hidden="false">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-    </rule>
     <rule id="ae9c-d115-d4a9-ba02" name="Teleport Strike" hidden="false">
       <profiles/>
       <rules/>
@@ -7311,60 +7698,11 @@
       <modifiers/>
       <description>During deployment, you can set up this model in a teleportarium chamber instead of placing it on the battlefield. At the end of any of your Movement phases the model can use a teleport strike to arrive on the battlefield - set it up anywhere on the battlefield that is more than 9&quot; away from any enemy models.</description>
     </rule>
-    <rule id="2946-510b-88fb-5c9c" name="Daemonic" hidden="false">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <description>This model has a 5++.</description>
-    </rule>
-    <rule id="b4eb-f3f5-d439-1834" name="Daemonic Machine Spirit" hidden="false">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <description>Ignore the -1 to hit modifier for moving and shooting Heavy weapons for this model.</description>
-    </rule>
-    <rule id="94d8-b556-103a-36ec" name="Sigil of Corruption" hidden="false">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <description>This model has a 4++ save.</description>
-    </rule>
     <rule id="224f-2c86-454d-54aa" name="Daemonic Ritual" hidden="false">
       <profiles/>
       <rules/>
       <infoLinks/>
       <modifiers/>
-    </rule>
-    <rule id="8ce7-b46b-12bd-dbb8" name="Lord of Chaos" hidden="false">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <description>You can re-roll hit rolls of 1 made for friendly &lt;Legion&gt; units within 6&quot; of this model.</description>
-    </rule>
-    <rule id="e008-161d-80a5-aef1" name="Turbo-boost" hidden="false">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <description>When this model Advances, add 6&quot; to its Move characteristic for that Movement phase instead of rolling a dice.</description>
-    </rule>
-    <rule id="e2cc-3e10-f4a9-d911" name="Terminator Armour" hidden="false">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <description>This model has a 5++.</description>
-    </rule>
-    <rule id="afd3-a04b-c770-90c1" name="Infernal Regeneration" hidden="false">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <description>At the beginning of each of your turns, this model heals one wound.</description>
     </rule>
   </sharedRules>
   <sharedProfiles>
@@ -7702,6 +8040,147 @@
         <characteristic name="AP" characteristicTypeId="75aa-a838-b675-6484" value="0"/>
         <characteristic name="D" characteristicTypeId="ae8a-3137-d65b-4ca7" value="1"/>
         <characteristic name="Abilities" characteristicTypeId="837d-5e63-aeb7-1410" value="-"/>
+      </characteristics>
+    </profile>
+    <profile id="8f11-6c2b-25e0-d130" name="Disgustingly Resilient" hidden="false" profileTypeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" profileTypeName="Abilities">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <characteristics>
+        <characteristic name="Description" characteristicTypeId="21befb24-fc85-4f52-a745-64b2e48f8228" value="Each time this model loses a wound, roll a D6; on a 5-6, it does not lose that wound."/>
+      </characteristics>
+    </profile>
+    <profile id="c365-8ca4-3ee1-1677" name="Death to the False Emperor" hidden="false" profileTypeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" profileTypeName="Abilities">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <characteristics>
+        <characteristic name="Description" characteristicTypeId="21befb24-fc85-4f52-a745-64b2e48f8228" value="Each time you roll a hit roll of 6+ for a model with this ability in the Fight phase, it can, if it was targeting an IMPERIUM unit, immediately make an extra attack against the same unit using the same weapon. These extra attacks cannot themselves generate any further attacks."/>
+      </characteristics>
+    </profile>
+    <profile id="057a-5462-ce7c-192e" name="Cataphractii Armour" book="" hidden="false" profileTypeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" profileTypeName="Abilities">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <characteristics>
+        <characteristic name="Description" characteristicTypeId="21befb24-fc85-4f52-a745-64b2e48f8228" value="This model has a 4+ invulnerable save, but you must halve the result of the dice rolled when determining how far he Advances."/>
+      </characteristics>
+    </profile>
+    <profile id="c1eb-0be8-7b52-a516" name="Nurgle&apos;s Gift" hidden="false" profileTypeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" profileTypeName="Abilities">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <characteristics>
+        <characteristic name="Description" characteristicTypeId="21befb24-fc85-4f52-a745-64b2e48f8228" value="All DEATH GUARD models within 7&quot; of this model are surrounded by a deadly aura of plague and disease. Roll a D6 for each enemy unit that is within 1&quot; of one or more such model at the start of your turn. On a 4+ that unit suffers a mortal wound."/>
+      </characteristics>
+    </profile>
+    <profile id="d147-d281-9501-00b9" name="Mindless" hidden="false" profileTypeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" profileTypeName="Abilities">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <characteristics>
+        <characteristic name="Description" characteristicTypeId="21befb24-fc85-4f52-a745-64b2e48f8228" value="This unit never has to take Morale tests."/>
+      </characteristics>
+    </profile>
+    <profile id="5511-cb37-e1c1-5391" name="Daemonic" hidden="false" profileTypeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" profileTypeName="Abilities">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <characteristics>
+        <characteristic name="Description" characteristicTypeId="21befb24-fc85-4f52-a745-64b2e48f8228" value="This model has a 5+ invulnerable save."/>
+      </characteristics>
+    </profile>
+    <profile id="3db4-da59-6233-9d52" name="Infernal Gaze" hidden="false" profileTypeId="ae70-4738-0161-bec0" profileTypeName="Psychic Power">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <characteristics>
+        <characteristic name="Warp Charge" characteristicTypeId="5ffd-b800-c317-532a" value="5"/>
+        <characteristic name="Range" characteristicTypeId="fd64-cbc4-94de-24cc" value="18&quot;"/>
+        <characteristic name="Details" characteristicTypeId="ad96-dfa4-b4ed-656d" value="If manifested, select a visible enemy unit within 18&quot; of the psyker and roll 3 dice. The target suffers one mortal wound for each roll of 4+."/>
+      </characteristics>
+    </profile>
+    <profile id="ed9e-f5b3-1d95-faaf" name="Warptime" hidden="false" profileTypeId="ae70-4738-0161-bec0" profileTypeName="Psychic Power">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <characteristics>
+        <characteristic name="Warp Charge" characteristicTypeId="5ffd-b800-c317-532a" value="6"/>
+        <characteristic name="Range" characteristicTypeId="fd64-cbc4-94de-24cc" value="3&quot;"/>
+        <characteristic name="Details" characteristicTypeId="ad96-dfa4-b4ed-656d" value="If manifested, pick a friendly HERETIC ASTARTES unit within 3&quot; of the psyker. That unit can immediately move as if it were its Movement phase. You cannot use Warptime on a unit ,pre than once in each Psychic phase."/>
+      </characteristics>
+    </profile>
+    <profile id="e0ef-08d9-8f70-b6b7" name="Prescience" hidden="false" profileTypeId="ae70-4738-0161-bec0" profileTypeName="Psychic Power">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <characteristics>
+        <characteristic name="Warp Charge" characteristicTypeId="5ffd-b800-c317-532a" value="7"/>
+        <characteristic name="Range" characteristicTypeId="fd64-cbc4-94de-24cc" value="18&quot;"/>
+        <characteristic name="Details" characteristicTypeId="ad96-dfa4-b4ed-656d" value="If manifested, select a HERETIC ASTARTES unit within 18&quot; of the psyker. You can add 1 to all hit rolls made for that unit until the start of your next Psychic phase."/>
+      </characteristics>
+    </profile>
+    <profile id="766d-c385-bb6c-01a3" name="Lord of Chaos" hidden="false" profileTypeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" profileTypeName="Abilities">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <characteristics>
+        <characteristic name="Description" characteristicTypeId="21befb24-fc85-4f52-a745-64b2e48f8228" value="You can re-roll hit rolls of 1 made for friendly &lt;Legion&gt; units within 6&quot; of this model."/>
+      </characteristics>
+    </profile>
+    <profile id="88cc-1fee-7767-1ab4" name="Sigil of Corruption" hidden="false" profileTypeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" profileTypeName="Abilities">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <characteristics>
+        <characteristic name="Description" characteristicTypeId="21befb24-fc85-4f52-a745-64b2e48f8228" value="This model has a 4+ invulnerable save."/>
+      </characteristics>
+    </profile>
+    <profile id="5528-f83b-71b3-0383" name="Infernal Regeneration" hidden="false" profileTypeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" profileTypeName="Abilities">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <characteristics>
+        <characteristic name="Description" characteristicTypeId="21befb24-fc85-4f52-a745-64b2e48f8228" value="At the beginning of each of your turns, this model heals one wound."/>
+      </characteristics>
+    </profile>
+    <profile id="0a51-a58b-8738-a51f" name="Daemonic Machine Spirit" hidden="false" profileTypeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" profileTypeName="Abilities">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <characteristics>
+        <characteristic name="Description" characteristicTypeId="21befb24-fc85-4f52-a745-64b2e48f8228" value="Ignore the -1 to hit modifier for moving and shooting Heavy weapons for this model."/>
+      </characteristics>
+    </profile>
+    <profile id="3b9c-0848-e334-fcce" name="Terminator Armour" hidden="false" profileTypeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" profileTypeName="Abilities">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <characteristics>
+        <characteristic name="Description" characteristicTypeId="21befb24-fc85-4f52-a745-64b2e48f8228" value="This model has a 5+ invulnerable save."/>
+      </characteristics>
+    </profile>
+    <profile id="096a-65d2-c413-f9db" name="Turbo-boost" hidden="false" profileTypeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" profileTypeName="Abilities">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <characteristics>
+        <characteristic name="Description" characteristicTypeId="21befb24-fc85-4f52-a745-64b2e48f8228" value="When this model Advances, add 6&quot; to its Move characteristic for that Movement phase instead of rolling a dice."/>
       </characteristics>
     </profile>
   </sharedProfiles>

--- a/Chaos - Death Guard.cat
+++ b/Chaos - Death Guard.cat
@@ -2078,7 +2078,10 @@
                   <rules/>
                   <infoLinks/>
                   <modifiers/>
-                  <constraints/>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="23a4-54e6-f12f-6a84" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="986b-deeb-0751-039e" type="min"/>
+                  </constraints>
                   <categoryLinks/>
                 </entryLink>
               </entryLinks>
@@ -2176,7 +2179,10 @@
                           <categoryLinks/>
                         </entryLink>
                       </entryLinks>
-                      <costs/>
+                      <costs>
+                        <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="0.0"/>
+                        <cost name="pts" costTypeId="points" value="0.0"/>
+                      </costs>
                     </selectionEntry>
                   </selectionEntries>
                   <selectionEntryGroups/>
@@ -2202,6 +2208,7 @@
                   <modifiers/>
                   <constraints>
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5ac3-f596-742b-5b71" type="min"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ff57-d343-375f-289f" type="max"/>
                   </constraints>
                   <categoryLinks/>
                 </entryLink>
@@ -2219,6 +2226,7 @@
               </entryLinks>
               <costs>
                 <cost name="pts" costTypeId="points" value="21.0"/>
+                <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -7083,7 +7091,10 @@
       <selectionEntries/>
       <selectionEntryGroups/>
       <entryLinks/>
-      <costs/>
+      <costs>
+        <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="0.0"/>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
     </selectionEntry>
     <selectionEntry id="e298-8e5d-be7f-e27d" name="Blight Grenades" hidden="false" collective="true" type="upgrade">
       <profiles/>

--- a/Chaos - Death Guard.cat
+++ b/Chaos - Death Guard.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="ce57-cc1c-37cb-cb71" name="Chaos - Death Guard" book="Index: Chaos" revision="10" battleScribeVersion="2.01" authorName="BSData team" authorUrl="http://battlescribedata.appspot.com/#/repo/wh40k" gameSystemId="28ec-711c-d87f-3aeb" gameSystemRevision="1" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="ce57-cc1c-37cb-cb71" name="Chaos - Death Guard" book="Index: Chaos" revision="11" battleScribeVersion="2.01" authorName="BSData team" authorUrl="http://battlescribedata.appspot.com/#/repo/wh40k" gameSystemId="28ec-711c-d87f-3aeb" gameSystemRevision="1" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <profiles/>
   <rules/>
   <infoLinks/>

--- a/Chaos - FW Heretic Astartes.cat
+++ b/Chaos - FW Heretic Astartes.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="2128-f196-8f1c-b352" name="Chaos - FW Heretic Astartes" revision="4" battleScribeVersion="2.01" gameSystemId="28ec-711c-d87f-3aeb" gameSystemRevision="1" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="2128-f196-8f1c-b352" name="Chaos - FW Heretic Astartes" revision="5" battleScribeVersion="2.01" gameSystemId="28ec-711c-d87f-3aeb" gameSystemRevision="1" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <profiles/>
   <rules/>
   <infoLinks/>
@@ -53,14 +53,14 @@
     </profileType>
   </profileTypes>
   <categoryEntries>
-    <categoryEntry id="2b8b-d5c5-972d-1d7a" name="(Legion)" hidden="false">
+    <categoryEntry id="2b8b-d5c5-972d-1d7a" name="&lt;Legion&gt;" hidden="false">
       <profiles/>
       <rules/>
       <infoLinks/>
       <modifiers/>
       <constraints/>
     </categoryEntry>
-    <categoryEntry id="096e-708c-dd20-2c10" name="(Mark of Chaos)" hidden="false">
+    <categoryEntry id="096e-708c-dd20-2c10" name="&lt;Mark of Chaos&gt;" hidden="false">
       <profiles/>
       <rules/>
       <infoLinks/>
@@ -215,6 +215,20 @@
       <constraints/>
     </categoryEntry>
     <categoryEntry id="1220-2c46-baf6-0616" name="World Eaters" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints/>
+    </categoryEntry>
+    <categoryEntry id="8005-9fea-4a32-1869" name="Vindicator" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints/>
+    </categoryEntry>
+    <categoryEntry id="10f6-976a-6af5-e817" name="Relic" hidden="false">
       <profiles/>
       <rules/>
       <infoLinks/>
@@ -506,6 +520,30 @@
       <categoryLinks/>
     </entryLink>
     <entryLink id="35e4-efb2-a787-084f" name="Plague Hulk of Nurgle" hidden="false" targetId="d9a0-b543-74aa-fe4f" type="selectionEntry">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints/>
+      <categoryLinks/>
+    </entryLink>
+    <entryLink id="ee56-80f6-2fb4-36ef" name="Ferrum Infernus Dreadnought" hidden="false" targetId="2cc8-0e93-7906-cdf0" type="selectionEntry">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints/>
+      <categoryLinks/>
+    </entryLink>
+    <entryLink id="9ac9-076a-9aea-0687" name="Sonic Dreadnought" hidden="false" targetId="3672-0dd5-d396-dc4b" type="selectionEntry">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints/>
+      <categoryLinks/>
+    </entryLink>
+    <entryLink id="9017-2a26-dbd7-cbd4" name="Chaos Vindicator Laser Destroyer" hidden="false" targetId="f957-f774-e452-34ea" type="selectionEntry">
       <profiles/>
       <rules/>
       <infoLinks/>
@@ -1618,7 +1656,7 @@
               <selectionEntryGroups/>
               <entryLinks/>
               <costs>
-                <cost name="pts" costTypeId="points" value="30.0"/>
+                <cost name="pts" costTypeId="points" value="60.0"/>
                 <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="0.0"/>
               </costs>
             </selectionEntry>
@@ -2348,7 +2386,7 @@
                     </entryLink>
                   </entryLinks>
                 </selectionEntryGroup>
-                <selectionEntryGroup id="28bf-f3fc-56c4-35d1" name="Claw option" hidden="false" collective="false" defaultSelectionEntryId="aacc-e8e2-e103-9dec">
+                <selectionEntryGroup id="28bf-f3fc-56c4-35d1" name="Claw option" hidden="false" collective="false" defaultSelectionEntryId="bf7d-7e96-e5d3-f90e">
                   <profiles/>
                   <rules/>
                   <infoLinks/>
@@ -2366,70 +2404,26 @@
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="385f-c620-a954-93e4" type="min"/>
                   </constraints>
                   <categoryLinks/>
-                  <selectionEntries>
-                    <selectionEntry id="aacc-e8e2-e103-9dec" name="Hellforged deathclaw" hidden="false" collective="false" type="upgrade">
-                      <profiles>
-                        <profile id="6ebf-fb38-b114-cd23" name="Hellforged deathclaw" hidden="false" profileTypeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" profileTypeName="Weapon">
-                          <profiles/>
-                          <rules/>
-                          <infoLinks/>
-                          <modifiers/>
-                          <characteristics>
-                            <characteristic name="Range" characteristicTypeId="6fa97fa8-ea74-4a27-a0fb-bc4e5f367464" value="Melee"/>
-                            <characteristic name="Type" characteristicTypeId="077c342f-d7b9-45c6-b8af-88e97cafd3a2" value="Melee"/>
-                            <characteristic name="S" characteristicTypeId="59b1-319e-ec13-d466" value="x2"/>
-                            <characteristic name="AP" characteristicTypeId="75aa-a838-b675-6484" value="-3"/>
-                            <characteristic name="D" characteristicTypeId="ae8a-3137-d65b-4ca7" value="3"/>
-                            <characteristic name="Abilities" characteristicTypeId="837d-5e63-aeb7-1410" value="-"/>
-                          </characteristics>
-                        </profile>
-                      </profiles>
-                      <rules/>
-                      <infoLinks/>
-                      <modifiers/>
-                      <constraints/>
-                      <categoryLinks/>
-                      <selectionEntries/>
-                      <selectionEntryGroups/>
-                      <entryLinks/>
-                      <costs>
-                        <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="0.0"/>
-                        <cost name="pts" costTypeId="points" value="0.0"/>
-                      </costs>
-                    </selectionEntry>
-                    <selectionEntry id="6584-641a-41f5-3547" name="Hellforged chainclaw" hidden="false" collective="false" type="upgrade">
-                      <profiles>
-                        <profile id="78d1-b625-dd9b-d749" name="Hellforged chainclaw" hidden="false" profileTypeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" profileTypeName="Weapon">
-                          <profiles/>
-                          <rules/>
-                          <infoLinks/>
-                          <modifiers/>
-                          <characteristics>
-                            <characteristic name="Range" characteristicTypeId="6fa97fa8-ea74-4a27-a0fb-bc4e5f367464" value="Melee"/>
-                            <characteristic name="Type" characteristicTypeId="077c342f-d7b9-45c6-b8af-88e97cafd3a2" value="Melee"/>
-                            <characteristic name="S" characteristicTypeId="59b1-319e-ec13-d466" value="x2"/>
-                            <characteristic name="AP" characteristicTypeId="75aa-a838-b675-6484" value="-4"/>
-                            <characteristic name="D" characteristicTypeId="ae8a-3137-d65b-4ca7" value="4"/>
-                            <characteristic name="Abilities" characteristicTypeId="837d-5e63-aeb7-1410" value="-"/>
-                          </characteristics>
-                        </profile>
-                      </profiles>
-                      <rules/>
-                      <infoLinks/>
-                      <modifiers/>
-                      <constraints/>
-                      <categoryLinks/>
-                      <selectionEntries/>
-                      <selectionEntryGroups/>
-                      <entryLinks/>
-                      <costs>
-                        <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="0.0"/>
-                        <cost name="pts" costTypeId="points" value="0.0"/>
-                      </costs>
-                    </selectionEntry>
-                  </selectionEntries>
+                  <selectionEntries/>
                   <selectionEntryGroups/>
-                  <entryLinks/>
+                  <entryLinks>
+                    <entryLink id="fa2a-ecdc-50db-1d8b" name="Hellforged chainclaw" hidden="false" targetId="7ddb-5720-22f2-7236" type="selectionEntry">
+                      <profiles/>
+                      <rules/>
+                      <infoLinks/>
+                      <modifiers/>
+                      <constraints/>
+                      <categoryLinks/>
+                    </entryLink>
+                    <entryLink id="bf7d-7e96-e5d3-f90e" name="Hellforged deathclaw" hidden="false" targetId="a52d-b64c-83d6-5c20" type="selectionEntry">
+                      <profiles/>
+                      <rules/>
+                      <infoLinks/>
+                      <modifiers/>
+                      <constraints/>
+                      <categoryLinks/>
+                    </entryLink>
+                  </entryLinks>
                 </selectionEntryGroup>
                 <selectionEntryGroup id="d50c-c0d8-4fa1-0273" name="Combi-bolter option" hidden="false" collective="false" defaultSelectionEntryId="a58b-cd1c-f474-2bfb">
                   <profiles/>
@@ -2605,7 +2599,7 @@
                     </entryLink>
                   </entryLinks>
                 </selectionEntryGroup>
-                <selectionEntryGroup id="a229-dc85-e085-61fc" name="Claw option" hidden="false" collective="false" defaultSelectionEntryId="b4ea-e17a-09fd-c423">
+                <selectionEntryGroup id="a229-dc85-e085-61fc" name="Claw option" hidden="false" collective="false" defaultSelectionEntryId="c8d1-834e-f1a9-06f8">
                   <profiles/>
                   <rules/>
                   <infoLinks/>
@@ -2623,70 +2617,26 @@
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="40ae-18aa-8d69-589d" type="min"/>
                   </constraints>
                   <categoryLinks/>
-                  <selectionEntries>
-                    <selectionEntry id="b4ea-e17a-09fd-c423" name="Hellforged deathclaw" hidden="false" collective="false" type="upgrade">
-                      <profiles>
-                        <profile id="0780-3a6a-fd47-8ce0" name="Hellforged deathclaw" hidden="false" profileTypeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" profileTypeName="Weapon">
-                          <profiles/>
-                          <rules/>
-                          <infoLinks/>
-                          <modifiers/>
-                          <characteristics>
-                            <characteristic name="Range" characteristicTypeId="6fa97fa8-ea74-4a27-a0fb-bc4e5f367464" value="Melee"/>
-                            <characteristic name="Type" characteristicTypeId="077c342f-d7b9-45c6-b8af-88e97cafd3a2" value="Melee"/>
-                            <characteristic name="S" characteristicTypeId="59b1-319e-ec13-d466" value="x2"/>
-                            <characteristic name="AP" characteristicTypeId="75aa-a838-b675-6484" value="-3"/>
-                            <characteristic name="D" characteristicTypeId="ae8a-3137-d65b-4ca7" value="3"/>
-                            <characteristic name="Abilities" characteristicTypeId="837d-5e63-aeb7-1410" value="-"/>
-                          </characteristics>
-                        </profile>
-                      </profiles>
-                      <rules/>
-                      <infoLinks/>
-                      <modifiers/>
-                      <constraints/>
-                      <categoryLinks/>
-                      <selectionEntries/>
-                      <selectionEntryGroups/>
-                      <entryLinks/>
-                      <costs>
-                        <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="0.0"/>
-                        <cost name="pts" costTypeId="points" value="0.0"/>
-                      </costs>
-                    </selectionEntry>
-                    <selectionEntry id="63d1-a117-9c7f-7ae3" name="Hellforged chainclaw" hidden="false" collective="false" type="upgrade">
-                      <profiles>
-                        <profile id="5f5c-071c-44d2-675f" name="Hellforged chainclaw" hidden="false" profileTypeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" profileTypeName="Weapon">
-                          <profiles/>
-                          <rules/>
-                          <infoLinks/>
-                          <modifiers/>
-                          <characteristics>
-                            <characteristic name="Range" characteristicTypeId="6fa97fa8-ea74-4a27-a0fb-bc4e5f367464" value="Melee"/>
-                            <characteristic name="Type" characteristicTypeId="077c342f-d7b9-45c6-b8af-88e97cafd3a2" value="Melee"/>
-                            <characteristic name="S" characteristicTypeId="59b1-319e-ec13-d466" value="x2"/>
-                            <characteristic name="AP" characteristicTypeId="75aa-a838-b675-6484" value="-4"/>
-                            <characteristic name="D" characteristicTypeId="ae8a-3137-d65b-4ca7" value="4"/>
-                            <characteristic name="Abilities" characteristicTypeId="837d-5e63-aeb7-1410" value="-"/>
-                          </characteristics>
-                        </profile>
-                      </profiles>
-                      <rules/>
-                      <infoLinks/>
-                      <modifiers/>
-                      <constraints/>
-                      <categoryLinks/>
-                      <selectionEntries/>
-                      <selectionEntryGroups/>
-                      <entryLinks/>
-                      <costs>
-                        <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="0.0"/>
-                        <cost name="pts" costTypeId="points" value="0.0"/>
-                      </costs>
-                    </selectionEntry>
-                  </selectionEntries>
+                  <selectionEntries/>
                   <selectionEntryGroups/>
-                  <entryLinks/>
+                  <entryLinks>
+                    <entryLink id="15ca-c83f-e1e1-2634" name="Hellforged chainclaw" hidden="false" targetId="7ddb-5720-22f2-7236" type="selectionEntry">
+                      <profiles/>
+                      <rules/>
+                      <infoLinks/>
+                      <modifiers/>
+                      <constraints/>
+                      <categoryLinks/>
+                    </entryLink>
+                    <entryLink id="c8d1-834e-f1a9-06f8" name="Hellforged deathclaw" hidden="false" targetId="a52d-b64c-83d6-5c20" type="selectionEntry">
+                      <profiles/>
+                      <rules/>
+                      <infoLinks/>
+                      <modifiers/>
+                      <constraints/>
+                      <categoryLinks/>
+                    </entryLink>
+                  </entryLinks>
                 </selectionEntryGroup>
                 <selectionEntryGroup id="6064-6b79-164b-996e" name="Combi-bolter option" hidden="false" collective="false" defaultSelectionEntryId="e0ab-239a-b2e2-8967">
                   <profiles/>
@@ -2965,7 +2915,7 @@
           <infoLinks/>
           <modifiers/>
           <characteristics>
-            <characteristic name="Description" characteristicTypeId="21befb24-fc85-4f52-a745-64b2e48f8228" value="If this model is reduced to 0 wounds, roll a D6 before removing it from the battlefield. On a roll of a 6 it explodes and the hellish energies at its core are unleashed. Each unit within 6&quot; suffers 2D3 mortal wounds unless it is a Psyker, in which case it suffers D6 mortal wounds instead."/>
+            <characteristic name="Description" characteristicTypeId="21befb24-fc85-4f52-a745-64b2e48f8228" value="If this model is reduced to 0 wounds, roll a D6 before removing it from the battlefield. On a roll of a 6 it explodes and the hellish energies at its core are unleashed. Each unit within 6&quot; suffers D6 mortal wounds unless it is a PSYKER, in which case it suffers 2D3 mortal wounds instead."/>
           </characteristics>
         </profile>
         <profile id="44c5-97ee-a27b-b2a8" name="Hellforged Land Raider Proteus" hidden="false" profileTypeId="b3a8-0452-7436-44d1" profileTypeName="Transport">
@@ -3091,7 +3041,10 @@
           <selectionEntries/>
           <selectionEntryGroups/>
           <entryLinks/>
-          <costs/>
+          <costs>
+            <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="0.0"/>
+            <cost name="pts" costTypeId="points" value="0.0"/>
+          </costs>
         </selectionEntry>
       </selectionEntries>
       <selectionEntryGroups>
@@ -3329,7 +3282,7 @@
           <infoLinks/>
           <modifiers/>
           <characteristics>
-            <characteristic name="Description" characteristicTypeId="21befb24-fc85-4f52-a745-64b2e48f8228" value="If this model is reduced to 0 wounds, roll a D6 before removing it from the battlefield. On a roll of a 6 it explodes and the hellish energies at its core are unleashed. Each unit within 6&quot; suffers 2D3 mortal wounds unless it is a PSYKER, in which case it suffers D6 mortal wounds instead."/>
+            <characteristic name="Description" characteristicTypeId="21befb24-fc85-4f52-a745-64b2e48f8228" value="If this model is reduced to 0 wounds, roll a D6 before removing it from the battlefield. On a roll of a 6 it explodes and the hellish energies at its core are unleashed. Each unit within 6&quot; suffers D6 mortal wounds unless it is a PSYKER, in which case it suffers 2D3 mortal wounds instead."/>
           </characteristics>
         </profile>
         <profile id="d193-9a69-3dbc-653e" name="Hellforged Land Raider Achilles" hidden="false" profileTypeId="b3a8-0452-7436-44d1" profileTypeName="Transport">
@@ -4435,7 +4388,7 @@
             </entryLink>
           </entryLinks>
         </selectionEntryGroup>
-        <selectionEntryGroup id="cd09-29f1-d58a-9c46" name="Additional weapons" hidden="false" collective="false">
+        <selectionEntryGroup id="cd09-29f1-d58a-9c46" name="Sponson weapons" hidden="false" collective="false">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -4469,6 +4422,7 @@
               </entryLinks>
               <costs>
                 <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="0.0"/>
+                <cost name="pts" costTypeId="points" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="0fd9-3436-0241-5b3a" name="Lascannons" hidden="false" collective="false" type="upgrade">
@@ -4495,7 +4449,7 @@
               </entryLinks>
               <costs>
                 <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="0.0"/>
-                <cost name="pts" costTypeId="points" value="50.0"/>
+                <cost name="pts" costTypeId="points" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -4556,7 +4510,7 @@
             <characteristic name="S" characteristicTypeId="59b1-319e-ec13-d466" value="7"/>
             <characteristic name="AP" characteristicTypeId="75aa-a838-b675-6484" value="-1"/>
             <characteristic name="D" characteristicTypeId="ae8a-3137-d65b-4ca7" value="2"/>
-            <characteristic name="Abilities" characteristicTypeId="837d-5e63-aeb7-1410" value="Attacks made with this weapon suffer no pentalty to its hit roll when targeting units with the Fly keyword. In addition, every wound roll of 6 made with this weapon increases the Ap of that individual wound to -3."/>
+            <characteristic name="Abilities" characteristicTypeId="837d-5e63-aeb7-1410" value="Attacks made with this weapon suffer no penalty to its hit roll when targeting units with the FLY keyword. In addition, every wound roll of 6 made with this weapon increases the AP of that individual wound to -3."/>
           </characteristics>
         </profile>
       </profiles>
@@ -4759,7 +4713,7 @@
             </entryLink>
           </entryLinks>
         </selectionEntryGroup>
-        <selectionEntryGroup id="4864-a1f5-921a-3ea1" name="Additional weapons" hidden="false" collective="false">
+        <selectionEntryGroup id="4864-a1f5-921a-3ea1" name="Sponson weapons" hidden="false" collective="false">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -9425,7 +9379,7 @@
           <characteristics>
             <characteristic name="Remaining W" characteristicTypeId="8e45-c866-b2d4-c9ab" value="1-3"/>
             <characteristic name="Characteristic 1" characteristicTypeId="bf41-c860-50bc-2a7e" value="20&quot;"/>
-            <characteristic name="Characteristic 2" characteristicTypeId="dc18-e51f-309b-8efa" value="4+"/>
+            <characteristic name="Characteristic 2" characteristicTypeId="dc18-e51f-309b-8efa" value="5+"/>
             <characteristic name="Characteristic 3" characteristicTypeId="df06-8eca-150f-90ba" value="1"/>
           </characteristics>
         </profile>
@@ -9834,7 +9788,7 @@
           <characteristics>
             <characteristic name="Remaining W" characteristicTypeId="8e45-c866-b2d4-c9ab" value="1-3"/>
             <characteristic name="Characteristic 1" characteristicTypeId="bf41-c860-50bc-2a7e" value="20&quot;"/>
-            <characteristic name="Characteristic 2" characteristicTypeId="dc18-e51f-309b-8efa" value="4+"/>
+            <characteristic name="Characteristic 2" characteristicTypeId="dc18-e51f-309b-8efa" value="5+"/>
             <characteristic name="Characteristic 3" characteristicTypeId="df06-8eca-150f-90ba" value="1"/>
           </characteristics>
         </profile>
@@ -12454,7 +12408,10 @@
           </selectionEntries>
           <selectionEntryGroups/>
           <entryLinks/>
-          <costs/>
+          <costs>
+            <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="0.0"/>
+            <cost name="pts" costTypeId="points" value="0.0"/>
+          </costs>
         </selectionEntry>
       </selectionEntries>
       <selectionEntryGroups/>
@@ -12672,7 +12629,10 @@
           <selectionEntries/>
           <selectionEntryGroups/>
           <entryLinks/>
-          <costs/>
+          <costs>
+            <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="0.0"/>
+            <cost name="pts" costTypeId="points" value="0.0"/>
+          </costs>
         </selectionEntry>
         <selectionEntry id="1825-4604-3dd3-5379" name="Rancid vomit" hidden="false" collective="false" type="upgrade">
           <profiles>
@@ -12702,7 +12662,10 @@
           <selectionEntries/>
           <selectionEntryGroups/>
           <entryLinks/>
-          <costs/>
+          <costs>
+            <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="0.0"/>
+            <cost name="pts" costTypeId="points" value="0.0"/>
+          </costs>
         </selectionEntry>
       </selectionEntries>
       <selectionEntryGroups>
@@ -12744,7 +12707,10 @@
               <selectionEntries/>
               <selectionEntryGroups/>
               <entryLinks/>
-              <costs/>
+              <costs>
+                <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="0.0"/>
+                <cost name="pts" costTypeId="points" value="0.0"/>
+              </costs>
             </selectionEntry>
             <selectionEntry id="4886-3f85-be63-6153" name="Warpsword" hidden="false" collective="false" type="upgrade">
               <profiles>
@@ -12773,7 +12739,10 @@
               <selectionEntries/>
               <selectionEntryGroups/>
               <entryLinks/>
-              <costs/>
+              <costs>
+                <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="0.0"/>
+                <cost name="pts" costTypeId="points" value="0.0"/>
+              </costs>
             </selectionEntry>
           </selectionEntries>
           <selectionEntryGroups/>
@@ -12810,7 +12779,10 @@
       <selectionEntries/>
       <selectionEntryGroups/>
       <entryLinks/>
-      <costs/>
+      <costs>
+        <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="0.0"/>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
     </selectionEntry>
     <selectionEntry id="c827-4bb5-de4b-d1b1" name="Gift of Contagion" hidden="false" collective="false" type="upgrade">
       <profiles>
@@ -12866,7 +12838,10 @@
       <selectionEntries/>
       <selectionEntryGroups/>
       <entryLinks/>
-      <costs/>
+      <costs>
+        <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="0.0"/>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
     </selectionEntry>
     <selectionEntry id="50d6-2f0a-9d38-15b0" name="Plague Wind" hidden="false" collective="false" type="upgrade">
       <profiles>
@@ -12892,7 +12867,1367 @@
       <selectionEntries/>
       <selectionEntryGroups/>
       <entryLinks/>
-      <costs/>
+      <costs>
+        <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="0.0"/>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="7ddb-5720-22f2-7236" name="Hellforged chainclaw" hidden="false" collective="false" type="upgrade">
+      <profiles>
+        <profile id="8d64-104a-d8ca-602e" name="Hellforged chainclaw" hidden="false" profileTypeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" profileTypeName="Weapon">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Range" characteristicTypeId="6fa97fa8-ea74-4a27-a0fb-bc4e5f367464" value="Melee"/>
+            <characteristic name="Type" characteristicTypeId="077c342f-d7b9-45c6-b8af-88e97cafd3a2" value="Melee"/>
+            <characteristic name="S" characteristicTypeId="59b1-319e-ec13-d466" value="x2"/>
+            <characteristic name="AP" characteristicTypeId="75aa-a838-b675-6484" value="-4"/>
+            <characteristic name="D" characteristicTypeId="ae8a-3137-d65b-4ca7" value="4"/>
+            <characteristic name="Abilities" characteristicTypeId="837d-5e63-aeb7-1410" value="-"/>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints/>
+      <categoryLinks/>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="0.0"/>
+        <cost name="pts" costTypeId="points" value="45.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="a52d-b64c-83d6-5c20" name="Hellforged deathclaw" hidden="false" collective="false" type="upgrade">
+      <profiles>
+        <profile id="00df-6bae-e524-04f5" name="Hellforged deathclaw" hidden="false" profileTypeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" profileTypeName="Weapon">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Range" characteristicTypeId="6fa97fa8-ea74-4a27-a0fb-bc4e5f367464" value="Melee"/>
+            <characteristic name="Type" characteristicTypeId="077c342f-d7b9-45c6-b8af-88e97cafd3a2" value="Melee"/>
+            <characteristic name="S" characteristicTypeId="59b1-319e-ec13-d466" value="x2"/>
+            <characteristic name="AP" characteristicTypeId="75aa-a838-b675-6484" value="-3"/>
+            <characteristic name="D" characteristicTypeId="ae8a-3137-d65b-4ca7" value="3"/>
+            <characteristic name="Abilities" characteristicTypeId="837d-5e63-aeb7-1410" value="-"/>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints/>
+      <categoryLinks/>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="0.0"/>
+        <cost name="pts" costTypeId="points" value="40.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="2cc8-0e93-7906-cdf0" name="Ferrum Infernus Dreadnought" page="" hidden="false" collective="false" type="model">
+      <profiles>
+        <profile id="2bd2-0ced-feee-183e" name="Ferrum Infernus Dreadnought" page="" hidden="false" profileTypeId="800f-21d0-4387-c943" profileTypeName="Unit">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers>
+            <modifier type="set" field="13fc-b29b-31f2-ab9f" value="5">
+              <repeats/>
+              <conditions/>
+              <conditionGroups>
+                <conditionGroup type="and">
+                  <conditions>
+                    <condition field="selections" scope="2cc8-0e93-7906-cdf0" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="a34e-5842-d02c-aa2b" type="equalTo"/>
+                  </conditions>
+                  <conditionGroups>
+                    <conditionGroup type="or">
+                      <conditions>
+                        <condition field="selections" scope="2cc8-0e93-7906-cdf0" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="46b0-2d96-9ae9-fcf9" type="equalTo"/>
+                        <condition field="selections" scope="2cc8-0e93-7906-cdf0" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="6953-d88f-40ce-231f" type="equalTo"/>
+                        <condition field="selections" scope="2cc8-0e93-7906-cdf0" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="91ce-45ca-8f58-d9ff" type="equalTo"/>
+                      </conditions>
+                      <conditionGroups/>
+                    </conditionGroup>
+                  </conditionGroups>
+                </conditionGroup>
+              </conditionGroups>
+            </modifier>
+          </modifiers>
+          <characteristics>
+            <characteristic name="M" characteristicTypeId="0bdf-a96e-9e38-7779" value="8&quot;"/>
+            <characteristic name="WS" characteristicTypeId="e7f0-1278-0250-df0c" value="3+"/>
+            <characteristic name="BS" characteristicTypeId="381b-eb28-74c3-df5f" value="3+"/>
+            <characteristic name="S" characteristicTypeId="2218-aa3c-265f-2939" value="6"/>
+            <characteristic name="T" characteristicTypeId="9c9f-9774-a358-3a39" value="7"/>
+            <characteristic name="W" characteristicTypeId="f330-5e6e-4110-0978" value="8"/>
+            <characteristic name="A" characteristicTypeId="13fc-b29b-31f2-ab9f" value="4"/>
+            <characteristic name="Ld" characteristicTypeId="00ca-f8b8-876d-b705" value="8"/>
+            <characteristic name="Save" characteristicTypeId="c0df-df94-abd7-e8d3" value="3+"/>
+          </characteristics>
+        </profile>
+        <profile id="5540-c898-3b8c-6dea" name="Crazed" hidden="false" profileTypeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" profileTypeName="Abilities">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Description" characteristicTypeId="21befb24-fc85-4f52-a745-64b2e48f8228" value="At the end of any phase in which this model suffers any unsaved wounds or mortal wounds, roll a D6. On a roll of 6, this model immediately makes a shooting attack as if it were your Shooting phase if there no enemies within 1&quot;, or a piles in and fights as if it were in the Fight phase if there are enemies within 1&quot;. If there is no visible target within range, nothing happens."/>
+          </characteristics>
+        </profile>
+        <profile id="4189-3282-4281-e27c" name="Battering Onslaught" hidden="true" profileTypeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" profileTypeName="Abilities">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers>
+            <modifier type="set" field="hidden" value="false">
+              <repeats/>
+              <conditions/>
+              <conditionGroups>
+                <conditionGroup type="and">
+                  <conditions>
+                    <condition field="selections" scope="2cc8-0e93-7906-cdf0" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="a34e-5842-d02c-aa2b" type="equalTo"/>
+                  </conditions>
+                  <conditionGroups>
+                    <conditionGroup type="or">
+                      <conditions>
+                        <condition field="selections" scope="2cc8-0e93-7906-cdf0" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="46b0-2d96-9ae9-fcf9" type="equalTo"/>
+                        <condition field="selections" scope="2cc8-0e93-7906-cdf0" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="91ce-45ca-8f58-d9ff" type="equalTo"/>
+                        <condition field="selections" scope="2cc8-0e93-7906-cdf0" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="6953-d88f-40ce-231f" type="equalTo"/>
+                      </conditions>
+                      <conditionGroups/>
+                    </conditionGroup>
+                  </conditionGroups>
+                </conditionGroup>
+              </conditionGroups>
+            </modifier>
+          </modifiers>
+          <characteristics>
+            <characteristic name="Description" characteristicTypeId="21befb24-fc85-4f52-a745-64b2e48f8228" value="Add 1 to this model&apos;s Attacks characteristic if it is equipped with two melee weapons. This extra attack has been added to its profile."/>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules/>
+      <infoLinks>
+        <infoLink id="7c09-e982-00a6-820b" name="Explodes" hidden="false" targetId="9446-1148-da70-4028" type="profile">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints/>
+      <categoryLinks>
+        <categoryLink id="87a8-2897-c4e8-1340" name="New CategoryLink" hidden="false" targetId="5cf1-acf2-ca3b-c2e5" primary="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
+        <categoryLink id="3025-66cc-be00-c4b2" name="New CategoryLink" hidden="false" targetId="638d74c6-bd97-4de5-b65a-6aaa24e9f4b2" primary="true">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
+        <categoryLink id="ecde-e438-f60f-7950" name="New CategoryLink" hidden="false" targetId="c8fd-783f-3230-493e" primary="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
+        <categoryLink id="5505-a882-8e1b-60ea" name="New CategoryLink" hidden="false" targetId="4f27-f60b-7d4d-24d5" primary="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
+        <categoryLink id="998f-ec63-59ca-5bd8" name="New CategoryLink" hidden="false" targetId="2b8b-d5c5-972d-1d7a" primary="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
+        <categoryLink id="b4f3-d295-3335-3fa3" name="New CategoryLink" hidden="false" targetId="096e-708c-dd20-2c10" primary="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
+        <categoryLink id="1749-b827-bfd9-4e30" name="New CategoryLink" hidden="false" targetId="5c4c-f549-6ee9-2f4b" primary="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
+      </categoryLinks>
+      <selectionEntries/>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="ba1e-6dcc-1f60-f211" name="Helbrute fist options" hidden="false" collective="false" defaultSelectionEntryId="46b0-2d96-9ae9-fcf9">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3444-fe3e-5637-f9ec" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b9b3-71dd-817f-1a74" type="min"/>
+          </constraints>
+          <categoryLinks/>
+          <selectionEntries>
+            <selectionEntry id="46b0-2d96-9ae9-fcf9" name="Helbrute fist" hidden="false" collective="false" type="upgrade">
+              <profiles>
+                <profile id="d64c-8b29-35b3-1d21" name="Helbrute fist" hidden="false" profileTypeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" profileTypeName="Weapon">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <characteristics>
+                    <characteristic name="Range" characteristicTypeId="6fa97fa8-ea74-4a27-a0fb-bc4e5f367464" value="Melee"/>
+                    <characteristic name="Type" characteristicTypeId="077c342f-d7b9-45c6-b8af-88e97cafd3a2" value="Melee"/>
+                    <characteristic name="S" characteristicTypeId="59b1-319e-ec13-d466" value="x2"/>
+                    <characteristic name="AP" characteristicTypeId="75aa-a838-b675-6484" value="-3"/>
+                    <characteristic name="D" characteristicTypeId="ae8a-3137-d65b-4ca7" value="3"/>
+                    <characteristic name="Abilities" characteristicTypeId="837d-5e63-aeb7-1410" value="-"/>
+                  </characteristics>
+                </profile>
+              </profiles>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+              <categoryLinks/>
+              <selectionEntries/>
+              <selectionEntryGroups>
+                <selectionEntryGroup id="9ea6-c5ce-a51d-9f6d" name="Ranged options" hidden="false" collective="false">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1a27-7789-27fb-27a4" type="max"/>
+                  </constraints>
+                  <categoryLinks/>
+                  <selectionEntries/>
+                  <selectionEntryGroups/>
+                  <entryLinks>
+                    <entryLink id="ac71-f087-30b7-41d5" name="New EntryLink" hidden="false" targetId="eba0-9fc6-5334-a390" type="selectionEntry">
+                      <profiles/>
+                      <rules/>
+                      <infoLinks/>
+                      <modifiers/>
+                      <constraints/>
+                      <categoryLinks/>
+                    </entryLink>
+                    <entryLink id="d57d-8b13-e82c-0b79" name="New EntryLink" hidden="false" targetId="18bc-b335-29c2-2ae2" type="selectionEntry">
+                      <profiles/>
+                      <rules/>
+                      <infoLinks/>
+                      <modifiers/>
+                      <constraints/>
+                      <categoryLinks/>
+                    </entryLink>
+                  </entryLinks>
+                </selectionEntryGroup>
+              </selectionEntryGroups>
+              <entryLinks/>
+              <costs>
+                <cost name="pts" costTypeId="points" value="40.0"/>
+                <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="6953-d88f-40ce-231f" name="Helbrute hammer" hidden="false" collective="false" type="upgrade">
+              <profiles>
+                <profile id="9417-226f-a655-ba69" name="Helbrute hammer" hidden="false" profileTypeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" profileTypeName="Weapon">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <characteristics>
+                    <characteristic name="Range" characteristicTypeId="6fa97fa8-ea74-4a27-a0fb-bc4e5f367464" value="Melee"/>
+                    <characteristic name="Type" characteristicTypeId="077c342f-d7b9-45c6-b8af-88e97cafd3a2" value="Melee"/>
+                    <characteristic name="S" characteristicTypeId="59b1-319e-ec13-d466" value="x2"/>
+                    <characteristic name="AP" characteristicTypeId="75aa-a838-b675-6484" value="-4"/>
+                    <characteristic name="D" characteristicTypeId="ae8a-3137-d65b-4ca7" value="D6"/>
+                    <characteristic name="Abilities" characteristicTypeId="837d-5e63-aeb7-1410" value="When attacking with this weapon, you must subtract 1 from the hit roll."/>
+                  </characteristics>
+                </profile>
+              </profiles>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+              <categoryLinks/>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks/>
+              <costs>
+                <cost name="pts" costTypeId="points" value="52.0"/>
+                <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="91ce-45ca-8f58-d9ff" name="Power scourge" hidden="false" collective="false" type="upgrade">
+              <profiles>
+                <profile id="c510-b4fd-e997-4007" name="Power scourge" hidden="false" profileTypeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" profileTypeName="Weapon">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <characteristics>
+                    <characteristic name="Range" characteristicTypeId="6fa97fa8-ea74-4a27-a0fb-bc4e5f367464" value="Melee"/>
+                    <characteristic name="Type" characteristicTypeId="077c342f-d7b9-45c6-b8af-88e97cafd3a2" value="Melee"/>
+                    <characteristic name="S" characteristicTypeId="59b1-319e-ec13-d466" value="+2"/>
+                    <characteristic name="AP" characteristicTypeId="75aa-a838-b675-6484" value="-2"/>
+                    <characteristic name="D" characteristicTypeId="ae8a-3137-d65b-4ca7" value="2"/>
+                    <characteristic name="Abilities" characteristicTypeId="837d-5e63-aeb7-1410" value="Each time the bearer fights, it can make 3 additional attacks with this weapon."/>
+                  </characteristics>
+                </profile>
+              </profiles>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+              <categoryLinks/>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks/>
+              <costs>
+                <cost name="pts" costTypeId="points" value="43.0"/>
+                <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="0.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="2876-3922-b235-a99d" name="New EntryLink" hidden="false" targetId="1469-1964-7a91-94d4" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers>
+                <modifier type="set" field="hidden" value="true">
+                  <repeats/>
+                  <conditions>
+                    <condition field="selections" scope="2cc8-0e93-7906-cdf0" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="0880-1545-1817-81b2" type="equalTo"/>
+                  </conditions>
+                  <conditionGroups/>
+                </modifier>
+              </modifiers>
+              <constraints/>
+              <categoryLinks/>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="31b3-7961-a807-1d25" name="Multi-melta options" hidden="false" collective="false" defaultSelectionEntryId="3e8a-098c-184c-bb22">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f3d6-f02e-3abc-e067" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="45c2-ab0b-ed5d-002b" type="min"/>
+          </constraints>
+          <categoryLinks/>
+          <selectionEntries>
+            <selectionEntry id="a34e-5842-d02c-aa2b" name="Helbrute fist" hidden="false" collective="false" type="upgrade">
+              <profiles>
+                <profile id="788d-e3c2-6d7c-73a7" name="Helbrute fist" hidden="false" profileTypeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" profileTypeName="Weapon">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <characteristics>
+                    <characteristic name="Range" characteristicTypeId="6fa97fa8-ea74-4a27-a0fb-bc4e5f367464" value="Melee"/>
+                    <characteristic name="Type" characteristicTypeId="077c342f-d7b9-45c6-b8af-88e97cafd3a2" value="Melee"/>
+                    <characteristic name="S" characteristicTypeId="59b1-319e-ec13-d466" value="x2"/>
+                    <characteristic name="AP" characteristicTypeId="75aa-a838-b675-6484" value="-3"/>
+                    <characteristic name="D" characteristicTypeId="ae8a-3137-d65b-4ca7" value="3"/>
+                    <characteristic name="Abilities" characteristicTypeId="837d-5e63-aeb7-1410" value="-"/>
+                  </characteristics>
+                </profile>
+              </profiles>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+              <categoryLinks/>
+              <selectionEntries/>
+              <selectionEntryGroups>
+                <selectionEntryGroup id="27f7-6118-28bc-00d6" name="Ranged options" hidden="false" collective="false">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="dba3-a854-371e-4290" type="max"/>
+                  </constraints>
+                  <categoryLinks/>
+                  <selectionEntries/>
+                  <selectionEntryGroups/>
+                  <entryLinks>
+                    <entryLink id="97f8-cf4d-d025-b188" name="New EntryLink" hidden="false" targetId="eba0-9fc6-5334-a390" type="selectionEntry">
+                      <profiles/>
+                      <rules/>
+                      <infoLinks/>
+                      <modifiers/>
+                      <constraints/>
+                      <categoryLinks/>
+                    </entryLink>
+                    <entryLink id="f105-3be7-3a27-fff9" name="New EntryLink" hidden="false" targetId="18bc-b335-29c2-2ae2" type="selectionEntry">
+                      <profiles/>
+                      <rules/>
+                      <infoLinks/>
+                      <modifiers/>
+                      <constraints/>
+                      <categoryLinks/>
+                    </entryLink>
+                  </entryLinks>
+                </selectionEntryGroup>
+              </selectionEntryGroups>
+              <entryLinks/>
+              <costs>
+                <cost name="pts" costTypeId="points" value="40.0"/>
+                <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="a3d1-274e-ddd9-bdcb" name="Helbrute plasma cannon" hidden="false" collective="false" type="upgrade">
+              <profiles>
+                <profile id="7029-099d-7c79-5639" name="Helbrute plasma cannon" hidden="false" profileTypeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" profileTypeName="Weapon">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <characteristics>
+                    <characteristic name="Range" characteristicTypeId="6fa97fa8-ea74-4a27-a0fb-bc4e5f367464" value="36&quot;"/>
+                    <characteristic name="Type" characteristicTypeId="077c342f-d7b9-45c6-b8af-88e97cafd3a2" value="Heavy D3"/>
+                    <characteristic name="S" characteristicTypeId="59b1-319e-ec13-d466" value="8"/>
+                    <characteristic name="AP" characteristicTypeId="75aa-a838-b675-6484" value="-3"/>
+                    <characteristic name="D" characteristicTypeId="ae8a-3137-d65b-4ca7" value="2"/>
+                    <characteristic name="Abilities" characteristicTypeId="837d-5e63-aeb7-1410" value="For each hit roll of 1, the Hellbrute suffers a MW after all of this weapon&apos;s shots have been resolved."/>
+                  </characteristics>
+                </profile>
+              </profiles>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+              <categoryLinks/>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks/>
+              <costs>
+                <cost name="pts" costTypeId="points" value="30.0"/>
+                <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="0.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="3e8a-098c-184c-bb22" name="Multi-melta" hidden="false" targetId="2b37-65ee-9443-b4ef" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+              <categoryLinks/>
+            </entryLink>
+            <entryLink id="8e3a-7876-a741-7fd7" name="New EntryLink" hidden="false" targetId="5ab4-1ee7-95ad-7e15" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+              <categoryLinks/>
+            </entryLink>
+            <entryLink id="9ad6-e0fd-85fa-3545" name="New EntryLink" hidden="false" targetId="09d8-7790-ed3f-4d6d" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+              <categoryLinks/>
+            </entryLink>
+            <entryLink id="b34f-c9a5-0e0e-92a0" name="New EntryLink" hidden="false" targetId="ee18-b1cd-6b60-464d" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+              <categoryLinks/>
+            </entryLink>
+            <entryLink id="0880-1545-1817-81b2" name="New EntryLink" hidden="false" targetId="1469-1964-7a91-94d4" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers>
+                <modifier type="set" field="hidden" value="true">
+                  <repeats/>
+                  <conditions>
+                    <condition field="selections" scope="0880-1545-1817-81b2" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="2876-3922-b235-a99d" type="equalTo"/>
+                  </conditions>
+                  <conditionGroups/>
+                </modifier>
+              </modifiers>
+              <constraints/>
+              <categoryLinks/>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <entryLinks>
+        <entryLink id="439b-b5d1-7045-13cb" name="Mark of Chaos" hidden="false" targetId="1b73-13a0-a735-3dc7" type="selectionEntryGroup">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+          <categoryLinks>
+            <categoryLink id="8ec8-0a13-ee14-e570" name="New CategoryLink" hidden="false" targetId="2b8b-d5c5-972d-1d7a" primary="false">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </categoryLink>
+            <categoryLink id="48ca-d9e9-7caa-a209" name="New CategoryLink" hidden="false" targetId="096e-708c-dd20-2c10" primary="false">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </categoryLink>
+            <categoryLink id="5980-158b-ac52-6833" name="New CategoryLink" hidden="false" targetId="5c4c-f549-6ee9-2f4b" primary="false">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </categoryLink>
+          </categoryLinks>
+        </entryLink>
+      </entryLinks>
+      <costs>
+        <cost name="pts" costTypeId="points" value="72.0"/>
+        <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="8.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="3672-0dd5-d396-dc4b" name="Sonic Dreadnought" page="" hidden="false" collective="false" type="model">
+      <profiles>
+        <profile id="2e73-c1a9-b5f9-de35" name="Sonic Dreadnought" page="" hidden="false" profileTypeId="800f-21d0-4387-c943" profileTypeName="Unit">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers>
+            <modifier type="set" field="13fc-b29b-31f2-ab9f" value="5">
+              <repeats/>
+              <conditions/>
+              <conditionGroups>
+                <conditionGroup type="and">
+                  <conditions>
+                    <condition field="selections" scope="3672-0dd5-d396-dc4b" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="b5dd-9086-fd9d-5857" type="equalTo"/>
+                  </conditions>
+                  <conditionGroups>
+                    <conditionGroup type="or">
+                      <conditions>
+                        <condition field="selections" scope="3672-0dd5-d396-dc4b" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="dacd-d812-377e-af38" type="equalTo"/>
+                        <condition field="selections" scope="3672-0dd5-d396-dc4b" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="dc36-13de-3194-d92c" type="equalTo"/>
+                        <condition field="selections" scope="3672-0dd5-d396-dc4b" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="9dae-54fd-c8bf-1d8d" type="equalTo"/>
+                      </conditions>
+                      <conditionGroups/>
+                    </conditionGroup>
+                  </conditionGroups>
+                </conditionGroup>
+              </conditionGroups>
+            </modifier>
+          </modifiers>
+          <characteristics>
+            <characteristic name="M" characteristicTypeId="0bdf-a96e-9e38-7779" value="8&quot;"/>
+            <characteristic name="WS" characteristicTypeId="e7f0-1278-0250-df0c" value="3+"/>
+            <characteristic name="BS" characteristicTypeId="381b-eb28-74c3-df5f" value="3+"/>
+            <characteristic name="S" characteristicTypeId="2218-aa3c-265f-2939" value="6"/>
+            <characteristic name="T" characteristicTypeId="9c9f-9774-a358-3a39" value="7"/>
+            <characteristic name="W" characteristicTypeId="f330-5e6e-4110-0978" value="8"/>
+            <characteristic name="A" characteristicTypeId="13fc-b29b-31f2-ab9f" value="4"/>
+            <characteristic name="Ld" characteristicTypeId="00ca-f8b8-876d-b705" value="8"/>
+            <characteristic name="Save" characteristicTypeId="c0df-df94-abd7-e8d3" value="3+"/>
+          </characteristics>
+        </profile>
+        <profile id="2aa4-d287-c022-ac94" name="Crazed" hidden="false" profileTypeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" profileTypeName="Abilities">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Description" characteristicTypeId="21befb24-fc85-4f52-a745-64b2e48f8228" value="At the end of any phase in which this model suffers any unsaved wounds or mortal wounds, roll a D6. On a roll of 6, this model immediately makes a shooting attack as if it were your Shooting phase if there no enemies within 1&quot;, or a piles in and fights as if it were in the Fight phase if there are enemies within 1&quot;. If there is no visible target within range, nothing happens."/>
+          </characteristics>
+        </profile>
+        <profile id="0810-2738-a1c1-3d97" name="Battering Onslaught" hidden="true" profileTypeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" profileTypeName="Abilities">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers>
+            <modifier type="set" field="hidden" value="false">
+              <repeats/>
+              <conditions/>
+              <conditionGroups>
+                <conditionGroup type="and">
+                  <conditions>
+                    <condition field="selections" scope="3672-0dd5-d396-dc4b" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="b5dd-9086-fd9d-5857" type="equalTo"/>
+                  </conditions>
+                  <conditionGroups>
+                    <conditionGroup type="or">
+                      <conditions>
+                        <condition field="selections" scope="3672-0dd5-d396-dc4b" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="dc36-13de-3194-d92c" type="equalTo"/>
+                        <condition field="selections" scope="3672-0dd5-d396-dc4b" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="dacd-d812-377e-af38" type="equalTo"/>
+                        <condition field="selections" scope="3672-0dd5-d396-dc4b" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="9dae-54fd-c8bf-1d8d" type="equalTo"/>
+                      </conditions>
+                      <conditionGroups/>
+                    </conditionGroup>
+                  </conditionGroups>
+                </conditionGroup>
+              </conditionGroups>
+            </modifier>
+          </modifiers>
+          <characteristics>
+            <characteristic name="Description" characteristicTypeId="21befb24-fc85-4f52-a745-64b2e48f8228" value="Add 1 to this model&apos;s Attacks characteristic if it is equipped with two melee weapons. This extra attack has been added to its profile."/>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules/>
+      <infoLinks>
+        <infoLink id="27e7-0057-b83a-530b" name="Explodes" hidden="false" targetId="9446-1148-da70-4028" type="profile">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints/>
+      <categoryLinks>
+        <categoryLink id="d04d-8e70-90f6-7ea0" name="New CategoryLink" hidden="false" targetId="5cf1-acf2-ca3b-c2e5" primary="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
+        <categoryLink id="bd6d-bef5-a1ca-5d36" name="New CategoryLink" hidden="false" targetId="638d74c6-bd97-4de5-b65a-6aaa24e9f4b2" primary="true">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
+        <categoryLink id="3fea-3b50-3869-daca" name="New CategoryLink" hidden="false" targetId="c8fd-783f-3230-493e" primary="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
+        <categoryLink id="ccdd-9825-54b7-4117" name="New CategoryLink" hidden="false" targetId="4f27-f60b-7d4d-24d5" primary="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
+        <categoryLink id="ad6c-463e-c11c-296a" name="New CategoryLink" hidden="false" targetId="2b8b-d5c5-972d-1d7a" primary="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
+        <categoryLink id="6d57-49b5-ac2d-0627" name="New CategoryLink" hidden="false" targetId="5c4c-f549-6ee9-2f4b" primary="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
+        <categoryLink id="2ebd-ff7d-3e11-def4" name="New CategoryLink" hidden="false" targetId="87d3-e3bf-b880-f282" primary="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="6c89-2470-4006-f42d" name="Doom siren" hidden="false" collective="false" type="upgrade">
+          <profiles>
+            <profile id="91cb-7a7b-59ba-9bca" name="Doom siren" hidden="false" profileTypeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" profileTypeName="Weapon">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <characteristics>
+                <characteristic name="Range" characteristicTypeId="6fa97fa8-ea74-4a27-a0fb-bc4e5f367464" value="8&quot;"/>
+                <characteristic name="Type" characteristicTypeId="077c342f-d7b9-45c6-b8af-88e97cafd3a2" value="Assault D3"/>
+                <characteristic name="S" characteristicTypeId="59b1-319e-ec13-d466" value="5"/>
+                <characteristic name="AP" characteristicTypeId="75aa-a838-b675-6484" value="-2"/>
+                <characteristic name="D" characteristicTypeId="ae8a-3137-d65b-4ca7" value="1"/>
+                <characteristic name="Abilities" characteristicTypeId="837d-5e63-aeb7-1410" value="This weapon automatically hits its target. Units targeted by this weapon do not gain any bonus to their saving throws for being in cover."/>
+              </characteristics>
+            </profile>
+          </profiles>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f1a1-c9d1-f4d4-e779" type="max"/>
+          </constraints>
+          <categoryLinks/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="22.0"/>
+            <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="0.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="1d3e-1b81-4155-28be" name="Helbrute fist options" hidden="false" collective="false" defaultSelectionEntryId="dacd-d812-377e-af38">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="37a2-6763-1cd9-9268" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2531-16ef-ec44-c8b2" type="min"/>
+          </constraints>
+          <categoryLinks/>
+          <selectionEntries>
+            <selectionEntry id="dacd-d812-377e-af38" name="Helbrute fist" hidden="false" collective="false" type="upgrade">
+              <profiles>
+                <profile id="96a8-6585-0a7d-ad0a" name="Helbrute fist" hidden="false" profileTypeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" profileTypeName="Weapon">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <characteristics>
+                    <characteristic name="Range" characteristicTypeId="6fa97fa8-ea74-4a27-a0fb-bc4e5f367464" value="Melee"/>
+                    <characteristic name="Type" characteristicTypeId="077c342f-d7b9-45c6-b8af-88e97cafd3a2" value="Melee"/>
+                    <characteristic name="S" characteristicTypeId="59b1-319e-ec13-d466" value="x2"/>
+                    <characteristic name="AP" characteristicTypeId="75aa-a838-b675-6484" value="-3"/>
+                    <characteristic name="D" characteristicTypeId="ae8a-3137-d65b-4ca7" value="3"/>
+                    <characteristic name="Abilities" characteristicTypeId="837d-5e63-aeb7-1410" value="-"/>
+                  </characteristics>
+                </profile>
+              </profiles>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+              <categoryLinks/>
+              <selectionEntries/>
+              <selectionEntryGroups>
+                <selectionEntryGroup id="ba9b-a66c-a420-f35e" name="Ranged options" hidden="false" collective="false">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f928-0d31-3623-e2d7" type="max"/>
+                  </constraints>
+                  <categoryLinks/>
+                  <selectionEntries/>
+                  <selectionEntryGroups/>
+                  <entryLinks>
+                    <entryLink id="8814-8757-2b43-4c49" name="New EntryLink" hidden="false" targetId="eba0-9fc6-5334-a390" type="selectionEntry">
+                      <profiles/>
+                      <rules/>
+                      <infoLinks/>
+                      <modifiers/>
+                      <constraints/>
+                      <categoryLinks/>
+                    </entryLink>
+                    <entryLink id="54a3-1fa2-30ae-2bde" name="New EntryLink" hidden="false" targetId="18bc-b335-29c2-2ae2" type="selectionEntry">
+                      <profiles/>
+                      <rules/>
+                      <infoLinks/>
+                      <modifiers/>
+                      <constraints/>
+                      <categoryLinks/>
+                    </entryLink>
+                  </entryLinks>
+                </selectionEntryGroup>
+              </selectionEntryGroups>
+              <entryLinks/>
+              <costs>
+                <cost name="pts" costTypeId="points" value="40.0"/>
+                <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="dc36-13de-3194-d92c" name="Helbrute hammer" hidden="false" collective="false" type="upgrade">
+              <profiles>
+                <profile id="15b0-0b80-f677-f245" name="Helbrute hammer" hidden="false" profileTypeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" profileTypeName="Weapon">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <characteristics>
+                    <characteristic name="Range" characteristicTypeId="6fa97fa8-ea74-4a27-a0fb-bc4e5f367464" value="Melee"/>
+                    <characteristic name="Type" characteristicTypeId="077c342f-d7b9-45c6-b8af-88e97cafd3a2" value="Melee"/>
+                    <characteristic name="S" characteristicTypeId="59b1-319e-ec13-d466" value="x2"/>
+                    <characteristic name="AP" characteristicTypeId="75aa-a838-b675-6484" value="-4"/>
+                    <characteristic name="D" characteristicTypeId="ae8a-3137-d65b-4ca7" value="D6"/>
+                    <characteristic name="Abilities" characteristicTypeId="837d-5e63-aeb7-1410" value="When attacking with this weapon, you must subtract 1 from the hit roll."/>
+                  </characteristics>
+                </profile>
+              </profiles>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+              <categoryLinks/>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks/>
+              <costs>
+                <cost name="pts" costTypeId="points" value="52.0"/>
+                <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="9dae-54fd-c8bf-1d8d" name="Power scourge" hidden="false" collective="false" type="upgrade">
+              <profiles>
+                <profile id="4699-58fc-6562-1c08" name="Power scourge" hidden="false" profileTypeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" profileTypeName="Weapon">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <characteristics>
+                    <characteristic name="Range" characteristicTypeId="6fa97fa8-ea74-4a27-a0fb-bc4e5f367464" value="Melee"/>
+                    <characteristic name="Type" characteristicTypeId="077c342f-d7b9-45c6-b8af-88e97cafd3a2" value="Melee"/>
+                    <characteristic name="S" characteristicTypeId="59b1-319e-ec13-d466" value="+2"/>
+                    <characteristic name="AP" characteristicTypeId="75aa-a838-b675-6484" value="-2"/>
+                    <characteristic name="D" characteristicTypeId="ae8a-3137-d65b-4ca7" value="2"/>
+                    <characteristic name="Abilities" characteristicTypeId="837d-5e63-aeb7-1410" value="Each time the bearer fights, it can make 3 additional attacks with this weapon."/>
+                  </characteristics>
+                </profile>
+              </profiles>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+              <categoryLinks/>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks/>
+              <costs>
+                <cost name="pts" costTypeId="points" value="43.0"/>
+                <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="0.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="071c-94e8-72a8-2eaf" name="New EntryLink" hidden="false" targetId="1469-1964-7a91-94d4" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers>
+                <modifier type="set" field="hidden" value="true">
+                  <repeats/>
+                  <conditions>
+                    <condition field="selections" scope="3672-0dd5-d396-dc4b" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="ad64-0cae-aa2e-1ecb" type="equalTo"/>
+                  </conditions>
+                  <conditionGroups/>
+                </modifier>
+              </modifiers>
+              <constraints/>
+              <categoryLinks/>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="9b11-75fb-4bf6-0ad5" name="Multi-melta options" hidden="false" collective="false" defaultSelectionEntryId="5efb-dd0c-bc9b-07b7">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ad47-eb0f-36e1-2e69" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0971-ca41-5568-6300" type="min"/>
+          </constraints>
+          <categoryLinks/>
+          <selectionEntries>
+            <selectionEntry id="b5dd-9086-fd9d-5857" name="Helbrute fist" hidden="false" collective="false" type="upgrade">
+              <profiles>
+                <profile id="51cc-285c-8e66-0a96" name="Helbrute fist" hidden="false" profileTypeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" profileTypeName="Weapon">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <characteristics>
+                    <characteristic name="Range" characteristicTypeId="6fa97fa8-ea74-4a27-a0fb-bc4e5f367464" value="Melee"/>
+                    <characteristic name="Type" characteristicTypeId="077c342f-d7b9-45c6-b8af-88e97cafd3a2" value="Melee"/>
+                    <characteristic name="S" characteristicTypeId="59b1-319e-ec13-d466" value="x2"/>
+                    <characteristic name="AP" characteristicTypeId="75aa-a838-b675-6484" value="-3"/>
+                    <characteristic name="D" characteristicTypeId="ae8a-3137-d65b-4ca7" value="3"/>
+                    <characteristic name="Abilities" characteristicTypeId="837d-5e63-aeb7-1410" value="-"/>
+                  </characteristics>
+                </profile>
+              </profiles>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+              <categoryLinks/>
+              <selectionEntries/>
+              <selectionEntryGroups>
+                <selectionEntryGroup id="2896-6a88-9e76-e080" name="Ranged options" hidden="false" collective="false">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e04c-d431-2dac-2fce" type="max"/>
+                  </constraints>
+                  <categoryLinks/>
+                  <selectionEntries/>
+                  <selectionEntryGroups/>
+                  <entryLinks>
+                    <entryLink id="e5d6-613d-b4be-e4d7" name="New EntryLink" hidden="false" targetId="eba0-9fc6-5334-a390" type="selectionEntry">
+                      <profiles/>
+                      <rules/>
+                      <infoLinks/>
+                      <modifiers/>
+                      <constraints/>
+                      <categoryLinks/>
+                    </entryLink>
+                    <entryLink id="ed87-c46a-e2a8-0c60" name="New EntryLink" hidden="false" targetId="18bc-b335-29c2-2ae2" type="selectionEntry">
+                      <profiles/>
+                      <rules/>
+                      <infoLinks/>
+                      <modifiers/>
+                      <constraints/>
+                      <categoryLinks/>
+                    </entryLink>
+                  </entryLinks>
+                </selectionEntryGroup>
+              </selectionEntryGroups>
+              <entryLinks/>
+              <costs>
+                <cost name="pts" costTypeId="points" value="40.0"/>
+                <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="571f-090c-1642-bd35" name="Helbrute plasma cannon" hidden="false" collective="false" type="upgrade">
+              <profiles>
+                <profile id="9cdd-7830-2bbd-8983" name="Helbrute plasma cannon" hidden="false" profileTypeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" profileTypeName="Weapon">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <characteristics>
+                    <characteristic name="Range" characteristicTypeId="6fa97fa8-ea74-4a27-a0fb-bc4e5f367464" value="36&quot;"/>
+                    <characteristic name="Type" characteristicTypeId="077c342f-d7b9-45c6-b8af-88e97cafd3a2" value="Heavy D3"/>
+                    <characteristic name="S" characteristicTypeId="59b1-319e-ec13-d466" value="8"/>
+                    <characteristic name="AP" characteristicTypeId="75aa-a838-b675-6484" value="-3"/>
+                    <characteristic name="D" characteristicTypeId="ae8a-3137-d65b-4ca7" value="2"/>
+                    <characteristic name="Abilities" characteristicTypeId="837d-5e63-aeb7-1410" value="For each hit roll of 1, the Hellbrute suffers a MW after all of this weapon&apos;s shots have been resolved."/>
+                  </characteristics>
+                </profile>
+              </profiles>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+              <categoryLinks/>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks/>
+              <costs>
+                <cost name="pts" costTypeId="points" value="30.0"/>
+                <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="cfd2-1a1c-9952-c9c5" name="Twin blastmaster" hidden="false" collective="false" type="upgrade">
+              <profiles>
+                <profile id="91cb-90ef-cc99-7e6c" name="Twin blastmaster, Single frequency" hidden="false" profileTypeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" profileTypeName="Weapon">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <characteristics>
+                    <characteristic name="Range" characteristicTypeId="6fa97fa8-ea74-4a27-a0fb-bc4e5f367464" value="48&quot;"/>
+                    <characteristic name="Type" characteristicTypeId="077c342f-d7b9-45c6-b8af-88e97cafd3a2" value="Heavy 2D3"/>
+                    <characteristic name="S" characteristicTypeId="59b1-319e-ec13-d466" value="8"/>
+                    <characteristic name="AP" characteristicTypeId="75aa-a838-b675-6484" value="-2"/>
+                    <characteristic name="D" characteristicTypeId="ae8a-3137-d65b-4ca7" value="D3"/>
+                    <characteristic name="Abilities" characteristicTypeId="837d-5e63-aeb7-1410" value="Units targeted by this weapon do not gain any bonus to their saving throws for being in cover."/>
+                  </characteristics>
+                </profile>
+                <profile id="2e1c-7b87-4645-3e6d" name="Twin blastmaster, Varied frequency" hidden="false" profileTypeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" profileTypeName="Weapon">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <characteristics>
+                    <characteristic name="Range" characteristicTypeId="6fa97fa8-ea74-4a27-a0fb-bc4e5f367464" value="36&quot;"/>
+                    <characteristic name="Type" characteristicTypeId="077c342f-d7b9-45c6-b8af-88e97cafd3a2" value="Assault 2D6"/>
+                    <characteristic name="S" characteristicTypeId="59b1-319e-ec13-d466" value="4"/>
+                    <characteristic name="AP" characteristicTypeId="75aa-a838-b675-6484" value="-1"/>
+                    <characteristic name="D" characteristicTypeId="ae8a-3137-d65b-4ca7" value="1"/>
+                    <characteristic name="Abilities" characteristicTypeId="837d-5e63-aeb7-1410" value="Units targeted by this weapon do not gain any bonus to their saving throws for being in cover."/>
+                  </characteristics>
+                </profile>
+              </profiles>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4abf-1817-d9fd-8168" type="max"/>
+              </constraints>
+              <categoryLinks/>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks/>
+              <costs>
+                <cost name="pts" costTypeId="points" value="56.0"/>
+                <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="0.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="5efb-dd0c-bc9b-07b7" name="Multi-melta" hidden="false" targetId="2b37-65ee-9443-b4ef" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+              <categoryLinks/>
+            </entryLink>
+            <entryLink id="1e06-b6e6-1cee-de87" name="New EntryLink" hidden="false" targetId="5ab4-1ee7-95ad-7e15" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+              <categoryLinks/>
+            </entryLink>
+            <entryLink id="6733-c964-0c94-e990" name="Twin heavy bolter" hidden="false" targetId="09d8-7790-ed3f-4d6d" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+              <categoryLinks/>
+            </entryLink>
+            <entryLink id="844e-d3d7-8efb-c265" name="Twin lascannon" hidden="false" targetId="ee18-b1cd-6b60-464d" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+              <categoryLinks/>
+            </entryLink>
+            <entryLink id="ad64-0cae-aa2e-1ecb" name="New EntryLink" hidden="false" targetId="1469-1964-7a91-94d4" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers>
+                <modifier type="set" field="hidden" value="true">
+                  <repeats/>
+                  <conditions>
+                    <condition field="selections" scope="3672-0dd5-d396-dc4b" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="071c-94e8-72a8-2eaf" type="equalTo"/>
+                  </conditions>
+                  <conditionGroups/>
+                </modifier>
+              </modifiers>
+              <constraints/>
+              <categoryLinks/>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="72.0"/>
+        <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="8.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="f9c1-caf1-c410-a3d6" name="Hunter-killer missile" hidden="false" collective="false" type="upgrade">
+      <profiles/>
+      <rules/>
+      <infoLinks>
+        <infoLink id="4961-3974-8592-4444" name="Hunter-killer missile" hidden="false" targetId="e2a9-e8fc-3a6b-2eec" type="profile">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints/>
+      <categoryLinks/>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="6.0"/>
+        <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="f957-f774-e452-34ea" name="Chaos Vindicator Laser Destroyer" hidden="false" collective="false" type="model">
+      <profiles>
+        <profile id="6aa0-b4ec-1ba3-db91" name="Chaos Vindicator Laser Destroyer 1" hidden="false" profileTypeId="5f4f-ea74-0630-4afe" profileTypeName="Wound Track">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Remaining W" characteristicTypeId="8e45-c866-b2d4-c9ab" value="7-12+"/>
+            <characteristic name="Characteristic 1" characteristicTypeId="bf41-c860-50bc-2a7e" value="10&quot;"/>
+            <characteristic name="Characteristic 2" characteristicTypeId="dc18-e51f-309b-8efa" value="3+"/>
+            <characteristic name="Characteristic 3" characteristicTypeId="df06-8eca-150f-90ba" value="3"/>
+          </characteristics>
+        </profile>
+        <profile id="2c35-23ce-aac1-c46b" name="Chaos Vindicator Laser Destroyer 2" hidden="false" profileTypeId="5f4f-ea74-0630-4afe" profileTypeName="Wound Track">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Remaining W" characteristicTypeId="8e45-c866-b2d4-c9ab" value="3-6"/>
+            <characteristic name="Characteristic 1" characteristicTypeId="bf41-c860-50bc-2a7e" value="5&quot;"/>
+            <characteristic name="Characteristic 2" characteristicTypeId="dc18-e51f-309b-8efa" value="4+"/>
+            <characteristic name="Characteristic 3" characteristicTypeId="df06-8eca-150f-90ba" value="D3"/>
+          </characteristics>
+        </profile>
+        <profile id="7f9b-b2e0-ed7b-f595" name="Chaos Vindicator Laser Destroyer 3" hidden="false" profileTypeId="5f4f-ea74-0630-4afe" profileTypeName="Wound Track">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Remaining W" characteristicTypeId="8e45-c866-b2d4-c9ab" value="1-2"/>
+            <characteristic name="Characteristic 1" characteristicTypeId="bf41-c860-50bc-2a7e" value="3&quot;"/>
+            <characteristic name="Characteristic 2" characteristicTypeId="dc18-e51f-309b-8efa" value="5+"/>
+            <characteristic name="Characteristic 3" characteristicTypeId="df06-8eca-150f-90ba" value="1"/>
+          </characteristics>
+        </profile>
+        <profile id="e2d6-a304-9a1b-41ae" name="Power Capacitor" hidden="false" profileTypeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" profileTypeName="Abilities">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Description" characteristicTypeId="21befb24-fc85-4f52-a745-64b2e48f8228" value="On any turn in which the Chaos Vindicator does not move in the Movement phase, it may fire twice with its laser volley cannon, but may only use volley fire if it does so."/>
+          </characteristics>
+        </profile>
+        <profile id="c3fe-da2a-1cfa-7737" name="Chaos Vindicator Laser Destroyer" hidden="false" profileTypeId="5f4f-ea74-0630-4afe" profileTypeName="Wound Track">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Remaining W" characteristicTypeId="8e45-c866-b2d4-c9ab" value=""/>
+            <characteristic name="Characteristic 1" characteristicTypeId="bf41-c860-50bc-2a7e" value="M"/>
+            <characteristic name="Characteristic 2" characteristicTypeId="dc18-e51f-309b-8efa" value="BS"/>
+            <characteristic name="Characteristic 3" characteristicTypeId="df06-8eca-150f-90ba" value="A"/>
+          </characteristics>
+        </profile>
+        <profile id="cbab-24e4-b068-42d0" name="Chaos Vindicator" hidden="false" profileTypeId="800f-21d0-4387-c943" profileTypeName="Unit">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="M" characteristicTypeId="0bdf-a96e-9e38-7779" value="*"/>
+            <characteristic name="WS" characteristicTypeId="e7f0-1278-0250-df0c" value="6+"/>
+            <characteristic name="BS" characteristicTypeId="381b-eb28-74c3-df5f" value="*"/>
+            <characteristic name="S" characteristicTypeId="2218-aa3c-265f-2939" value="6"/>
+            <characteristic name="T" characteristicTypeId="9c9f-9774-a358-3a39" value="8"/>
+            <characteristic name="W" characteristicTypeId="f330-5e6e-4110-0978" value="12"/>
+            <characteristic name="A" characteristicTypeId="13fc-b29b-31f2-ab9f" value="*"/>
+            <characteristic name="Ld" characteristicTypeId="00ca-f8b8-876d-b705" value="8"/>
+            <characteristic name="Save" characteristicTypeId="c0df-df94-abd7-e8d3" value="3+"/>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules/>
+      <infoLinks>
+        <infoLink id="300a-af5b-9810-04f1" name="Smoke Launchers" hidden="false" targetId="9adf-09bc-1635-b650" type="profile">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="6da6-f2ec-4f76-bcc0" name="Explodes" hidden="false" targetId="9446-1148-da70-4028" type="profile">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="939d-1889-ffd5-41e6" name="Machina Malifica" hidden="false" targetId="d36c-b849-b0ba-625b" type="profile">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints/>
+      <categoryLinks>
+        <categoryLink id="d36a-4b78-3f42-f33a" name="New CategoryLink" hidden="false" targetId="c8fd-783f-3230-493e" primary="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
+        <categoryLink id="b9c8-2073-5789-6dea" name="New CategoryLink" hidden="false" targetId="abf5fd55-9ac7-4263-8bc1-a9fb0a8fa6a6" primary="true">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
+        <categoryLink id="60e4-68c9-1d8a-e89b" name="New CategoryLink" hidden="false" targetId="2b8b-d5c5-972d-1d7a" primary="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
+        <categoryLink id="f6c8-1804-b122-437c" name="New CategoryLink" hidden="false" targetId="096e-708c-dd20-2c10" primary="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
+        <categoryLink id="4c2e-2342-1c6a-680f" name="New CategoryLink" hidden="false" targetId="5c4c-f549-6ee9-2f4b" primary="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
+        <categoryLink id="5f6e-86eb-61fd-fc26" name="New CategoryLink" hidden="false" targetId="f379-3f19-8545-bfc1" primary="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
+        <categoryLink id="eed7-6036-e15c-9d5a" name="New CategoryLink" hidden="false" targetId="5cf1-acf2-ca3b-c2e5" primary="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
+        <categoryLink id="db5f-c71c-942b-e58e" name="New CategoryLink" hidden="false" targetId="8005-9fea-4a32-1869" primary="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
+        <categoryLink id="7fe6-8272-5a36-3a3a" name="New CategoryLink" hidden="false" targetId="10f6-976a-6af5-e817" primary="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="8ae0-803b-a88a-6818" name="Laser volley cannon" hidden="false" collective="false" type="upgrade">
+          <profiles>
+            <profile id="efaa-4a60-207f-0f1e" name="Laser volley cannon, Overcharge fire" hidden="false" profileTypeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" profileTypeName="Weapon">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <characteristics>
+                <characteristic name="Range" characteristicTypeId="6fa97fa8-ea74-4a27-a0fb-bc4e5f367464" value="36&quot;"/>
+                <characteristic name="Type" characteristicTypeId="077c342f-d7b9-45c6-b8af-88e97cafd3a2" value="Heavy 2"/>
+                <characteristic name="S" characteristicTypeId="59b1-319e-ec13-d466" value="10"/>
+                <characteristic name="AP" characteristicTypeId="75aa-a838-b675-6484" value="-5"/>
+                <characteristic name="D" characteristicTypeId="ae8a-3137-d65b-4ca7" value="6"/>
+                <characteristic name="Abilities" characteristicTypeId="837d-5e63-aeb7-1410" value="If any hit rolls made for this weapon result in one or more results of a &apos;1&apos;, the firing vehicle suffers 3 mortal wounds."/>
+              </characteristics>
+            </profile>
+            <profile id="6d01-1f60-5a67-4c60" name="Laser volley cannon, Volley fire" hidden="false" profileTypeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" profileTypeName="Weapon">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <characteristics>
+                <characteristic name="Range" characteristicTypeId="6fa97fa8-ea74-4a27-a0fb-bc4e5f367464" value="36&quot;"/>
+                <characteristic name="Type" characteristicTypeId="077c342f-d7b9-45c6-b8af-88e97cafd3a2" value="Heavy 2"/>
+                <characteristic name="S" characteristicTypeId="59b1-319e-ec13-d466" value="9"/>
+                <characteristic name="AP" characteristicTypeId="75aa-a838-b675-6484" value="-3"/>
+                <characteristic name="D" characteristicTypeId="ae8a-3137-d65b-4ca7" value="3"/>
+                <characteristic name="Abilities" characteristicTypeId="837d-5e63-aeb7-1410" value="-"/>
+              </characteristics>
+            </profile>
+          </profiles>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1492-f073-0101-87b1" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a01e-f466-453e-bdc7" type="min"/>
+          </constraints>
+          <categoryLinks/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks/>
+          <costs>
+            <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="0.0"/>
+            <cost name="pts" costTypeId="points" value="0.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups/>
+      <entryLinks>
+        <entryLink id="c78f-7cf9-c359-77d9" name="Storm bolter" hidden="false" targetId="2b03-8d64-3711-f300" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="72a9-178a-e56d-70dd" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="97a4-9a8b-1a84-e301" type="min"/>
+          </constraints>
+          <categoryLinks/>
+        </entryLink>
+        <entryLink id="bb89-de86-2d14-564f" name="Hunter-killer missile" hidden="false" targetId="f9c1-caf1-c410-a3d6" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c1fd-a6e0-4a6b-94db" type="max"/>
+          </constraints>
+          <categoryLinks/>
+        </entryLink>
+      </entryLinks>
+      <costs>
+        <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="10.0"/>
+        <cost name="pts" costTypeId="points" value="183.0"/>
+      </costs>
     </selectionEntry>
   </sharedSelectionEntries>
   <sharedSelectionEntryGroups>
@@ -12977,6 +14312,68 @@
           <categoryLinks/>
         </entryLink>
       </entryLinks>
+    </selectionEntryGroup>
+    <selectionEntryGroup id="1b73-13a0-a735-3dc7" name="Mark of Chaos" hidden="false" collective="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="db48-6100-5e03-6a77" type="max"/>
+      </constraints>
+      <categoryLinks/>
+      <selectionEntries>
+        <selectionEntry id="b62e-145a-fea0-e1ad" name="Khorne" hidden="false" collective="false" type="upgrade">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+          <categoryLinks/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks/>
+          <costs/>
+        </selectionEntry>
+        <selectionEntry id="ca12-0f7f-200b-d442" name="Nurgle" hidden="false" collective="false" type="upgrade">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+          <categoryLinks/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks/>
+          <costs/>
+        </selectionEntry>
+        <selectionEntry id="9142-b5d9-442a-bcb9" name="Slaanesh" hidden="false" collective="false" type="upgrade">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+          <categoryLinks/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks/>
+          <costs/>
+        </selectionEntry>
+        <selectionEntry id="cd53-1b66-5a28-7e42" name="Tzeentch" hidden="false" collective="false" type="upgrade">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+          <categoryLinks/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks/>
+          <costs/>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups/>
+      <entryLinks/>
     </selectionEntryGroup>
   </sharedSelectionEntryGroups>
   <sharedRules>
@@ -13149,6 +14546,34 @@ If your summoning roll included any doubles, your character then suffers a morta
       <modifiers/>
       <characteristics>
         <characteristic name="Description" characteristicTypeId="21befb24-fc85-4f52-a745-64b2e48f8228" value="This model heals one wound at the start of each of your turns."/>
+      </characteristics>
+    </profile>
+    <profile id="56b1-be11-b8ee-1e9e" name="Laser volley cannon, Overcharge fire" hidden="false" profileTypeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" profileTypeName="Weapon">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <characteristics>
+        <characteristic name="Range" characteristicTypeId="6fa97fa8-ea74-4a27-a0fb-bc4e5f367464" value="36&quot;"/>
+        <characteristic name="Type" characteristicTypeId="077c342f-d7b9-45c6-b8af-88e97cafd3a2" value="Heavy 2"/>
+        <characteristic name="S" characteristicTypeId="59b1-319e-ec13-d466" value="10"/>
+        <characteristic name="AP" characteristicTypeId="75aa-a838-b675-6484" value="-5"/>
+        <characteristic name="D" characteristicTypeId="ae8a-3137-d65b-4ca7" value="6"/>
+        <characteristic name="Abilities" characteristicTypeId="837d-5e63-aeb7-1410" value="If any hit rolls made for this weapon result in one or more results of a &apos;1&apos;, the firing vehicle suffers 3 mortal wounds."/>
+      </characteristics>
+    </profile>
+    <profile id="b9c7-5531-26d9-7612" name="Laser volley cannon, Volley fire" hidden="false" profileTypeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" profileTypeName="Weapon">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <characteristics>
+        <characteristic name="Range" characteristicTypeId="6fa97fa8-ea74-4a27-a0fb-bc4e5f367464" value="36&quot;"/>
+        <characteristic name="Type" characteristicTypeId="077c342f-d7b9-45c6-b8af-88e97cafd3a2" value="Heavy 2"/>
+        <characteristic name="S" characteristicTypeId="59b1-319e-ec13-d466" value="9"/>
+        <characteristic name="AP" characteristicTypeId="75aa-a838-b675-6484" value="-3"/>
+        <characteristic name="D" characteristicTypeId="ae8a-3137-d65b-4ca7" value="3"/>
+        <characteristic name="Abilities" characteristicTypeId="837d-5e63-aeb7-1410" value="-"/>
       </characteristics>
     </profile>
   </sharedProfiles>

--- a/Chaos - Thousand Sons.cat
+++ b/Chaos - Thousand Sons.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="c553-15f3-3890-be39" name="Chaos - Thousand Sons" book="Index: Chaos" revision="10" battleScribeVersion="2.01" authorName="BSData team" authorUrl="http://battlescribedata.appspot.com/#/repo/wh40k" gameSystemId="28ec-711c-d87f-3aeb" gameSystemRevision="1" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="c553-15f3-3890-be39" name="Chaos - Thousand Sons" book="Index: Chaos" revision="11" battleScribeVersion="2.01" authorName="BSData team" authorUrl="http://battlescribedata.appspot.com/#/repo/wh40k" gameSystemId="28ec-711c-d87f-3aeb" gameSystemRevision="1" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <profiles/>
   <rules/>
   <infoLinks/>

--- a/Chaos - Thousand Sons.cat
+++ b/Chaos - Thousand Sons.cat
@@ -4,7 +4,14 @@
   <rules/>
   <infoLinks/>
   <costTypes/>
-  <profileTypes/>
+  <profileTypes>
+    <profileType id="e1ed-eb4e-ce69-a9f5" name="Boon of Change table">
+      <characteristicTypes>
+        <characteristicType id="06b5-f9e5-9b75-188a" name="D3 Roll"/>
+        <characteristicType id="4e0d-1c11-63e2-72a2" name="Effect"/>
+      </characteristicTypes>
+    </profileType>
+  </profileTypes>
   <categoryEntries>
     <categoryEntry id="848a6ff2-0def-4c72-8433-ff7da70e6bc7" name="HQ" hidden="false">
       <profiles/>
@@ -966,13 +973,13 @@
         </rule>
       </rules>
       <infoLinks>
-        <infoLink id="2c65-43c6-922d-0004" name="New InfoLink" hidden="false" targetId="6349-022a-cea9-524c" type="rule">
+        <infoLink id="2c65-43c6-922d-0004" name="Death to the False Emperor" hidden="false" targetId="27a8-c34a-7a70-904e" type="profile">
           <profiles/>
           <rules/>
           <infoLinks/>
           <modifiers/>
         </infoLink>
-        <infoLink id="a861-3c9c-1034-761d" name="New InfoLink" hidden="false" targetId="2946-510b-88fb-5c9c" type="rule">
+        <infoLink id="a861-3c9c-1034-761d" name="Daemonic" hidden="false" targetId="126f-8dee-afb0-f9bd" type="profile">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -1191,13 +1198,13 @@
           <infoLinks/>
           <modifiers/>
         </infoLink>
-        <infoLink id="c736-96a1-f303-347b" name="New InfoLink" hidden="false" targetId="2946-510b-88fb-5c9c" type="rule">
+        <infoLink id="c736-96a1-f303-347b" name="Daemonic" hidden="false" targetId="126f-8dee-afb0-f9bd" type="profile">
           <profiles/>
           <rules/>
           <infoLinks/>
           <modifiers/>
         </infoLink>
-        <infoLink id="7890-822a-4a71-8c31" name="New InfoLink" hidden="false" targetId="afd3-a04b-c770-90c1" type="rule">
+        <infoLink id="7890-822a-4a71-8c31" name="Infernal Regeneration" hidden="false" targetId="d9f4-3f35-8c4b-f847" type="profile">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -1546,13 +1553,13 @@
         </rule>
       </rules>
       <infoLinks>
-        <infoLink id="fc94-8f49-944c-df76" name="New InfoLink" hidden="false" targetId="2946-510b-88fb-5c9c" type="rule">
+        <infoLink id="fc94-8f49-944c-df76" name="Daemonic" hidden="false" targetId="126f-8dee-afb0-f9bd" type="profile">
           <profiles/>
           <rules/>
           <infoLinks/>
           <modifiers/>
         </infoLink>
-        <infoLink id="0edd-ba98-a3b9-a06a" name="New InfoLink" hidden="false" targetId="afd3-a04b-c770-90c1" type="rule">
+        <infoLink id="0edd-ba98-a3b9-a06a" name="Infernal Regeneration" hidden="false" targetId="d9f4-3f35-8c4b-f847" type="profile">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -1798,13 +1805,13 @@
       </profiles>
       <rules/>
       <infoLinks>
-        <infoLink id="03ee-da67-d4d4-b2a3" name="Daemonic" hidden="false" targetId="2946-510b-88fb-5c9c" type="rule">
+        <infoLink id="03ee-da67-d4d4-b2a3" name="Daemonic" hidden="false" targetId="126f-8dee-afb0-f9bd" type="profile">
           <profiles/>
           <rules/>
           <infoLinks/>
           <modifiers/>
         </infoLink>
-        <infoLink id="7312-680e-f85f-f2bf" name="Infernal Regeneration" hidden="false" targetId="afd3-a04b-c770-90c1" type="rule">
+        <infoLink id="7312-680e-f85f-f2bf" name="Infernal Regeneration" hidden="false" targetId="d9f4-3f35-8c4b-f847" type="profile">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -2029,7 +2036,7 @@
       </profiles>
       <rules/>
       <infoLinks>
-        <infoLink id="e3a5-1035-6513-5ead" name="New InfoLink" hidden="false" targetId="6349-022a-cea9-524c" type="rule">
+        <infoLink id="e3a5-1035-6513-5ead" name="Death to the False Emperor" hidden="false" targetId="27a8-c34a-7a70-904e" type="profile">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -2211,7 +2218,7 @@
       </profiles>
       <rules/>
       <infoLinks>
-        <infoLink id="b88a-d832-87bd-b60f" name="New InfoLink" hidden="false" targetId="6349-022a-cea9-524c" type="rule">
+        <infoLink id="b88a-d832-87bd-b60f" name="Death to the False Emperor" hidden="false" targetId="27a8-c34a-7a70-904e" type="profile">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -2623,13 +2630,13 @@
           <infoLinks/>
           <modifiers/>
         </infoLink>
-        <infoLink id="6131-6f2a-3c9e-9cba" name="New InfoLink" hidden="false" targetId="e2cc-3e10-f4a9-d911" type="rule">
+        <infoLink id="6131-6f2a-3c9e-9cba" name="Terminator Armour" hidden="false" targetId="ed56-a1a0-7f92-a3ec" type="profile">
           <profiles/>
           <rules/>
           <infoLinks/>
           <modifiers/>
         </infoLink>
-        <infoLink id="9f0d-c2d6-94e6-d77a" name="New InfoLink" hidden="false" targetId="6349-022a-cea9-524c" type="rule">
+        <infoLink id="9f0d-c2d6-94e6-d77a" name="Death to the False Emperor" hidden="false" targetId="27a8-c34a-7a70-904e" type="profile">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -3081,7 +3088,7 @@
       </profiles>
       <rules/>
       <infoLinks>
-        <infoLink id="3fe6-9c8f-0c91-5966" name="New InfoLink" hidden="false" targetId="6349-022a-cea9-524c" type="rule">
+        <infoLink id="3fe6-9c8f-0c91-5966" name="Death to the False Emperor" hidden="false" targetId="27a8-c34a-7a70-904e" type="profile">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -3225,13 +3232,13 @@
         </rule>
       </rules>
       <infoLinks>
-        <infoLink id="4e39-3732-b1e1-220c" name="New InfoLink" hidden="false" targetId="6349-022a-cea9-524c" type="rule">
+        <infoLink id="4e39-3732-b1e1-220c" name="Death to the False Emperor" hidden="false" targetId="27a8-c34a-7a70-904e" type="profile">
           <profiles/>
           <rules/>
           <infoLinks/>
           <modifiers/>
         </infoLink>
-        <infoLink id="53f2-1999-22d7-52e2" name="New InfoLink" hidden="false" targetId="2946-510b-88fb-5c9c" type="rule">
+        <infoLink id="53f2-1999-22d7-52e2" name="Daemonic" hidden="false" targetId="126f-8dee-afb0-f9bd" type="profile">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -3422,7 +3429,7 @@
       </profiles>
       <rules/>
       <infoLinks>
-        <infoLink id="2370-ad7a-4106-a343" name="New InfoLink" hidden="false" targetId="6349-022a-cea9-524c" type="rule">
+        <infoLink id="2370-ad7a-4106-a343" name="Death to the False Emperor" hidden="false" targetId="27a8-c34a-7a70-904e" type="profile">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -3434,7 +3441,7 @@
           <infoLinks/>
           <modifiers/>
         </infoLink>
-        <infoLink id="003d-95c4-1498-c261" name="New InfoLink" hidden="false" targetId="e2cc-3e10-f4a9-d911" type="rule">
+        <infoLink id="003d-95c4-1498-c261" name="Terminator Armour" hidden="false" targetId="ed56-a1a0-7f92-a3ec" type="profile">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -3638,7 +3645,7 @@
         </rule>
       </rules>
       <infoLinks>
-        <infoLink id="7232-cf00-a9c1-8364" name="New InfoLink" hidden="false" targetId="6349-022a-cea9-524c" type="rule">
+        <infoLink id="7232-cf00-a9c1-8364" name="Death to the False Emperor" hidden="false" targetId="27a8-c34a-7a70-904e" type="profile">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -3908,7 +3915,7 @@
         </rule>
       </rules>
       <infoLinks>
-        <infoLink id="b394-4dae-b58d-112c" name="New InfoLink" hidden="false" targetId="6349-022a-cea9-524c" type="rule">
+        <infoLink id="b394-4dae-b58d-112c" name="Death to the False Emperor" hidden="false" targetId="27a8-c34a-7a70-904e" type="profile">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -5066,7 +5073,7 @@
       </profiles>
       <rules/>
       <infoLinks>
-        <infoLink id="f266-70d3-c684-421d" name="New InfoLink" hidden="false" targetId="6349-022a-cea9-524c" type="rule">
+        <infoLink id="f266-70d3-c684-421d" name="Death to the False Emperor" hidden="false" targetId="27a8-c34a-7a70-904e" type="profile">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -5723,7 +5730,7 @@
       </profiles>
       <rules/>
       <infoLinks>
-        <infoLink id="ad25-8b45-55a1-6856" name="New InfoLink" hidden="false" targetId="6349-022a-cea9-524c" type="rule">
+        <infoLink id="ad25-8b45-55a1-6856" name="Death to the False Emperor" hidden="false" targetId="27a8-c34a-7a70-904e" type="profile">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -6186,7 +6193,7 @@
           <infoLinks/>
           <modifiers/>
           <characteristics>
-            <characteristic name="Description" characteristicTypeId="21befb24-fc85-4f52-a745-64b2e48f8228" value="Ahriman has a 4++ save."/>
+            <characteristic name="Description" characteristicTypeId="21befb24-fc85-4f52-a745-64b2e48f8228" value="Ahriman has a 4+ invulnerable save."/>
           </characteristics>
         </profile>
         <profile id="d716-6db8-f706-eae0" name="Lord of the Thousand Sons" hidden="false" profileTypeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" profileTypeName="Abilities">
@@ -6195,7 +6202,7 @@
           <infoLinks/>
           <modifiers/>
           <characteristics>
-            <characteristic name="Description" characteristicTypeId="21befb24-fc85-4f52-a745-64b2e48f8228" value="You can re-roll invulnerable saving throws of 1 made for friendly Thousand Sons Infantry units within 6&quot; of this model."/>
+            <characteristic name="Description" characteristicTypeId="21befb24-fc85-4f52-a745-64b2e48f8228" value="You can re-roll invulnerable saving throws of 1 made for friendly THOUSAND SONS INFANTRY units within 6&quot; of this model."/>
           </characteristics>
         </profile>
         <profile id="26b5-45a1-6463-37cf" name="Ahriman" hidden="false" profileTypeId="800f-21d0-4387-c943" profileTypeName="Unit">
@@ -6223,14 +6230,14 @@
           <characteristics>
             <characteristic name="Cast" characteristicTypeId="5afb-9914-904b-d3b3" value="3"/>
             <characteristic name="Deny" characteristicTypeId="b5ac-9c20-5d5a-6f9b" value="3"/>
-            <characteristic name="Powers Known" characteristicTypeId="69d7-b45e-00a2-7e46" value="3 Dark Hereticus"/>
-            <characteristic name="Other" characteristicTypeId="c2e2-f115-0003-5d7b" value="+1 to Psychic or Deny the Witch tests"/>
+            <characteristic name="Powers Known" characteristicTypeId="69d7-b45e-00a2-7e46" value="Smite and three powers from the Dark Hereticus discipline"/>
+            <characteristic name="Other" characteristicTypeId="c2e2-f115-0003-5d7b" value="Whenever Ahriman attempts to manifest or resist a psychic power, add 1 to his Psychic or Deny the Witch tests"/>
           </characteristics>
         </profile>
       </profiles>
       <rules/>
       <infoLinks>
-        <infoLink id="7a81-2211-d524-8a1f" name="New InfoLink" hidden="false" targetId="6349-022a-cea9-524c" type="rule">
+        <infoLink id="7a81-2211-d524-8a1f" name="Death to the False Emperor" hidden="false" targetId="27a8-c34a-7a70-904e" type="profile">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -6247,7 +6254,7 @@
         </modifier>
       </modifiers>
       <constraints>
-        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="94a7-a458-7cec-2f58" type="max"/>
+        <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="94a7-a458-7cec-2f58" type="max"/>
       </constraints>
       <categoryLinks>
         <categoryLink id="7cce-b63c-a8e2-c02a" name="New CategoryLink" hidden="false" targetId="717b-8863-9d25-5e2a" primary="false">
@@ -6372,6 +6379,47 @@
           </constraints>
           <categoryLinks/>
         </entryLink>
+        <entryLink id="17a1-f2b5-9941-26e3" name="Smite" hidden="false" targetId="03fd-db47-5333-1e1f" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b0b5-6744-d183-3342" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="14d6-e4d9-7c24-d29a" type="min"/>
+          </constraints>
+          <categoryLinks/>
+        </entryLink>
+        <entryLink id="77b9-ab76-78c7-8145" name="Infernal Gaze" hidden="false" targetId="6c4a-1e10-1b14-8656" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="20a0-2f89-cd8d-775a" type="min"/>
+          </constraints>
+          <categoryLinks/>
+        </entryLink>
+        <entryLink id="75f7-0656-5273-eeed" name="Prescience" hidden="false" targetId="7eee-d684-f212-f2be" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3f92-9e6e-02cd-5a17" type="min"/>
+          </constraints>
+          <categoryLinks/>
+        </entryLink>
+        <entryLink id="9384-ab22-78b6-a542" name="Warptime" hidden="false" targetId="bb7e-c0e1-d38d-33dd" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="dac1-8503-7e3c-bf46" type="min"/>
+          </constraints>
+          <categoryLinks/>
+        </entryLink>
       </entryLinks>
       <costs>
         <cost name="pts" costTypeId="points" value="131.0"/>
@@ -6386,7 +6434,7 @@
           <infoLinks/>
           <modifiers/>
           <characteristics>
-            <characteristic name="Description" characteristicTypeId="21befb24-fc85-4f52-a745-64b2e48f8228" value="Ahriman has a 4++ save."/>
+            <characteristic name="Description" characteristicTypeId="21befb24-fc85-4f52-a745-64b2e48f8228" value="Ahriman has a 4+ invulnerable save."/>
           </characteristics>
         </profile>
         <profile id="5e27-aa9c-9e69-1524" name="Lord of the Thousand Sons" hidden="false" profileTypeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" profileTypeName="Abilities">
@@ -6395,7 +6443,7 @@
           <infoLinks/>
           <modifiers/>
           <characteristics>
-            <characteristic name="Description" characteristicTypeId="21befb24-fc85-4f52-a745-64b2e48f8228" value="You can re-roll invulnerable saving throws of 1 made for friendly Thousand Sons Infantry units within 6&quot; of this model."/>
+            <characteristic name="Description" characteristicTypeId="21befb24-fc85-4f52-a745-64b2e48f8228" value="You can re-roll invulnerable saving throws of 1 made for friendly THOUSAND SONS INFANTRY units within 6&quot; of this model."/>
           </characteristics>
         </profile>
         <profile id="2bcb-f496-d6ee-b77d" name="Ahriman" hidden="false" profileTypeId="800f-21d0-4387-c943" profileTypeName="Unit">
@@ -6415,7 +6463,7 @@
             <characteristic name="Save" characteristicTypeId="c0df-df94-abd7-e8d3" value="3+"/>
           </characteristics>
         </profile>
-        <profile id="5235-5fe1-5ede-6a0a" name="Ahriman" hidden="false" profileTypeId="bc97-dea9-9e88-bb7d" profileTypeName="Psyker">
+        <profile id="828f-54dc-8677-b5a3" name="Ahriman" hidden="false" profileTypeId="bc97-dea9-9e88-bb7d" profileTypeName="Psyker">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -6423,14 +6471,14 @@
           <characteristics>
             <characteristic name="Cast" characteristicTypeId="5afb-9914-904b-d3b3" value="3"/>
             <characteristic name="Deny" characteristicTypeId="b5ac-9c20-5d5a-6f9b" value="3"/>
-            <characteristic name="Powers Known" characteristicTypeId="69d7-b45e-00a2-7e46" value="3 Dark Hereticus"/>
-            <characteristic name="Other" characteristicTypeId="c2e2-f115-0003-5d7b" value="+1 to Psychic or Deny the Witch tests"/>
+            <characteristic name="Powers Known" characteristicTypeId="69d7-b45e-00a2-7e46" value="Smite and three powers from the Dark Hereticus discipline"/>
+            <characteristic name="Other" characteristicTypeId="c2e2-f115-0003-5d7b" value="Whenever Ahriman attempts to manifest or resist a psychic power, add 1 to his Psychic or Deny the Witch tests"/>
           </characteristics>
         </profile>
       </profiles>
       <rules/>
       <infoLinks>
-        <infoLink id="4f82-7946-6f9f-cf6e" name="New InfoLink" hidden="false" targetId="6349-022a-cea9-524c" type="rule">
+        <infoLink id="4f82-7946-6f9f-cf6e" name="Death to the False Emperor" hidden="false" targetId="27a8-c34a-7a70-904e" type="profile">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -6626,6 +6674,47 @@
           </constraints>
           <categoryLinks/>
         </entryLink>
+        <entryLink id="3fb8-7ce6-dce0-216f" name="Infernal Gaze" hidden="false" targetId="6c4a-1e10-1b14-8656" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="89d5-ff15-7c23-7e81" type="min"/>
+          </constraints>
+          <categoryLinks/>
+        </entryLink>
+        <entryLink id="4840-921f-e8bc-5f4c" name="Prescience" hidden="false" targetId="7eee-d684-f212-f2be" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a1ec-a3bf-a926-2c32" type="min"/>
+          </constraints>
+          <categoryLinks/>
+        </entryLink>
+        <entryLink id="bc0d-8234-921c-320b" name="Smite" hidden="false" targetId="03fd-db47-5333-1e1f" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="030a-9b0e-7b6b-f48f" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ce53-a95e-653d-ccf2" type="min"/>
+          </constraints>
+          <categoryLinks/>
+        </entryLink>
+        <entryLink id="69c1-7225-9637-6802" name="Warptime" hidden="false" targetId="bb7e-c0e1-d38d-33dd" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6aeb-4498-57fb-c9d4" type="min"/>
+          </constraints>
+          <categoryLinks/>
+        </entryLink>
       </entryLinks>
       <costs>
         <cost name="pts" costTypeId="points" value="166.0"/>
@@ -6719,7 +6808,7 @@
         </rule>
       </rules>
       <infoLinks>
-        <infoLink id="9afa-8ea1-58d9-b1b6" name="New InfoLink" hidden="false" targetId="b4eb-f3f5-d439-1834" type="rule">
+        <infoLink id="9afa-8ea1-58d9-b1b6" name="Daemonic Machine Spirit" hidden="false" targetId="79d3-db1a-c054-9cf3" type="profile">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -6922,19 +7011,19 @@
       </profiles>
       <rules/>
       <infoLinks>
-        <infoLink id="2949-acad-a68c-de71" name="New InfoLink" hidden="false" targetId="3541-94a7-a138-358b" type="rule">
+        <infoLink id="2949-acad-a68c-de71" name="Explodes" hidden="false" targetId="3541-94a7-a138-358b" type="rule">
           <profiles/>
           <rules/>
           <infoLinks/>
           <modifiers/>
         </infoLink>
-        <infoLink id="4eaa-e868-57f3-c6f0" name="New InfoLink" hidden="false" targetId="afd3-a04b-c770-90c1" type="rule">
+        <infoLink id="4eaa-e868-57f3-c6f0" name="Infernal Regeneration" hidden="false" targetId="d9f4-3f35-8c4b-f847" type="profile">
           <profiles/>
           <rules/>
           <infoLinks/>
           <modifiers/>
         </infoLink>
-        <infoLink id="0c42-4f38-726b-b2a0" name="New InfoLink" hidden="false" targetId="2946-510b-88fb-5c9c" type="rule">
+        <infoLink id="0c42-4f38-726b-b2a0" name="Daemonic" hidden="false" targetId="126f-8dee-afb0-f9bd" type="profile">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -7158,6 +7247,93 @@
       <costs>
         <cost name="pts" costTypeId="points" value="119.0"/>
         <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="10.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="7eee-d684-f212-f2be" name="Prescience" hidden="false" collective="false" type="upgrade">
+      <profiles>
+        <profile id="cd2d-3c3a-2e46-ff85" name="Prescience" hidden="false" profileTypeId="ae70-4738-0161-bec0" profileTypeName="Psychic Power">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Warp Charge" characteristicTypeId="5ffd-b800-c317-532a" value="7"/>
+            <characteristic name="Range" characteristicTypeId="fd64-cbc4-94de-24cc" value="18&quot;"/>
+            <characteristic name="Details" characteristicTypeId="ad96-dfa4-b4ed-656d" value="If manifested, select a HERETIC ASTARTES unit within 18&quot; of the psyker. You can add 1 to all hit rolls made for that unit until the start of your next Psychic phase."/>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3de0-2781-16e3-c2f0" type="max"/>
+      </constraints>
+      <categoryLinks/>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="0.0"/>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="6c4a-1e10-1b14-8656" name="Infernal Gaze" hidden="false" collective="false" type="upgrade">
+      <profiles>
+        <profile id="970b-a6d5-5f92-61ac" name="Infernal Gaze" hidden="false" profileTypeId="ae70-4738-0161-bec0" profileTypeName="Psychic Power">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Warp Charge" characteristicTypeId="5ffd-b800-c317-532a" value="5"/>
+            <characteristic name="Range" characteristicTypeId="fd64-cbc4-94de-24cc" value="18&quot;"/>
+            <characteristic name="Details" characteristicTypeId="ad96-dfa4-b4ed-656d" value="If manifested, select a visible enemy unit within 18&quot; of the psyker and roll 3 dice. The target suffers one mortal wound for each roll of 4+."/>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="774f-c44b-fa7d-2dfa" type="max"/>
+      </constraints>
+      <categoryLinks/>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="0.0"/>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="bb7e-c0e1-d38d-33dd" name="Warptime" hidden="false" collective="false" type="upgrade">
+      <profiles>
+        <profile id="b968-b5bf-210d-802c" name="Warptime" hidden="false" profileTypeId="ae70-4738-0161-bec0" profileTypeName="Psychic Power">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Warp Charge" characteristicTypeId="5ffd-b800-c317-532a" value="6"/>
+            <characteristic name="Range" characteristicTypeId="fd64-cbc4-94de-24cc" value="3&quot;"/>
+            <characteristic name="Details" characteristicTypeId="ad96-dfa4-b4ed-656d" value="If manifested, pick a friendly HERETIC ASTARTES unit within 3&quot; of the psyker. That unit can immediately move as if it were its Movement phase. You cannot use Warptime on a unit ,pre than once in each Psychic phase."/>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3284-5d62-2a3f-1f5c" type="max"/>
+      </constraints>
+      <categoryLinks/>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="0.0"/>
+        <cost name="pts" costTypeId="points" value="0.0"/>
       </costs>
     </selectionEntry>
   </sharedSelectionEntries>
@@ -7524,21 +7700,44 @@
         </entryLink>
       </entryLinks>
     </selectionEntryGroup>
+    <selectionEntryGroup id="cca1-01a1-45fa-e054" name="Dark Hereticus Discipline" hidden="false" collective="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints/>
+      <categoryLinks/>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks>
+        <entryLink id="21c1-2d30-50fc-77e1" name="Infernal Gaze" hidden="false" targetId="6c4a-1e10-1b14-8656" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+          <categoryLinks/>
+        </entryLink>
+        <entryLink id="2853-b27c-0a71-f00c" name="Warptime" hidden="false" targetId="bb7e-c0e1-d38d-33dd" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+          <categoryLinks/>
+        </entryLink>
+        <entryLink id="16ee-d07e-8200-d145" name="Prescience" hidden="false" targetId="7eee-d684-f212-f2be" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+          <categoryLinks/>
+        </entryLink>
+      </entryLinks>
+    </selectionEntryGroup>
   </sharedSelectionEntryGroups>
   <sharedRules>
-    <rule id="b962-c13b-7edc-556d" name="Mindless" hidden="false">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <description>This unit never has to take Morale tests.</description>
-    </rule>
-    <rule id="6349-022a-cea9-524c" name="Death to the False Emperor" hidden="false">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-    </rule>
     <rule id="ae9c-d115-d4a9-ba02" name="Teleport Strike" hidden="false">
       <profiles/>
       <rules/>
@@ -7546,60 +7745,11 @@
       <modifiers/>
       <description>During deployment, you can set up this model in a teleportarium chamber instead of placing it on the battlefield. At the end of any of your Movement phases the model can use a teleport strike to arrive on the battlefield - set it up anywhere on the battlefield that is more than 9&quot; away from any enemy models.</description>
     </rule>
-    <rule id="2946-510b-88fb-5c9c" name="Daemonic" hidden="false">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <description>This model has a 5++.</description>
-    </rule>
-    <rule id="b4eb-f3f5-d439-1834" name="Daemonic Machine Spirit" hidden="false">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <description>Ignore the -1 to hit modifier for moving and shooting Heavy weapons for this model.</description>
-    </rule>
-    <rule id="94d8-b556-103a-36ec" name="Sigil of Corruption" hidden="false">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <description>This model has a 4++ save.</description>
-    </rule>
     <rule id="224f-2c86-454d-54aa" name="Daemonic Ritual" hidden="false">
       <profiles/>
       <rules/>
       <infoLinks/>
       <modifiers/>
-    </rule>
-    <rule id="8ce7-b46b-12bd-dbb8" name="Lord of Chaos" hidden="false">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <description>You can re-roll hit rolls of 1 made for friendly Thousand Sons units within 6&quot; of this model.</description>
-    </rule>
-    <rule id="e008-161d-80a5-aef1" name="Turbo-boost" hidden="false">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <description>When this model Advances, add 6&quot; to its Move characteristic for that Movement phase instead of rolling a dice.</description>
-    </rule>
-    <rule id="e2cc-3e10-f4a9-d911" name="Terminator Armour" hidden="false">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <description>This model has a 5++.</description>
-    </rule>
-    <rule id="afd3-a04b-c770-90c1" name="Infernal Regeneration" hidden="false">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <description>At the beginning of each of your turns, this model heals one wound.</description>
     </rule>
   </sharedRules>
   <sharedProfiles>
@@ -7923,6 +8073,51 @@
         <characteristic name="AP" characteristicTypeId="75aa-a838-b675-6484" value="0"/>
         <characteristic name="D" characteristicTypeId="ae8a-3137-d65b-4ca7" value="1"/>
         <characteristic name="Abilities" characteristicTypeId="837d-5e63-aeb7-1410" value="-"/>
+      </characteristics>
+    </profile>
+    <profile id="126f-8dee-afb0-f9bd" name="Daemonic" hidden="false" profileTypeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" profileTypeName="Abilities">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <characteristics>
+        <characteristic name="Description" characteristicTypeId="21befb24-fc85-4f52-a745-64b2e48f8228" value="This model has a 5+ invulnerable save."/>
+      </characteristics>
+    </profile>
+    <profile id="27a8-c34a-7a70-904e" name="Death to the False Emperor" hidden="false" profileTypeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" profileTypeName="Abilities">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <characteristics>
+        <characteristic name="Description" characteristicTypeId="21befb24-fc85-4f52-a745-64b2e48f8228" value="Each time you roll a hit roll of 6+ for a model with this ability in the Fight phase, it can, if it was targeting an IMPERIUM unit, immediately make an extra attack against the same unit using the same weapon. These extra attacks cannot themselves generate any further attacks."/>
+      </characteristics>
+    </profile>
+    <profile id="79d3-db1a-c054-9cf3" name="Daemonic Machine Spirit" hidden="false" profileTypeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" profileTypeName="Abilities">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <characteristics>
+        <characteristic name="Description" characteristicTypeId="21befb24-fc85-4f52-a745-64b2e48f8228" value="Ignore the -1 to hit modifier for moving and shooting Heavy weapons for this model."/>
+      </characteristics>
+    </profile>
+    <profile id="d9f4-3f35-8c4b-f847" name="Infernal Regeneration" hidden="false" profileTypeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" profileTypeName="Abilities">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <characteristics>
+        <characteristic name="Description" characteristicTypeId="21befb24-fc85-4f52-a745-64b2e48f8228" value="At the beginning of each of your turns, this model heals one wound."/>
+      </characteristics>
+    </profile>
+    <profile id="ed56-a1a0-7f92-a3ec" name="Terminator Armour" hidden="false" profileTypeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" profileTypeName="Abilities">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <characteristics>
+        <characteristic name="Description" characteristicTypeId="21befb24-fc85-4f52-a745-64b2e48f8228" value="This model has a 5+ invulnerable save."/>
       </characteristics>
     </profile>
   </sharedProfiles>

--- a/Chaos - Thousand Sons.cat
+++ b/Chaos - Thousand Sons.cat
@@ -111,6 +111,13 @@
       <modifiers/>
       <constraints/>
     </categoryEntry>
+    <categoryEntry id="68f9-33bb-bd2b-c777" name="Sorcerer" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints/>
+    </categoryEntry>
   </categoryEntries>
   <forceEntries>
     <forceEntry id="f733-c79b-0ac7-764e" name="Testing Detachment" hidden="false">
@@ -958,20 +965,12 @@
           <characteristics>
             <characteristic name="Cast" characteristicTypeId="5afb-9914-904b-d3b3" value="1"/>
             <characteristic name="Deny" characteristicTypeId="b5ac-9c20-5d5a-6f9b" value="1"/>
-            <characteristic name="Powers Known" characteristicTypeId="69d7-b45e-00a2-7e46" value="1 Dark Hereticus"/>
+            <characteristic name="Powers Known" characteristicTypeId="69d7-b45e-00a2-7e46" value="Smite and one power from the Dark Hereticus discipline"/>
             <characteristic name="Other" characteristicTypeId="c2e2-f115-0003-5d7b" value=""/>
           </characteristics>
         </profile>
       </profiles>
-      <rules>
-        <rule id="0e00-be0f-ee90-f822" name="Prince of Chaos" hidden="false">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <description>You can re-roll hit rolls of 1 made for friendly Thousand Sons units within 6&quot; of this model. This ability also affects friendly Daemon units within 6&quot;.</description>
-        </rule>
-      </rules>
+      <rules/>
       <infoLinks>
         <infoLink id="2c65-43c6-922d-0004" name="Death to the False Emperor" hidden="false" targetId="27a8-c34a-7a70-904e" type="profile">
           <profiles/>
@@ -980,6 +979,12 @@
           <modifiers/>
         </infoLink>
         <infoLink id="a861-3c9c-1034-761d" name="Daemonic" hidden="false" targetId="126f-8dee-afb0-f9bd" type="profile">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="9a6f-a8cd-bc26-84b3" name="Prince of Chaos" hidden="false" targetId="6c28-5b6b-0879-5f1d" type="profile">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -1039,6 +1044,13 @@
           <constraints/>
         </categoryLink>
         <categoryLink id="4d01-aec2-6510-1c8e" name="New CategoryLink" hidden="false" targetId="5723-c15a-5882-1f57" primary="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
+        <categoryLink id="853c-5962-1dc8-6e08" name="New CategoryLink" hidden="false" targetId="012f-abfc-397b-3519" primary="false">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -1113,6 +1125,28 @@
           <modifiers/>
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f03d-8095-182f-bf4b" type="max"/>
+          </constraints>
+          <categoryLinks/>
+        </entryLink>
+        <entryLink id="2063-87ae-5099-6f84" name="Smite" hidden="false" targetId="03fd-db47-5333-1e1f" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9f39-044a-c37d-0546" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7c0b-1ed6-35ed-ed49" type="min"/>
+          </constraints>
+          <categoryLinks/>
+        </entryLink>
+        <entryLink id="25f7-57aa-d10b-405e" name="Dark Hereticus Discipline" hidden="false" targetId="cca1-01a1-45fa-e054" type="selectionEntryGroup">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a03a-2350-1055-b5dd" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d7b4-d140-0ef9-aef8" type="min"/>
           </constraints>
           <categoryLinks/>
         </entryLink>
@@ -2197,15 +2231,6 @@
     </selectionEntry>
     <selectionEntry id="7142-e365-1c12-efd6" name="Rubric Marines" page="" hidden="false" collective="false" type="unit">
       <profiles>
-        <profile id="9947-7f55-8e1c-645d" name="Favoured of Tzeentch" hidden="false" profileTypeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" profileTypeName="Abilities">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <characteristics>
-            <characteristic name="Description" characteristicTypeId="21befb24-fc85-4f52-a745-64b2e48f8228" value="All models in this unit have a 5++."/>
-          </characteristics>
-        </profile>
         <profile id="0c81-ebb6-5c41-0730" name="All is Dust" hidden="false" profileTypeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" profileTypeName="Abilities">
           <profiles/>
           <rules/>
@@ -2213,6 +2238,23 @@
           <modifiers/>
           <characteristics>
             <characteristic name="Description" characteristicTypeId="21befb24-fc85-4f52-a745-64b2e48f8228" value="Add 1 to the saving throws for Rubric Marines if the attack has a Damage characteristic of 1. In addition, the -1 modifier to hit rolls for moving and shooting with a Heavy weapon does not apply to Rubric Marines."/>
+          </characteristics>
+        </profile>
+        <profile id="3ba7-ce60-4405-9e0c" name="Rubric Marine" page="0" hidden="false" profileTypeId="800f-21d0-4387-c943" profileTypeName="Unit">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="M" characteristicTypeId="0bdf-a96e-9e38-7779" value="5&quot;"/>
+            <characteristic name="WS" characteristicTypeId="e7f0-1278-0250-df0c" value="3+"/>
+            <characteristic name="BS" characteristicTypeId="381b-eb28-74c3-df5f" value="3+"/>
+            <characteristic name="S" characteristicTypeId="2218-aa3c-265f-2939" value="4"/>
+            <characteristic name="T" characteristicTypeId="9c9f-9774-a358-3a39" value="4"/>
+            <characteristic name="W" characteristicTypeId="f330-5e6e-4110-0978" value="1"/>
+            <characteristic name="A" characteristicTypeId="13fc-b29b-31f2-ab9f" value="1"/>
+            <characteristic name="Ld" characteristicTypeId="00ca-f8b8-876d-b705" value="7"/>
+            <characteristic name="Save" characteristicTypeId="c0df-df94-abd7-e8d3" value="3+"/>
           </characteristics>
         </profile>
       </profiles>
@@ -2224,19 +2266,38 @@
           <infoLinks/>
           <modifiers/>
         </infoLink>
+        <infoLink id="cd39-32e0-c1f2-69dc" name="Favour of Tzeentch" hidden="false" targetId="5d58-ea78-c523-b0c7" type="profile">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers>
+            <modifier type="set" field="name" value="Favoured of Tzeentch">
+              <repeats/>
+              <conditions/>
+              <conditionGroups/>
+            </modifier>
+          </modifiers>
+        </infoLink>
       </infoLinks>
       <modifiers>
-        <modifier type="increment" field="e356-c769-5920-6e14" value="6">
-          <repeats>
-            <repeat field="selections" scope="7142-e365-1c12-efd6" value="5.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="model" repeats="1" roundUp="true"/>
-          </repeats>
-          <conditions/>
-          <conditionGroups/>
-        </modifier>
-        <modifier type="decrement" field="e356-c769-5920-6e14" value="6">
+        <modifier type="set" field="e356-c769-5920-6e14" value="14">
           <repeats/>
           <conditions>
-            <condition field="selections" scope="7142-e365-1c12-efd6" value="4.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="model" type="greaterThan"/>
+            <condition field="selections" scope="7142-e365-1c12-efd6" value="5.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="model" type="greaterThan"/>
+          </conditions>
+          <conditionGroups/>
+        </modifier>
+        <modifier type="set" field="e356-c769-5920-6e14" value="20">
+          <repeats/>
+          <conditions>
+            <condition field="selections" scope="7142-e365-1c12-efd6" value="10.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="model" type="greaterThan"/>
+          </conditions>
+          <conditionGroups/>
+        </modifier>
+        <modifier type="set" field="e356-c769-5920-6e14" value="26">
+          <repeats/>
+          <conditions>
+            <condition field="selections" scope="7142-e365-1c12-efd6" value="15.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="model" type="greaterThan"/>
           </conditions>
           <conditionGroups/>
         </modifier>
@@ -2321,8 +2382,8 @@
               <characteristics>
                 <characteristic name="Cast" characteristicTypeId="5afb-9914-904b-d3b3" value="1"/>
                 <characteristic name="Deny" characteristicTypeId="b5ac-9c20-5d5a-6f9b" value="1"/>
-                <characteristic name="Powers Known" characteristicTypeId="69d7-b45e-00a2-7e46" value="-"/>
-                <characteristic name="Other" characteristicTypeId="c2e2-f115-0003-5d7b" value="Smite 1 MW instead of D3 W, D3 MW instead of D6 W if 10+"/>
+                <characteristic name="Powers Known" characteristicTypeId="69d7-b45e-00a2-7e46" value="Smite"/>
+                <characteristic name="Other" characteristicTypeId="c2e2-f115-0003-5d7b" value="When an Aspiring Sorcerer manifests the Smite psychic power, he inflicts 1 mortal wound instead of D3, and D3 mortal wounds instead of D6 if the Psychic Test is 10 or more."/>
               </characteristics>
             </profile>
           </profiles>
@@ -2334,7 +2395,35 @@
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
           </constraints>
           <categoryLinks/>
-          <selectionEntries/>
+          <selectionEntries>
+            <selectionEntry id="0f7c-c2eb-be4c-1e69" name="Smite" hidden="false" collective="false" type="upgrade">
+              <profiles>
+                <profile id="97c6-1fa2-03a5-bdaf" name="Smite" hidden="false" profileTypeId="ae70-4738-0161-bec0" profileTypeName="Psychic Power">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <characteristics>
+                    <characteristic name="Warp Charge" characteristicTypeId="5ffd-b800-c317-532a" value="5"/>
+                    <characteristic name="Range" characteristicTypeId="fd64-cbc4-94de-24cc" value="18&quot;"/>
+                    <characteristic name="Details" characteristicTypeId="ad96-dfa4-b4ed-656d" value="If manifested, the closest visible enemy unit within 18&quot; of the psyker suffers 1 mortal wound. If the result of the Psychic test was more than 10 the target suffers D3 mortal wounds instead."/>
+                  </characteristics>
+                </profile>
+              </profiles>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="43d1-6a7c-9bea-c0c5" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4d5e-825d-ae74-a3bf" type="min"/>
+              </constraints>
+              <categoryLinks/>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks/>
+              <costs/>
+            </selectionEntry>
+          </selectionEntries>
           <selectionEntryGroups>
             <selectionEntryGroup id="ef2e-1191-dd79-4a32" name="Pistol" hidden="false" collective="false" defaultSelectionEntryId="9790-4535-dfce-afd8">
               <profiles/>
@@ -2436,167 +2525,179 @@
             <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="0.0"/>
           </costs>
         </selectionEntry>
-        <selectionEntry id="df89-fe83-8f3b-387c" name="Rubric Marine" page="" hidden="false" collective="false" type="model">
-          <profiles>
-            <profile id="fd17-0e2c-9604-5934" name="Rubric Marine" page="0" hidden="false" profileTypeId="800f-21d0-4387-c943" profileTypeName="Unit">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <characteristics>
-                <characteristic name="M" characteristicTypeId="0bdf-a96e-9e38-7779" value="5&quot;"/>
-                <characteristic name="WS" characteristicTypeId="e7f0-1278-0250-df0c" value="3+"/>
-                <characteristic name="BS" characteristicTypeId="381b-eb28-74c3-df5f" value="3+"/>
-                <characteristic name="S" characteristicTypeId="2218-aa3c-265f-2939" value="4"/>
-                <characteristic name="T" characteristicTypeId="9c9f-9774-a358-3a39" value="4"/>
-                <characteristic name="W" characteristicTypeId="f330-5e6e-4110-0978" value="1"/>
-                <characteristic name="A" characteristicTypeId="13fc-b29b-31f2-ab9f" value="1"/>
-                <characteristic name="Ld" characteristicTypeId="00ca-f8b8-876d-b705" value="7"/>
-                <characteristic name="Save" characteristicTypeId="c0df-df94-abd7-e8d3" value="3+"/>
-              </characteristics>
-            </profile>
-          </profiles>
+      </selectionEntries>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="21f0-7b37-aaf6-64c8" name="Rubric Marines" hidden="false" collective="false" defaultSelectionEntryId="4bbf-ef51-cdfb-2f7e">
+          <profiles/>
           <rules/>
           <infoLinks/>
           <modifiers/>
           <constraints>
-            <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-            <constraint field="selections" scope="parent" value="19.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+            <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="8041-845e-06bb-1e57" type="min"/>
+            <constraint field="selections" scope="parent" value="19.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="7076-d107-517e-e775" type="max"/>
           </constraints>
           <categoryLinks/>
           <selectionEntries>
-            <selectionEntry id="bae1-8288-3794-d6a8" name="Inferno boltgun" hidden="false" collective="false" type="upgrade">
-              <profiles>
-                <profile id="9004-5c73-b304-79a4" name="Inferno boltgun" hidden="false" profileTypeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" profileTypeName="Weapon">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                  <characteristics>
-                    <characteristic name="Range" characteristicTypeId="6fa97fa8-ea74-4a27-a0fb-bc4e5f367464" value="24&quot;"/>
-                    <characteristic name="Type" characteristicTypeId="077c342f-d7b9-45c6-b8af-88e97cafd3a2" value="Rapid Fire 1"/>
-                    <characteristic name="S" characteristicTypeId="59b1-319e-ec13-d466" value="4"/>
-                    <characteristic name="AP" characteristicTypeId="75aa-a838-b675-6484" value="-2"/>
-                    <characteristic name="D" characteristicTypeId="ae8a-3137-d65b-4ca7" value="1"/>
-                    <characteristic name="Abilities" characteristicTypeId="837d-5e63-aeb7-1410" value="-"/>
-                  </characteristics>
-                </profile>
-              </profiles>
+            <selectionEntry id="4bbf-ef51-cdfb-2f7e" name="Rubric Marine w/ Inferno Boltgun" page="" hidden="false" collective="false" type="model">
+              <profiles/>
               <rules/>
               <infoLinks/>
               <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="aa1c-2f2b-694d-5db1" type="max"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e49b-0f72-cadd-b31b" type="min"/>
-              </constraints>
+              <constraints/>
               <categoryLinks/>
-              <selectionEntries/>
+              <selectionEntries>
+                <selectionEntry id="d783-25cb-ae60-0860" name="Inferno boltgun" hidden="false" collective="true" type="upgrade">
+                  <profiles>
+                    <profile id="3934-0062-89a3-85f7" name="Inferno boltgun" hidden="false" profileTypeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" profileTypeName="Weapon">
+                      <profiles/>
+                      <rules/>
+                      <infoLinks/>
+                      <modifiers/>
+                      <characteristics>
+                        <characteristic name="Range" characteristicTypeId="6fa97fa8-ea74-4a27-a0fb-bc4e5f367464" value="24&quot;"/>
+                        <characteristic name="Type" characteristicTypeId="077c342f-d7b9-45c6-b8af-88e97cafd3a2" value="Rapid Fire 1"/>
+                        <characteristic name="S" characteristicTypeId="59b1-319e-ec13-d466" value="4"/>
+                        <characteristic name="AP" characteristicTypeId="75aa-a838-b675-6484" value="-2"/>
+                        <characteristic name="D" characteristicTypeId="ae8a-3137-d65b-4ca7" value="1"/>
+                        <characteristic name="Abilities" characteristicTypeId="837d-5e63-aeb7-1410" value="-"/>
+                      </characteristics>
+                    </profile>
+                  </profiles>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="279b-2fb9-66ef-b364" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="33ec-295a-bde7-9c46" type="min"/>
+                  </constraints>
+                  <categoryLinks/>
+                  <selectionEntries/>
+                  <selectionEntryGroups/>
+                  <entryLinks/>
+                  <costs>
+                    <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="0.0"/>
+                    <cost name="pts" costTypeId="points" value="2.0"/>
+                  </costs>
+                </selectionEntry>
+              </selectionEntries>
               <selectionEntryGroups/>
               <entryLinks/>
               <costs>
+                <cost name="pts" costTypeId="points" value="18.0"/>
                 <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="0.0"/>
-                <cost name="pts" costTypeId="points" value="2.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="9b10-de36-4c44-8074" name="Rubric Marine w/ Warpflamer" hidden="false" collective="false" type="model">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+              <categoryLinks/>
+              <selectionEntries>
+                <selectionEntry id="36ce-1c82-1e7c-7f04" name="Warpflamer" hidden="false" collective="true" type="upgrade">
+                  <profiles>
+                    <profile id="3f4e-c651-c313-d4ee" name="Warpflamer" hidden="false" profileTypeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" profileTypeName="Weapon">
+                      <profiles/>
+                      <rules/>
+                      <infoLinks/>
+                      <modifiers/>
+                      <characteristics>
+                        <characteristic name="Range" characteristicTypeId="6fa97fa8-ea74-4a27-a0fb-bc4e5f367464" value="8&quot;"/>
+                        <characteristic name="Type" characteristicTypeId="077c342f-d7b9-45c6-b8af-88e97cafd3a2" value="Assault D6"/>
+                        <characteristic name="S" characteristicTypeId="59b1-319e-ec13-d466" value="4"/>
+                        <characteristic name="AP" characteristicTypeId="75aa-a838-b675-6484" value="-2"/>
+                        <characteristic name="D" characteristicTypeId="ae8a-3137-d65b-4ca7" value="1"/>
+                        <characteristic name="Abilities" characteristicTypeId="837d-5e63-aeb7-1410" value="This weapon automatically hits its target."/>
+                      </characteristics>
+                    </profile>
+                  </profiles>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="9b4f-0806-6acd-d854" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b8ba-2301-49f0-c1f3" type="min"/>
+                  </constraints>
+                  <categoryLinks/>
+                  <selectionEntries/>
+                  <selectionEntryGroups/>
+                  <entryLinks/>
+                  <costs>
+                    <cost name="pts" costTypeId="points" value="13.0"/>
+                    <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="0.0"/>
+                  </costs>
+                </selectionEntry>
+              </selectionEntries>
+              <selectionEntryGroups/>
+              <entryLinks/>
+              <costs>
+                <cost name="pts" costTypeId="points" value="18.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="3e5d-37fc-eb05-caf5" name="Rubric Marine w/ Soulreaper cannon" hidden="false" collective="false" type="model">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers>
+                <modifier type="increment" field="e6a9-abe4-0708-efe3" value="1">
+                  <repeats>
+                    <repeat field="selections" scope="7142-e365-1c12-efd6" value="10.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="model" repeats="1" roundUp="false"/>
+                  </repeats>
+                  <conditions/>
+                  <conditionGroups/>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="e6a9-abe4-0708-efe3" type="max"/>
+              </constraints>
+              <categoryLinks/>
+              <selectionEntries>
+                <selectionEntry id="8634-eae0-6028-99ce" name="Soulreaper cannon" hidden="false" collective="true" type="upgrade">
+                  <profiles>
+                    <profile id="5a1c-dabe-2ae8-bab0" name="Soulreaper Cannon" hidden="false" profileTypeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" profileTypeName="Weapon">
+                      <profiles/>
+                      <rules/>
+                      <infoLinks/>
+                      <modifiers/>
+                      <characteristics>
+                        <characteristic name="Range" characteristicTypeId="6fa97fa8-ea74-4a27-a0fb-bc4e5f367464" value="24&quot;"/>
+                        <characteristic name="Type" characteristicTypeId="077c342f-d7b9-45c6-b8af-88e97cafd3a2" value="Heavy 4"/>
+                        <characteristic name="S" characteristicTypeId="59b1-319e-ec13-d466" value="5"/>
+                        <characteristic name="AP" characteristicTypeId="75aa-a838-b675-6484" value="-3"/>
+                        <characteristic name="D" characteristicTypeId="ae8a-3137-d65b-4ca7" value="1"/>
+                        <characteristic name="Abilities" characteristicTypeId="837d-5e63-aeb7-1410" value="-"/>
+                      </characteristics>
+                    </profile>
+                  </profiles>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ec11-91d6-9822-8570" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3279-8164-027f-44a3" type="min"/>
+                  </constraints>
+                  <categoryLinks/>
+                  <selectionEntries/>
+                  <selectionEntryGroups/>
+                  <entryLinks/>
+                  <costs/>
+                </selectionEntry>
+              </selectionEntries>
+              <selectionEntryGroups/>
+              <entryLinks/>
+              <costs>
+                <cost name="pts" costTypeId="points" value="18.0"/>
+                <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
           <selectionEntryGroups/>
           <entryLinks/>
-          <costs>
-            <cost name="pts" costTypeId="points" value="18.0"/>
-            <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="0.0"/>
-          </costs>
-        </selectionEntry>
-        <selectionEntry id="8d22-8c2e-4e14-c92a" name="Replace inferno boltgun with soulreaper cannon" hidden="false" collective="false" type="upgrade">
-          <profiles>
-            <profile id="6021-0047-b28e-bd96" name="Soulreaper Cannon" hidden="false" profileTypeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" profileTypeName="Weapon">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <characteristics>
-                <characteristic name="Range" characteristicTypeId="6fa97fa8-ea74-4a27-a0fb-bc4e5f367464" value="24&quot;"/>
-                <characteristic name="Type" characteristicTypeId="077c342f-d7b9-45c6-b8af-88e97cafd3a2" value="Heavy 4"/>
-                <characteristic name="S" characteristicTypeId="59b1-319e-ec13-d466" value="5"/>
-                <characteristic name="AP" characteristicTypeId="75aa-a838-b675-6484" value="-3"/>
-                <characteristic name="D" characteristicTypeId="ae8a-3137-d65b-4ca7" value="1"/>
-                <characteristic name="Abilities" characteristicTypeId="837d-5e63-aeb7-1410" value="-"/>
-              </characteristics>
-            </profile>
-          </profiles>
-          <rules/>
-          <infoLinks/>
-          <modifiers>
-            <modifier type="increment" field="dd41-e55d-36e2-8f21" value="1">
-              <repeats>
-                <repeat field="selections" scope="7142-e365-1c12-efd6" value="10.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="model" repeats="1" roundUp="false"/>
-              </repeats>
-              <conditions/>
-              <conditionGroups/>
-            </modifier>
-            <modifier type="set" field="hidden" value="true">
-              <repeats/>
-              <conditions>
-                <condition field="selections" scope="7142-e365-1c12-efd6" value="10.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="model" type="lessThan"/>
-              </conditions>
-              <conditionGroups/>
-            </modifier>
-          </modifiers>
-          <constraints>
-            <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="dd41-e55d-36e2-8f21" type="max"/>
-          </constraints>
-          <categoryLinks/>
-          <selectionEntries/>
-          <selectionEntryGroups/>
-          <entryLinks/>
-          <costs>
-            <cost name="pts" costTypeId="points" value="18.0"/>
-            <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="0.0"/>
-          </costs>
-        </selectionEntry>
-        <selectionEntry id="0b1c-3585-5e6b-4944" name="Replace inferno boltgun with warpflamer" hidden="false" collective="false" type="upgrade">
-          <profiles>
-            <profile id="7d29-21de-4315-7164" name="Warpflamer" hidden="false" profileTypeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" profileTypeName="Weapon">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <characteristics>
-                <characteristic name="Range" characteristicTypeId="6fa97fa8-ea74-4a27-a0fb-bc4e5f367464" value="8&quot;"/>
-                <characteristic name="Type" characteristicTypeId="077c342f-d7b9-45c6-b8af-88e97cafd3a2" value="Assault D6"/>
-                <characteristic name="S" characteristicTypeId="59b1-319e-ec13-d466" value="4"/>
-                <characteristic name="AP" characteristicTypeId="75aa-a838-b675-6484" value="-2"/>
-                <characteristic name="D" characteristicTypeId="ae8a-3137-d65b-4ca7" value="1"/>
-                <characteristic name="Abilities" characteristicTypeId="837d-5e63-aeb7-1410" value="This weapon automatically hits its target."/>
-              </characteristics>
-            </profile>
-          </profiles>
-          <rules/>
-          <infoLinks/>
-          <modifiers>
-            <modifier type="increment" field="748f-a180-288f-c32b" value="1">
-              <repeats>
-                <repeat field="selections" scope="7142-e365-1c12-efd6" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="model" repeats="1" roundUp="false"/>
-              </repeats>
-              <conditions/>
-              <conditionGroups/>
-            </modifier>
-          </modifiers>
-          <constraints>
-            <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="748f-a180-288f-c32b" type="max"/>
-          </constraints>
-          <categoryLinks/>
-          <selectionEntries/>
-          <selectionEntryGroups/>
-          <entryLinks/>
-          <costs>
-            <cost name="pts" costTypeId="points" value="13.0"/>
-            <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="0.0"/>
-          </costs>
-        </selectionEntry>
-      </selectionEntries>
-      <selectionEntryGroups/>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
       <entryLinks>
-        <entryLink id="848a-07ae-f736-4b17" name="New EntryLink" hidden="false" targetId="0844-29e7-5ca3-1b56" type="selectionEntry">
+        <entryLink id="848a-07ae-f736-4b17" name="Icon of Flame" hidden="false" targetId="0844-29e7-5ca3-1b56" type="selectionEntry">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -2621,10 +2722,27 @@
             <characteristic name="Description" characteristicTypeId="21befb24-fc85-4f52-a745-64b2e48f8228" value="Add 1 to the saving throws for Rubric Marines if the attack has a Damage characteristic of 1. In addition, the -1 modifier to hit rolls for moving and shooting with a Heavy weapon does not apply to Rubric Marines."/>
           </characteristics>
         </profile>
+        <profile id="b4e8-d231-34d7-ee57" name="Scarab Occult Terminator" hidden="false" profileTypeId="800f-21d0-4387-c943" profileTypeName="Unit">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="M" characteristicTypeId="0bdf-a96e-9e38-7779" value="4&quot;"/>
+            <characteristic name="WS" characteristicTypeId="e7f0-1278-0250-df0c" value="3+"/>
+            <characteristic name="BS" characteristicTypeId="381b-eb28-74c3-df5f" value="3+"/>
+            <characteristic name="S" characteristicTypeId="2218-aa3c-265f-2939" value="4"/>
+            <characteristic name="T" characteristicTypeId="9c9f-9774-a358-3a39" value="4"/>
+            <characteristic name="W" characteristicTypeId="f330-5e6e-4110-0978" value="2"/>
+            <characteristic name="A" characteristicTypeId="13fc-b29b-31f2-ab9f" value="2"/>
+            <characteristic name="Ld" characteristicTypeId="00ca-f8b8-876d-b705" value="9"/>
+            <characteristic name="Save" characteristicTypeId="c0df-df94-abd7-e8d3" value="2+"/>
+          </characteristics>
+        </profile>
       </profiles>
       <rules/>
       <infoLinks>
-        <infoLink id="8ea0-adf0-0780-582b" name="New InfoLink" hidden="false" targetId="ae9c-d115-d4a9-ba02" type="rule">
+        <infoLink id="8ea0-adf0-0780-582b" name="Teleport Strike" hidden="false" targetId="ae9c-d115-d4a9-ba02" type="rule">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -2712,46 +2830,6 @@
         </categoryLink>
       </categoryLinks>
       <selectionEntries>
-        <selectionEntry id="f108-36e9-288f-3ab3" name="Hellfyre Missile Rack" hidden="false" collective="false" type="upgrade">
-          <profiles>
-            <profile id="2d12-3959-b1cd-f4f5" name="Hellfyre Missile Rack" hidden="false" profileTypeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" profileTypeName="Weapon">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <characteristics>
-                <characteristic name="Range" characteristicTypeId="6fa97fa8-ea74-4a27-a0fb-bc4e5f367464" value="24&quot;"/>
-                <characteristic name="Type" characteristicTypeId="077c342f-d7b9-45c6-b8af-88e97cafd3a2" value="Heavy 2"/>
-                <characteristic name="S" characteristicTypeId="59b1-319e-ec13-d466" value="8"/>
-                <characteristic name="AP" characteristicTypeId="75aa-a838-b675-6484" value="-2"/>
-                <characteristic name="D" characteristicTypeId="ae8a-3137-d65b-4ca7" value="D3"/>
-                <characteristic name="Abilities" characteristicTypeId="837d-5e63-aeb7-1410" value="-"/>
-              </characteristics>
-            </profile>
-          </profiles>
-          <rules/>
-          <infoLinks/>
-          <modifiers>
-            <modifier type="set" field="dd42-b0f3-a9e2-7bb1" value="2">
-              <repeats/>
-              <conditions>
-                <condition field="selections" scope="parent" value="10.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="model" type="equalTo"/>
-              </conditions>
-              <conditionGroups/>
-            </modifier>
-          </modifiers>
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="dd42-b0f3-a9e2-7bb1" type="max"/>
-          </constraints>
-          <categoryLinks/>
-          <selectionEntries/>
-          <selectionEntryGroups/>
-          <entryLinks/>
-          <costs>
-            <cost name="pts" costTypeId="points" value="22.0"/>
-            <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="0.0"/>
-          </costs>
-        </selectionEntry>
         <selectionEntry id="00a3-d61e-841d-a700" name="Scarab Occult Sorcerer" page="0" hidden="false" collective="false" type="model">
           <profiles>
             <profile id="c844-84b9-e7ef-6be0" name="Scarab Occult Sorcerer" hidden="false" profileTypeId="800f-21d0-4387-c943" profileTypeName="Unit">
@@ -2771,7 +2849,7 @@
                 <characteristic name="Save" characteristicTypeId="c0df-df94-abd7-e8d3" value="2+"/>
               </characteristics>
             </profile>
-            <profile id="43e0-098a-9f46-b795" name="Scarab Occult Sorcerer" hidden="false" profileTypeId="bc97-dea9-9e88-bb7d" profileTypeName="Psyker">
+            <profile id="47b5-1195-6756-a433" name="Scarab Occult Sorcerer" hidden="false" profileTypeId="bc97-dea9-9e88-bb7d" profileTypeName="Psyker">
               <profiles/>
               <rules/>
               <infoLinks/>
@@ -2779,8 +2857,8 @@
               <characteristics>
                 <characteristic name="Cast" characteristicTypeId="5afb-9914-904b-d3b3" value="1"/>
                 <characteristic name="Deny" characteristicTypeId="b5ac-9c20-5d5a-6f9b" value="1"/>
-                <characteristic name="Powers Known" characteristicTypeId="69d7-b45e-00a2-7e46" value="-"/>
-                <characteristic name="Other" characteristicTypeId="c2e2-f115-0003-5d7b" value="Smite 1 MW instead of D3 W, D3 MW instead of D6 W if 10+"/>
+                <characteristic name="Powers Known" characteristicTypeId="69d7-b45e-00a2-7e46" value="Smite"/>
+                <characteristic name="Other" characteristicTypeId="c2e2-f115-0003-5d7b" value="When a Scarab Occult Sorcerer manifests the Smite psychic power, he inflicts 1 mortal wound instead of D3, and D3 mortal wounds instead of D6 if the Psychic Test is 10 or more."/>
               </characteristics>
             </profile>
           </profiles>
@@ -2792,7 +2870,35 @@
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="a342-8e2c-0814-6305" type="max"/>
           </constraints>
           <categoryLinks/>
-          <selectionEntries/>
+          <selectionEntries>
+            <selectionEntry id="e116-5809-db9c-91bf" name="Smite" hidden="false" collective="false" type="upgrade">
+              <profiles>
+                <profile id="c765-c605-fbf6-4bf8" name="Smite" hidden="false" profileTypeId="ae70-4738-0161-bec0" profileTypeName="Psychic Power">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <characteristics>
+                    <characteristic name="Warp Charge" characteristicTypeId="5ffd-b800-c317-532a" value="5"/>
+                    <characteristic name="Range" characteristicTypeId="fd64-cbc4-94de-24cc" value="18&quot;"/>
+                    <characteristic name="Details" characteristicTypeId="ad96-dfa4-b4ed-656d" value="If manifested, the closest visible enemy unit within 18&quot; of the psyker suffers 1 mortal wound. If the result of the Psychic test was more than 10 the target suffers D3 mortal wounds instead."/>
+                  </characteristics>
+                </profile>
+              </profiles>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="29a4-3ab2-fd2b-d01e" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c131-0c5c-3096-3eab" type="min"/>
+              </constraints>
+              <categoryLinks/>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks/>
+              <costs/>
+            </selectionEntry>
+          </selectionEntries>
           <selectionEntryGroups>
             <selectionEntryGroup id="2e7a-f6a8-922d-4c8d" name="Weapon" hidden="false" collective="false" defaultSelectionEntryId="8535-c052-ddc0-95a4">
               <profiles/>
@@ -2866,163 +2972,243 @@
             <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="0.0"/>
           </costs>
         </selectionEntry>
-        <selectionEntry id="3ee9-4c4b-f4f9-bde9" name="Scarab Occult Terminator" page="0" hidden="false" collective="false" type="model">
-          <profiles>
-            <profile id="a225-4ed1-d4ca-bbca" name="Scarab Occult Terminator" hidden="false" profileTypeId="800f-21d0-4387-c943" profileTypeName="Unit">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <characteristics>
-                <characteristic name="M" characteristicTypeId="0bdf-a96e-9e38-7779" value="4&quot;"/>
-                <characteristic name="WS" characteristicTypeId="e7f0-1278-0250-df0c" value="3+"/>
-                <characteristic name="BS" characteristicTypeId="381b-eb28-74c3-df5f" value="3+"/>
-                <characteristic name="S" characteristicTypeId="2218-aa3c-265f-2939" value="4"/>
-                <characteristic name="T" characteristicTypeId="9c9f-9774-a358-3a39" value="4"/>
-                <characteristic name="W" characteristicTypeId="f330-5e6e-4110-0978" value="2"/>
-                <characteristic name="A" characteristicTypeId="13fc-b29b-31f2-ab9f" value="2"/>
-                <characteristic name="Ld" characteristicTypeId="00ca-f8b8-876d-b705" value="9"/>
-                <characteristic name="Save" characteristicTypeId="c0df-df94-abd7-e8d3" value="2+"/>
-              </characteristics>
-            </profile>
-          </profiles>
+      </selectionEntries>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="b7bd-5c16-d4ee-699e" name="Scarab Occult Terminators" hidden="false" collective="false" defaultSelectionEntryId="0f71-fbb2-b6d6-a5b5">
+          <profiles/>
           <rules/>
           <infoLinks/>
           <modifiers/>
           <constraints>
-            <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e47c-7dba-4415-19b1" type="min"/>
-            <constraint field="selections" scope="parent" value="9.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="272b-98ba-2226-06ef" type="max"/>
+            <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1441-003c-3a2d-673f" type="min"/>
+            <constraint field="selections" scope="parent" value="9.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d445-0de2-ce4f-8d20" type="max"/>
           </constraints>
           <categoryLinks/>
           <selectionEntries>
-            <selectionEntry id="4ed3-d39c-8835-9c21" name="Inferno Combi-bolter" hidden="false" collective="false" type="upgrade">
-              <profiles>
-                <profile id="313d-fdf0-e9e2-a920" name="Inferno Combi-bolter" hidden="false" profileTypeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" profileTypeName="Weapon">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                  <characteristics>
-                    <characteristic name="Range" characteristicTypeId="6fa97fa8-ea74-4a27-a0fb-bc4e5f367464" value="24&quot;"/>
-                    <characteristic name="Type" characteristicTypeId="077c342f-d7b9-45c6-b8af-88e97cafd3a2" value="Rapid Fire 2"/>
-                    <characteristic name="S" characteristicTypeId="59b1-319e-ec13-d466" value="4"/>
-                    <characteristic name="AP" characteristicTypeId="75aa-a838-b675-6484" value="-2"/>
-                    <characteristic name="D" characteristicTypeId="ae8a-3137-d65b-4ca7" value="1"/>
-                    <characteristic name="Abilities" characteristicTypeId="837d-5e63-aeb7-1410" value="-"/>
-                  </characteristics>
-                </profile>
-              </profiles>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints/>
-              <categoryLinks/>
-              <selectionEntries/>
-              <selectionEntryGroups/>
-              <entryLinks/>
-              <costs>
-                <cost name="pts" costTypeId="points" value="3.0"/>
-                <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="0.0"/>
-              </costs>
-            </selectionEntry>
-          </selectionEntries>
-          <selectionEntryGroups/>
-          <entryLinks>
-            <entryLink id="f094-25d9-c1e2-fe1d" name="New EntryLink" hidden="false" targetId="bc9e-551d-9afb-78d5" type="selectionEntry">
+            <selectionEntry id="0f71-fbb2-b6d6-a5b5" name="Terminator" page="0" hidden="false" collective="false" type="model">
               <profiles/>
               <rules/>
               <infoLinks/>
               <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3894-50e4-d40c-0030" type="max"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a3bf-e1d2-a272-e5ea" type="min"/>
-              </constraints>
+              <constraints/>
               <categoryLinks/>
-            </entryLink>
-          </entryLinks>
-          <costs>
-            <cost name="pts" costTypeId="points" value="33.0"/>
-            <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="0.0"/>
-          </costs>
-        </selectionEntry>
-      </selectionEntries>
-      <selectionEntryGroups>
-        <selectionEntryGroup id="a3d1-73ee-b7c3-8a2b" name="Replace Inferno Combi-bolter with:" hidden="false" collective="false">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers>
-            <modifier type="set" field="8859-8276-ffc3-e284" value="2">
-              <repeats/>
-              <conditions>
-                <condition field="selections" scope="parent" value="10.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="model" type="equalTo"/>
-              </conditions>
-              <conditionGroups/>
-            </modifier>
-          </modifiers>
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8859-8276-ffc3-e284" type="max"/>
-          </constraints>
-          <categoryLinks/>
-          <selectionEntries>
-            <selectionEntry id="7d2e-c975-2df1-5766" name="Heavy Warpflamer" hidden="false" collective="false" type="upgrade">
-              <profiles>
-                <profile id="9d48-11ae-77d2-394c" name="Heavy Warpflamer" hidden="false" profileTypeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" profileTypeName="Weapon">
-                  <profiles/>
+              <selectionEntries>
+                <selectionEntry id="d8dd-b57a-caf3-f4a1" name="Inferno Combi-bolter" hidden="false" collective="true" type="upgrade">
+                  <profiles>
+                    <profile id="a538-5799-b34b-75bb" name="Inferno Combi-bolter" hidden="false" profileTypeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" profileTypeName="Weapon">
+                      <profiles/>
+                      <rules/>
+                      <infoLinks/>
+                      <modifiers/>
+                      <characteristics>
+                        <characteristic name="Range" characteristicTypeId="6fa97fa8-ea74-4a27-a0fb-bc4e5f367464" value="24&quot;"/>
+                        <characteristic name="Type" characteristicTypeId="077c342f-d7b9-45c6-b8af-88e97cafd3a2" value="Rapid Fire 2"/>
+                        <characteristic name="S" characteristicTypeId="59b1-319e-ec13-d466" value="4"/>
+                        <characteristic name="AP" characteristicTypeId="75aa-a838-b675-6484" value="-2"/>
+                        <characteristic name="D" characteristicTypeId="ae8a-3137-d65b-4ca7" value="1"/>
+                        <characteristic name="Abilities" characteristicTypeId="837d-5e63-aeb7-1410" value="-"/>
+                      </characteristics>
+                    </profile>
+                  </profiles>
                   <rules/>
                   <infoLinks/>
                   <modifiers/>
-                  <characteristics>
-                    <characteristic name="Range" characteristicTypeId="6fa97fa8-ea74-4a27-a0fb-bc4e5f367464" value="8&quot;"/>
-                    <characteristic name="Type" characteristicTypeId="077c342f-d7b9-45c6-b8af-88e97cafd3a2" value="Heavy D6"/>
-                    <characteristic name="S" characteristicTypeId="59b1-319e-ec13-d466" value="5"/>
-                    <characteristic name="AP" characteristicTypeId="75aa-a838-b675-6484" value="-2"/>
-                    <characteristic name="D" characteristicTypeId="ae8a-3137-d65b-4ca7" value="1"/>
-                    <characteristic name="Abilities" characteristicTypeId="837d-5e63-aeb7-1410" value="This weapon automatically hits its target."/>
-                  </characteristics>
-                </profile>
-              </profiles>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints/>
-              <categoryLinks/>
-              <selectionEntries/>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9fba-c661-f4b3-d43d" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="db6c-63b4-7417-c2f9" type="min"/>
+                  </constraints>
+                  <categoryLinks/>
+                  <selectionEntries/>
+                  <selectionEntryGroups/>
+                  <entryLinks/>
+                  <costs>
+                    <cost name="pts" costTypeId="points" value="3.0"/>
+                    <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="0.0"/>
+                  </costs>
+                </selectionEntry>
+                <selectionEntry id="bd59-9d46-135f-3b9f" name="Powersword" hidden="false" collective="true" type="upgrade">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks>
+                    <infoLink id="2f69-a7ae-6726-1214" name="Power sword" hidden="false" targetId="47df-8e01-d0cf-58e8" type="profile">
+                      <profiles/>
+                      <rules/>
+                      <infoLinks/>
+                      <modifiers/>
+                    </infoLink>
+                  </infoLinks>
+                  <modifiers/>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d3ba-2f51-f196-0d1e" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4f60-d91c-352e-eb63" type="min"/>
+                  </constraints>
+                  <categoryLinks/>
+                  <selectionEntries/>
+                  <selectionEntryGroups/>
+                  <entryLinks/>
+                  <costs/>
+                </selectionEntry>
+              </selectionEntries>
               <selectionEntryGroups/>
-              <entryLinks/>
+              <entryLinks>
+                <entryLink id="0717-fb97-fc8f-ac86" name="Hellfyre Missile Rack" hidden="false" targetId="bad6-50db-be09-615f" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers>
+                    <modifier type="increment" field="a136-4310-caaf-7d6d" value="1">
+                      <repeats/>
+                      <conditions>
+                        <condition field="selections" scope="c8ba-1df2-c188-f6b8" value="10.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="model" type="equalTo"/>
+                      </conditions>
+                      <conditionGroups/>
+                    </modifier>
+                  </modifiers>
+                  <constraints>
+                    <constraint field="selections" scope="c8ba-1df2-c188-f6b8" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="a136-4310-caaf-7d6d" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d659-392d-45f2-2b4d" type="max"/>
+                  </constraints>
+                  <categoryLinks/>
+                </entryLink>
+              </entryLinks>
               <costs>
-                <cost name="pts" costTypeId="points" value="23.0"/>
+                <cost name="pts" costTypeId="points" value="33.0"/>
                 <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="0.0"/>
               </costs>
             </selectionEntry>
-            <selectionEntry id="ab7d-0599-453a-9b36" name="Soulreaper Cannon" hidden="false" collective="false" type="upgrade">
-              <profiles>
-                <profile id="6d84-1a80-86f4-6fe1" name="Soulreaper Cannon" hidden="false" profileTypeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" profileTypeName="Weapon">
+            <selectionEntry id="3e9a-5e5d-9d47-e110" name="Terminator w/ Heavy Weapon" hidden="false" collective="false" type="model">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers>
+                <modifier type="increment" field="abce-92e5-b80a-bd6f" value="1">
+                  <repeats/>
+                  <conditions>
+                    <condition field="selections" scope="c8ba-1df2-c188-f6b8" value="10.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="model" type="equalTo"/>
+                  </conditions>
+                  <conditionGroups/>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="abce-92e5-b80a-bd6f" type="max"/>
+              </constraints>
+              <categoryLinks/>
+              <selectionEntries/>
+              <selectionEntryGroups>
+                <selectionEntryGroup id="89d6-6008-74ba-a40d" name="Weapon" hidden="false" collective="false">
                   <profiles/>
                   <rules/>
                   <infoLinks/>
                   <modifiers/>
-                  <characteristics>
-                    <characteristic name="Range" characteristicTypeId="6fa97fa8-ea74-4a27-a0fb-bc4e5f367464" value="24&quot;"/>
-                    <characteristic name="Type" characteristicTypeId="077c342f-d7b9-45c6-b8af-88e97cafd3a2" value="Heavy 4"/>
-                    <characteristic name="S" characteristicTypeId="59b1-319e-ec13-d466" value="5"/>
-                    <characteristic name="AP" characteristicTypeId="75aa-a838-b675-6484" value="-3"/>
-                    <characteristic name="D" characteristicTypeId="ae8a-3137-d65b-4ca7" value="1"/>
-                    <characteristic name="Abilities" characteristicTypeId="837d-5e63-aeb7-1410" value="-"/>
-                  </characteristics>
-                </profile>
-              </profiles>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints/>
-              <categoryLinks/>
-              <selectionEntries/>
-              <selectionEntryGroups/>
-              <entryLinks/>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fa83-1fb2-5c8c-e832" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="323f-336e-7b46-6511" type="min"/>
+                  </constraints>
+                  <categoryLinks/>
+                  <selectionEntries>
+                    <selectionEntry id="2dc5-95da-211c-87e1" name="Heavy Warpflamer" hidden="false" collective="false" type="upgrade">
+                      <profiles>
+                        <profile id="edf7-fce3-df93-3dcb" name="Heavy Warpflamer" hidden="false" profileTypeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" profileTypeName="Weapon">
+                          <profiles/>
+                          <rules/>
+                          <infoLinks/>
+                          <modifiers/>
+                          <characteristics>
+                            <characteristic name="Range" characteristicTypeId="6fa97fa8-ea74-4a27-a0fb-bc4e5f367464" value="8&quot;"/>
+                            <characteristic name="Type" characteristicTypeId="077c342f-d7b9-45c6-b8af-88e97cafd3a2" value="Heavy D6"/>
+                            <characteristic name="S" characteristicTypeId="59b1-319e-ec13-d466" value="5"/>
+                            <characteristic name="AP" characteristicTypeId="75aa-a838-b675-6484" value="-2"/>
+                            <characteristic name="D" characteristicTypeId="ae8a-3137-d65b-4ca7" value="1"/>
+                            <characteristic name="Abilities" characteristicTypeId="837d-5e63-aeb7-1410" value="This weapon automatically hits its target."/>
+                          </characteristics>
+                        </profile>
+                      </profiles>
+                      <rules/>
+                      <infoLinks/>
+                      <modifiers/>
+                      <constraints>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="cb05-3d26-d686-98e0" type="max"/>
+                      </constraints>
+                      <categoryLinks/>
+                      <selectionEntries/>
+                      <selectionEntryGroups/>
+                      <entryLinks/>
+                      <costs>
+                        <cost name="pts" costTypeId="points" value="23.0"/>
+                        <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="0.0"/>
+                      </costs>
+                    </selectionEntry>
+                    <selectionEntry id="abd8-ea0b-da7d-cc44" name="Soulreaper Cannon" hidden="false" collective="false" type="upgrade">
+                      <profiles>
+                        <profile id="ca4b-e07a-2a9a-3e7c" name="Soulreaper Cannon" hidden="false" profileTypeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" profileTypeName="Weapon">
+                          <profiles/>
+                          <rules/>
+                          <infoLinks/>
+                          <modifiers/>
+                          <characteristics>
+                            <characteristic name="Range" characteristicTypeId="6fa97fa8-ea74-4a27-a0fb-bc4e5f367464" value="24&quot;"/>
+                            <characteristic name="Type" characteristicTypeId="077c342f-d7b9-45c6-b8af-88e97cafd3a2" value="Heavy 4"/>
+                            <characteristic name="S" characteristicTypeId="59b1-319e-ec13-d466" value="5"/>
+                            <characteristic name="AP" characteristicTypeId="75aa-a838-b675-6484" value="-3"/>
+                            <characteristic name="D" characteristicTypeId="ae8a-3137-d65b-4ca7" value="1"/>
+                            <characteristic name="Abilities" characteristicTypeId="837d-5e63-aeb7-1410" value="-"/>
+                          </characteristics>
+                        </profile>
+                      </profiles>
+                      <rules/>
+                      <infoLinks/>
+                      <modifiers/>
+                      <constraints>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="787b-e26b-3865-14bb" type="max"/>
+                      </constraints>
+                      <categoryLinks/>
+                      <selectionEntries/>
+                      <selectionEntryGroups/>
+                      <entryLinks/>
+                      <costs>
+                        <cost name="pts" costTypeId="points" value="20.0"/>
+                        <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="0.0"/>
+                      </costs>
+                    </selectionEntry>
+                  </selectionEntries>
+                  <selectionEntryGroups/>
+                  <entryLinks/>
+                </selectionEntryGroup>
+              </selectionEntryGroups>
+              <entryLinks>
+                <entryLink id="d953-4feb-0339-a8dd" name="Hellfyre Missile Rack" hidden="false" targetId="bad6-50db-be09-615f" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers>
+                    <modifier type="increment" field="d265-7cbf-4dc6-b4d7" value="1">
+                      <repeats/>
+                      <conditions>
+                        <condition field="selections" scope="c8ba-1df2-c188-f6b8" value="10.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="model" type="equalTo"/>
+                      </conditions>
+                      <conditionGroups/>
+                    </modifier>
+                  </modifiers>
+                  <constraints>
+                    <constraint field="selections" scope="c8ba-1df2-c188-f6b8" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="d265-7cbf-4dc6-b4d7" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fdcc-686a-a7e0-398a" type="max"/>
+                  </constraints>
+                  <categoryLinks/>
+                </entryLink>
+                <entryLink id="d58e-9964-a076-a543" name="Power sword" hidden="false" targetId="bc9e-551d-9afb-78d5" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9ff2-bb19-491c-af5f" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8ca5-a7da-99e1-8189" type="min"/>
+                  </constraints>
+                  <categoryLinks/>
+                </entryLink>
+              </entryLinks>
               <costs>
-                <cost name="pts" costTypeId="points" value="20.0"/>
-                <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="0.0"/>
+                <cost name="pts" costTypeId="points" value="33.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -3055,24 +3241,6 @@
             <characteristic name="Save" characteristicTypeId="c0df-df94-abd7-e8d3" value="3+"/>
           </characteristics>
         </profile>
-        <profile id="68dc-392e-a59f-204d" name="Favour of Tzeentch" hidden="false" profileTypeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" profileTypeName="Abilities">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <characteristics>
-            <characteristic name="Description" characteristicTypeId="21befb24-fc85-4f52-a745-64b2e48f8228" value="This model has a 5++."/>
-          </characteristics>
-        </profile>
-        <profile id="e0f4-0d61-75b9-4930" name="Lord of the Thousand Sons" hidden="false" profileTypeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" profileTypeName="Abilities">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <characteristics>
-            <characteristic name="Description" characteristicTypeId="21befb24-fc85-4f52-a745-64b2e48f8228" value="You can re-roll invulnerable saving throws of 1 made for friendly Thousand Sons Infantry units within 6&quot; of this model."/>
-          </characteristics>
-        </profile>
         <profile id="af48-f86f-b68d-27c3" name="Exalted Sorcerer" hidden="false" profileTypeId="bc97-dea9-9e88-bb7d" profileTypeName="Psyker">
           <profiles/>
           <rules/>
@@ -3081,7 +3249,7 @@
           <characteristics>
             <characteristic name="Cast" characteristicTypeId="5afb-9914-904b-d3b3" value="2"/>
             <characteristic name="Deny" characteristicTypeId="b5ac-9c20-5d5a-6f9b" value="1"/>
-            <characteristic name="Powers Known" characteristicTypeId="69d7-b45e-00a2-7e46" value="2 Dark Hereticus"/>
+            <characteristic name="Powers Known" characteristicTypeId="69d7-b45e-00a2-7e46" value="Smite and two powers from the Dark Hereticus discipline"/>
             <characteristic name="Other" characteristicTypeId="c2e2-f115-0003-5d7b" value=""/>
           </characteristics>
         </profile>
@@ -3089,6 +3257,18 @@
       <rules/>
       <infoLinks>
         <infoLink id="3fe6-9c8f-0c91-5966" name="Death to the False Emperor" hidden="false" targetId="27a8-c34a-7a70-904e" type="profile">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="469d-1229-b211-8d30" name="Favour of Tzeentch" hidden="false" targetId="5d58-ea78-c523-b0c7" type="profile">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="7e39-985d-fae8-3106" name="Lord of the Thousand Sons" hidden="false" targetId="92a0-3a44-c95b-ecdf" type="profile">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -3147,6 +3327,13 @@
           <modifiers/>
           <constraints/>
         </categoryLink>
+        <categoryLink id="bcdf-803f-a6f1-0058" name="New CategoryLink" hidden="false" targetId="68f9-33bb-bd2b-c777" primary="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
       </categoryLinks>
       <selectionEntries/>
       <selectionEntryGroups/>
@@ -3184,6 +3371,28 @@
           </constraints>
           <categoryLinks/>
         </entryLink>
+        <entryLink id="272f-3424-16fe-0817" name="Smite" hidden="false" targetId="03fd-db47-5333-1e1f" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4848-889e-cf5f-a33f" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c45e-0518-10cc-564e" type="min"/>
+          </constraints>
+          <categoryLinks/>
+        </entryLink>
+        <entryLink id="d882-4bf8-4af2-9a7e" name="Dark Hereticus Discipline" hidden="false" targetId="cca1-01a1-45fa-e054" type="selectionEntryGroup">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0759-a01d-801c-644f" type="max"/>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="62ca-6708-e248-9285" type="min"/>
+          </constraints>
+          <categoryLinks/>
+        </entryLink>
       </entryLinks>
       <costs>
         <cost name="pts" costTypeId="points" value="112.0"/>
@@ -3209,7 +3418,7 @@
             <characteristic name="Save" characteristicTypeId="c0df-df94-abd7-e8d3" value="3+"/>
           </characteristics>
         </profile>
-        <profile id="850e-8f7c-870d-a55a" name="Daemon Prince" hidden="false" profileTypeId="bc97-dea9-9e88-bb7d" profileTypeName="Psyker">
+        <profile id="66b9-592f-a720-62b2" name="Daemon Prince" hidden="false" profileTypeId="bc97-dea9-9e88-bb7d" profileTypeName="Psyker">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -3217,20 +3426,12 @@
           <characteristics>
             <characteristic name="Cast" characteristicTypeId="5afb-9914-904b-d3b3" value="1"/>
             <characteristic name="Deny" characteristicTypeId="b5ac-9c20-5d5a-6f9b" value="1"/>
-            <characteristic name="Powers Known" characteristicTypeId="69d7-b45e-00a2-7e46" value="1 Dark Hereticus"/>
+            <characteristic name="Powers Known" characteristicTypeId="69d7-b45e-00a2-7e46" value="Smite and one power from the Dark Hereticus discipline"/>
             <characteristic name="Other" characteristicTypeId="c2e2-f115-0003-5d7b" value=""/>
           </characteristics>
         </profile>
       </profiles>
-      <rules>
-        <rule id="e280-7b2e-48df-7128" name="Prince of Chaos" hidden="false">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <description>You can re-roll hit rolls of 1 made for friendly Thousand Sons units within 6&quot; of this model. This ability also affects friendly Daemon units within 6&quot;.</description>
-        </rule>
-      </rules>
+      <rules/>
       <infoLinks>
         <infoLink id="4e39-3732-b1e1-220c" name="Death to the False Emperor" hidden="false" targetId="27a8-c34a-7a70-904e" type="profile">
           <profiles/>
@@ -3239,6 +3440,12 @@
           <modifiers/>
         </infoLink>
         <infoLink id="53f2-1999-22d7-52e2" name="Daemonic" hidden="false" targetId="126f-8dee-afb0-f9bd" type="profile">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="04a9-58a1-dee6-70a3" name="Prince of Chaos" hidden="false" targetId="6c28-5b6b-0879-5f1d" type="profile">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -3378,7 +3585,7 @@
           </constraints>
           <categoryLinks/>
         </entryLink>
-        <entryLink id="0b74-d5fb-db29-131d" name="New EntryLink" hidden="false" targetId="ab5a-b591-31e2-e0d0" type="selectionEntry">
+        <entryLink id="0b74-d5fb-db29-131d" name="Malefic talon" hidden="false" targetId="ab5a-b591-31e2-e0d0" type="selectionEntry">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -3386,6 +3593,28 @@
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="6e3a-a538-633d-0b21" type="min"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="d997-cad4-ef06-3660" type="max"/>
+          </constraints>
+          <categoryLinks/>
+        </entryLink>
+        <entryLink id="30a5-a5cb-314c-586e" name="Dark Hereticus Discipline" hidden="false" targetId="cca1-01a1-45fa-e054" type="selectionEntryGroup">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="cc84-f09a-26eb-9931" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2c01-53c2-858a-0218" type="min"/>
+          </constraints>
+          <categoryLinks/>
+        </entryLink>
+        <entryLink id="a40c-1c43-a957-b5e8" name="Smite" hidden="false" targetId="03fd-db47-5333-1e1f" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3c13-421a-0692-df0f" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5b0a-4db0-843b-6648" type="min"/>
           </constraints>
           <categoryLinks/>
         </entryLink>
@@ -5046,7 +5275,7 @@
           <infoLinks/>
           <modifiers/>
           <characteristics>
-            <characteristic name="Description" characteristicTypeId="21befb24-fc85-4f52-a745-64b2e48f8228" value="You can re-roll hit rolls of 1 and invulnerable saving throws of 1 made for friendly Thousand Sons units within 9&quot; of Magnus the Red."/>
+            <characteristic name="Description" characteristicTypeId="21befb24-fc85-4f52-a745-64b2e48f8228" value="You can re-roll hit rolls of 1 and invulnerable saving throws of 1 made for friendly THOUSAND SONS units within 9&quot; of Magnus the Red."/>
           </characteristics>
         </profile>
         <profile id="57e3-3d57-646c-c742" name="Crown of the Crimson King" hidden="false" profileTypeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" profileTypeName="Abilities">
@@ -5055,7 +5284,7 @@
           <infoLinks/>
           <modifiers/>
           <characteristics>
-            <characteristic name="Description" characteristicTypeId="21befb24-fc85-4f52-a745-64b2e48f8228" value="Magnus the Red has a 4++. "/>
+            <characteristic name="Description" characteristicTypeId="21befb24-fc85-4f52-a745-64b2e48f8228" value="Magnus the Red has a 4+ invulnerable save. "/>
           </characteristics>
         </profile>
         <profile id="e66f-2ac5-f42c-c62f" name="Magnus the Red" hidden="false" profileTypeId="bc97-dea9-9e88-bb7d" profileTypeName="Psyker">
@@ -5066,8 +5295,17 @@
           <characteristics>
             <characteristic name="Cast" characteristicTypeId="5afb-9914-904b-d3b3" value="3"/>
             <characteristic name="Deny" characteristicTypeId="b5ac-9c20-5d5a-6f9b" value="3"/>
-            <characteristic name="Powers Known" characteristicTypeId="69d7-b45e-00a2-7e46" value="3 Dark Hereticus"/>
-            <characteristic name="Other" characteristicTypeId="c2e2-f115-0003-5d7b" value="Add bonus from Damage Table to Psychic and Deny the Witch tests"/>
+            <characteristic name="Powers Known" characteristicTypeId="69d7-b45e-00a2-7e46" value="Smite and three powers from the Dark Hereticus discipline"/>
+            <characteristic name="Other" characteristicTypeId="c2e2-f115-0003-5d7b" value="Whenever Magnus the Red attempts to manifest or deny a psychic power, add the bonus shown in his Damage Table to his Psychic or Deny the Witch test."/>
+          </characteristics>
+        </profile>
+        <profile id="2916-8e48-0255-7847" name="Gaze of Magnus" hidden="false" profileTypeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" profileTypeName="Abilities">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Description" characteristicTypeId="21befb24-fc85-4f52-a745-64b2e48f8228" value="If Magnus manifests the Smite power, it inflicts D6 mortal wounds, or 2D6 mortal wounds on a roll of 10 or more. This has been included in the profile for Smite."/>
           </characteristics>
         </profile>
       </profiles>
@@ -5174,16 +5412,92 @@
             <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="0.0"/>
           </costs>
         </selectionEntry>
+        <selectionEntry id="35d2-c089-9fdf-e22c" name="Smite" hidden="false" collective="false" type="upgrade">
+          <profiles>
+            <profile id="72d6-ebfa-7082-6bad" name="Smite" hidden="false" profileTypeId="ae70-4738-0161-bec0" profileTypeName="Psychic Power">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <characteristics>
+                <characteristic name="Warp Charge" characteristicTypeId="5ffd-b800-c317-532a" value="5"/>
+                <characteristic name="Range" characteristicTypeId="fd64-cbc4-94de-24cc" value="18&quot;"/>
+                <characteristic name="Details" characteristicTypeId="ad96-dfa4-b4ed-656d" value="If manifested, the closest visible enemy unit within 18&quot; of the psyker suffers D6 mortal wounds. If the result of the Psychic test was more than 10 the target suffers 2D6 mortal wounds instead."/>
+              </characteristics>
+            </profile>
+          </profiles>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2ff5-2fe0-2a80-bb28" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7784-19c1-aa18-a826" type="min"/>
+          </constraints>
+          <categoryLinks/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks/>
+          <costs/>
+        </selectionEntry>
       </selectionEntries>
       <selectionEntryGroups/>
-      <entryLinks/>
+      <entryLinks>
+        <entryLink id="2816-4d8f-1acb-91ed" name="Infernal Gaze" hidden="false" targetId="6c4a-1e10-1b14-8656" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fceb-4e83-13dd-52d7" type="min"/>
+          </constraints>
+          <categoryLinks/>
+        </entryLink>
+        <entryLink id="7ab4-2a7d-7d0a-2e33" name="Prescience" hidden="false" targetId="7eee-d684-f212-f2be" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c5d6-d4b0-80f1-9f66" type="min"/>
+          </constraints>
+          <categoryLinks/>
+        </entryLink>
+        <entryLink id="5c1e-3b3b-96f5-e04a" name="Warptime" hidden="false" targetId="bb7e-c0e1-d38d-33dd" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="719a-8d87-6b67-5903" type="min"/>
+          </constraints>
+          <categoryLinks/>
+        </entryLink>
+      </entryLinks>
       <costs>
         <cost name="pts" costTypeId="points" value="415.0"/>
         <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="21.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="94ba-3961-e217-214a" name="Chaos Cultists" page="" hidden="false" collective="false" type="unit">
-      <profiles/>
+      <profiles>
+        <profile id="fc37-719c-395d-c88d" name="Chaos Cultist" hidden="false" profileTypeId="800f-21d0-4387-c943" profileTypeName="Unit">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="M" characteristicTypeId="0bdf-a96e-9e38-7779" value="6&quot;"/>
+            <characteristic name="WS" characteristicTypeId="e7f0-1278-0250-df0c" value="4+"/>
+            <characteristic name="BS" characteristicTypeId="381b-eb28-74c3-df5f" value="4+"/>
+            <characteristic name="S" characteristicTypeId="2218-aa3c-265f-2939" value="3"/>
+            <characteristic name="T" characteristicTypeId="9c9f-9774-a358-3a39" value="3"/>
+            <characteristic name="W" characteristicTypeId="f330-5e6e-4110-0978" value="1"/>
+            <characteristic name="A" characteristicTypeId="13fc-b29b-31f2-ab9f" value="1"/>
+            <characteristic name="Ld" characteristicTypeId="00ca-f8b8-876d-b705" value="5"/>
+            <characteristic name="Save" characteristicTypeId="c0df-df94-abd7-e8d3" value="6+"/>
+          </characteristics>
+        </profile>
+      </profiles>
       <rules/>
       <infoLinks/>
       <modifiers>
@@ -5254,7 +5568,15 @@
               <profiles/>
               <rules/>
               <infoLinks/>
-              <modifiers/>
+              <modifiers>
+                <modifier type="set" field="13fc-b29b-31f2-ab9f" value="3">
+                  <repeats/>
+                  <conditions>
+                    <condition field="selections" scope="9e67-425a-1b51-e043" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="6a37-0d37-8454-fbd8" type="equalTo"/>
+                  </conditions>
+                  <conditionGroups/>
+                </modifier>
+              </modifiers>
               <characteristics>
                 <characteristic name="M" characteristicTypeId="0bdf-a96e-9e38-7779" value="6&quot;"/>
                 <characteristic name="WS" characteristicTypeId="e7f0-1278-0250-df0c" value="4+"/>
@@ -5278,7 +5600,7 @@
           <categoryLinks/>
           <selectionEntries/>
           <selectionEntryGroups>
-            <selectionEntryGroup id="d27f-af1a-7b7a-ef6a" name="Autogun options" hidden="false" collective="false">
+            <selectionEntryGroup id="d27f-af1a-7b7a-ef6a" name="Autogun options" hidden="false" collective="false" defaultSelectionEntryId="f93e-7da8-3e1f-c09e">
               <profiles/>
               <rules/>
               <infoLinks/>
@@ -5290,25 +5612,16 @@
               <categoryLinks/>
               <selectionEntries>
                 <selectionEntry id="6a37-0d37-8454-fbd8" name="Brutal assault weapon and Autopistol" hidden="false" collective="false" type="upgrade">
-                  <profiles>
-                    <profile id="e86c-792a-dd01-02e3" name="Brutal assault weapon" hidden="false" profileTypeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" profileTypeName="Weapon">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks>
+                    <infoLink id="dd26-9852-d8db-edeb" name="Autopistol" hidden="false" targetId="2481-001b-00f9-501b" type="profile">
                       <profiles/>
                       <rules/>
                       <infoLinks/>
                       <modifiers/>
-                      <characteristics>
-                        <characteristic name="Range" characteristicTypeId="6fa97fa8-ea74-4a27-a0fb-bc4e5f367464" value="Melee"/>
-                        <characteristic name="Type" characteristicTypeId="077c342f-d7b9-45c6-b8af-88e97cafd3a2" value="Melee"/>
-                        <characteristic name="S" characteristicTypeId="59b1-319e-ec13-d466" value="User"/>
-                        <characteristic name="AP" characteristicTypeId="75aa-a838-b675-6484" value="0"/>
-                        <characteristic name="D" characteristicTypeId="ae8a-3137-d65b-4ca7" value="1"/>
-                        <characteristic name="Abilities" characteristicTypeId="837d-5e63-aeb7-1410" value="Each time the bearer fights, it can make 1 additional attack with this weapon."/>
-                      </characteristics>
-                    </profile>
-                  </profiles>
-                  <rules/>
-                  <infoLinks>
-                    <infoLink id="dd26-9852-d8db-edeb" name="New InfoLink" hidden="false" targetId="2481-001b-00f9-501b" type="profile">
+                    </infoLink>
+                    <infoLink id="dbeb-cc2f-e7c9-6145" name="Brutal assault weapon" hidden="false" targetId="4d38-d3e5-a04b-55dc" type="profile">
                       <profiles/>
                       <rules/>
                       <infoLinks/>
@@ -5354,144 +5667,190 @@
             <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="0.0"/>
           </costs>
         </selectionEntry>
-        <selectionEntry id="3136-8b62-fb0a-8681" name="Chaos Cultist" hidden="false" collective="false" type="model">
-          <profiles>
-            <profile id="0ab9-cb16-22e9-4d78" name="Chaos Cultist" hidden="false" profileTypeId="800f-21d0-4387-c943" profileTypeName="Unit">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <characteristics>
-                <characteristic name="M" characteristicTypeId="0bdf-a96e-9e38-7779" value="6&quot;"/>
-                <characteristic name="WS" characteristicTypeId="e7f0-1278-0250-df0c" value="4+"/>
-                <characteristic name="BS" characteristicTypeId="381b-eb28-74c3-df5f" value="4+"/>
-                <characteristic name="S" characteristicTypeId="2218-aa3c-265f-2939" value="3"/>
-                <characteristic name="T" characteristicTypeId="9c9f-9774-a358-3a39" value="3"/>
-                <characteristic name="W" characteristicTypeId="f330-5e6e-4110-0978" value="1"/>
-                <characteristic name="A" characteristicTypeId="13fc-b29b-31f2-ab9f" value="1"/>
-                <characteristic name="Ld" characteristicTypeId="00ca-f8b8-876d-b705" value="5"/>
-                <characteristic name="Save" characteristicTypeId="c0df-df94-abd7-e8d3" value="6+"/>
-              </characteristics>
-            </profile>
-          </profiles>
+      </selectionEntries>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="d8d1-d429-b5a2-04d6" name="Cultists" hidden="false" collective="false" defaultSelectionEntryId="b505-bfa9-0c1c-aa2b">
+          <profiles/>
           <rules/>
           <infoLinks/>
           <modifiers/>
           <constraints>
-            <constraint field="selections" scope="parent" value="9.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7a72-05cb-3491-6960" type="min"/>
-            <constraint field="selections" scope="parent" value="39.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2684-8717-7c88-17b0" type="max"/>
+            <constraint field="selections" scope="parent" value="39.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a338-2a57-d328-2728" type="max"/>
+            <constraint field="selections" scope="parent" value="9.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e8cf-38d2-d70a-33fa" type="min"/>
           </constraints>
           <categoryLinks/>
           <selectionEntries>
-            <selectionEntry id="32fd-4784-3949-8da9" name="Autogun" hidden="false" collective="true" type="upgrade">
+            <selectionEntry id="b505-bfa9-0c1c-aa2b" name="Chaos Cultist w/ Autogun" hidden="false" collective="false" type="model">
               <profiles/>
               <rules/>
-              <infoLinks>
-                <infoLink id="baf7-3088-106a-fd27" name="New InfoLink" hidden="false" targetId="fcde-3e6a-e240-1157" type="profile">
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+              <categoryLinks/>
+              <selectionEntries>
+                <selectionEntry id="60bc-ac61-b303-52f1" name="Autogun" hidden="false" collective="true" type="upgrade">
                   <profiles/>
                   <rules/>
-                  <infoLinks/>
+                  <infoLinks>
+                    <infoLink id="8b46-9656-fb8a-49f1" name="New InfoLink" hidden="false" targetId="fcde-3e6a-e240-1157" type="profile">
+                      <profiles/>
+                      <rules/>
+                      <infoLinks/>
+                      <modifiers/>
+                    </infoLink>
+                  </infoLinks>
                   <modifiers/>
-                </infoLink>
-              </infoLinks>
-              <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="52fb-2085-2ab1-ed6a" type="min"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="224f-a27a-985e-0624" type="max"/>
-              </constraints>
-              <categoryLinks/>
-              <selectionEntries/>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d1e4-60d1-582b-6b38" type="min"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b83e-d632-8418-528b" type="max"/>
+                  </constraints>
+                  <categoryLinks/>
+                  <selectionEntries/>
+                  <selectionEntryGroups/>
+                  <entryLinks/>
+                  <costs>
+                    <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="0.0"/>
+                    <cost name="pts" costTypeId="points" value="0.0"/>
+                  </costs>
+                </selectionEntry>
+              </selectionEntries>
               <selectionEntryGroups/>
               <entryLinks/>
               <costs>
                 <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="0.0"/>
-                <cost name="pts" costTypeId="points" value="0.0"/>
+                <cost name="pts" costTypeId="points" value="5.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="8ae9-c17b-af6b-0d9e" name="Chaos Cultist w/ autopistol and brutal assault weapon" hidden="false" collective="false" type="model">
+              <profiles>
+                <profile id="8900-e8ef-e1f3-1c73" name="Chaos Cultist w/ Brutal assault weapon" hidden="false" profileTypeId="800f-21d0-4387-c943" profileTypeName="Unit">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <characteristics>
+                    <characteristic name="M" characteristicTypeId="0bdf-a96e-9e38-7779" value="6&quot;"/>
+                    <characteristic name="WS" characteristicTypeId="e7f0-1278-0250-df0c" value="4+"/>
+                    <characteristic name="BS" characteristicTypeId="381b-eb28-74c3-df5f" value="4+"/>
+                    <characteristic name="S" characteristicTypeId="2218-aa3c-265f-2939" value="3"/>
+                    <characteristic name="T" characteristicTypeId="9c9f-9774-a358-3a39" value="3"/>
+                    <characteristic name="W" characteristicTypeId="f330-5e6e-4110-0978" value="1"/>
+                    <characteristic name="A" characteristicTypeId="13fc-b29b-31f2-ab9f" value="2"/>
+                    <characteristic name="Ld" characteristicTypeId="00ca-f8b8-876d-b705" value="5"/>
+                    <characteristic name="Save" characteristicTypeId="c0df-df94-abd7-e8d3" value="6+"/>
+                  </characteristics>
+                </profile>
+              </profiles>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+              <categoryLinks/>
+              <selectionEntries>
+                <selectionEntry id="1f36-ef5c-78cb-d6e6" name="Autopistol" hidden="false" collective="true" type="upgrade">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks>
+                    <infoLink id="e6c9-0028-38d7-54a3" name="Autopistol" hidden="false" targetId="2481-001b-00f9-501b" type="profile">
+                      <profiles/>
+                      <rules/>
+                      <infoLinks/>
+                      <modifiers/>
+                    </infoLink>
+                  </infoLinks>
+                  <modifiers/>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ca61-66b9-1f6b-4172" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ff68-6a8c-6991-0a9a" type="min"/>
+                  </constraints>
+                  <categoryLinks/>
+                  <selectionEntries/>
+                  <selectionEntryGroups/>
+                  <entryLinks/>
+                  <costs>
+                    <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="0.0"/>
+                    <cost name="pts" costTypeId="points" value="0.0"/>
+                  </costs>
+                </selectionEntry>
+              </selectionEntries>
+              <selectionEntryGroups/>
+              <entryLinks>
+                <entryLink id="2c49-f981-8857-0276" name="Brutal assault weapon" hidden="false" targetId="b66a-94c9-f8bd-32f9" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e186-ff82-1fb6-1559" type="min"/>
+                  </constraints>
+                  <categoryLinks/>
+                </entryLink>
+              </entryLinks>
+              <costs>
+                <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="0.0"/>
+                <cost name="pts" costTypeId="points" value="5.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="7d90-d691-a7cb-4fd3" name="Chaos Cultist w/ special weapon" hidden="false" collective="false" type="upgrade">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers>
+                <modifier type="increment" field="8950-7d8b-027d-dcf3" value="1">
+                  <repeats>
+                    <repeat field="selections" scope="94ba-3961-e217-214a" value="10.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="model" repeats="1" roundUp="false"/>
+                  </repeats>
+                  <conditions/>
+                  <conditionGroups/>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8950-7d8b-027d-dcf3" type="max"/>
+              </constraints>
+              <categoryLinks/>
+              <selectionEntries/>
+              <selectionEntryGroups>
+                <selectionEntryGroup id="3104-7151-1976-312e" name="Weapon option" hidden="false" collective="false">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="92a4-0506-7777-88c9" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1233-a0ec-3c2a-d016" type="min"/>
+                  </constraints>
+                  <categoryLinks/>
+                  <selectionEntries/>
+                  <selectionEntryGroups/>
+                  <entryLinks>
+                    <entryLink id="882b-beba-768b-0aec" name="Flamer" hidden="false" targetId="fd22-6743-2d4c-dd62" type="selectionEntry">
+                      <profiles/>
+                      <rules/>
+                      <infoLinks/>
+                      <modifiers/>
+                      <constraints/>
+                      <categoryLinks/>
+                    </entryLink>
+                    <entryLink id="8fd5-e980-2b8e-b0e0" name="Heavy stubber" hidden="false" targetId="cfa3-5fcd-af10-5520" type="selectionEntry">
+                      <profiles/>
+                      <rules/>
+                      <infoLinks/>
+                      <modifiers/>
+                      <constraints/>
+                      <categoryLinks/>
+                    </entryLink>
+                  </entryLinks>
+                </selectionEntryGroup>
+              </selectionEntryGroups>
+              <entryLinks/>
+              <costs>
+                <cost name="pts" costTypeId="points" value="5.0"/>
+                <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
           <selectionEntryGroups/>
           <entryLinks/>
-          <costs>
-            <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="0.0"/>
-            <cost name="pts" costTypeId="points" value="5.0"/>
-          </costs>
-        </selectionEntry>
-        <selectionEntry id="0419-6af9-49e0-9010" name="Replace autogun with autopistol and brutal assault weapon" hidden="false" collective="true" type="upgrade">
-          <profiles>
-            <profile id="fe99-e9e0-2a4b-eb5f" name="Brutal assault weapon" hidden="false" profileTypeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" profileTypeName="Weapon">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <characteristics>
-                <characteristic name="Range" characteristicTypeId="6fa97fa8-ea74-4a27-a0fb-bc4e5f367464" value="Melee"/>
-                <characteristic name="Type" characteristicTypeId="077c342f-d7b9-45c6-b8af-88e97cafd3a2" value="Melee"/>
-                <characteristic name="S" characteristicTypeId="59b1-319e-ec13-d466" value="User"/>
-                <characteristic name="AP" characteristicTypeId="75aa-a838-b675-6484" value="0"/>
-                <characteristic name="D" characteristicTypeId="ae8a-3137-d65b-4ca7" value="1"/>
-                <characteristic name="Abilities" characteristicTypeId="837d-5e63-aeb7-1410" value="Each time the bearer fights, it can make 1 additional attack with this weapon."/>
-              </characteristics>
-            </profile>
-          </profiles>
-          <rules/>
-          <infoLinks>
-            <infoLink id="4d9b-ebda-a0f5-0177" name="New InfoLink" hidden="false" targetId="fcde-3e6a-e240-1157" type="profile">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-            </infoLink>
-          </infoLinks>
-          <modifiers/>
-          <constraints/>
-          <categoryLinks/>
-          <selectionEntries/>
-          <selectionEntryGroups/>
-          <entryLinks/>
-          <costs>
-            <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="0.0"/>
-            <cost name="pts" costTypeId="points" value="0.0"/>
-          </costs>
-        </selectionEntry>
-      </selectionEntries>
-      <selectionEntryGroups>
-        <selectionEntryGroup id="f115-fdbe-f24a-b7d2" name="Special weapon" hidden="false" collective="false">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers>
-            <modifier type="increment" field="ad9a-4d13-593e-8605" value="1">
-              <repeats>
-                <repeat field="selections" scope="parent" value="10.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="model" repeats="1" roundUp="true"/>
-              </repeats>
-              <conditions/>
-              <conditionGroups/>
-            </modifier>
-          </modifiers>
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="ad9a-4d13-593e-8605" type="max"/>
-          </constraints>
-          <categoryLinks/>
-          <selectionEntries/>
-          <selectionEntryGroups/>
-          <entryLinks>
-            <entryLink id="75d8-53f8-8a84-b300" name="New EntryLink" hidden="false" targetId="cfa3-5fcd-af10-5520" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints/>
-              <categoryLinks/>
-            </entryLink>
-            <entryLink id="4861-a967-3a81-a2ca" name="New EntryLink" hidden="false" targetId="fd22-6743-2d4c-dd62" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints/>
-              <categoryLinks/>
-            </entryLink>
-          </entryLinks>
         </selectionEntryGroup>
       </selectionEntryGroups>
       <entryLinks/>
@@ -5697,25 +6056,7 @@
             <characteristic name="Save" characteristicTypeId="c0df-df94-abd7-e8d3" value="3+"/>
           </characteristics>
         </profile>
-        <profile id="04f9-8bb2-7733-a730" name="Favour of Tzeentch" hidden="false" profileTypeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" profileTypeName="Abilities">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <characteristics>
-            <characteristic name="Description" characteristicTypeId="21befb24-fc85-4f52-a745-64b2e48f8228" value="This model has a 5++."/>
-          </characteristics>
-        </profile>
-        <profile id="bb8a-9d25-8dea-8f55" name="Lord of the Thousand Sons" hidden="false" profileTypeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" profileTypeName="Abilities">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <characteristics>
-            <characteristic name="Description" characteristicTypeId="21befb24-fc85-4f52-a745-64b2e48f8228" value="You can re-roll invulnerable saving throws of 1 made for friendly Thousand Sons Infantry units within 6&quot; of this model."/>
-          </characteristics>
-        </profile>
-        <profile id="a76d-623c-2bab-d67f" name="Exalted Sorcerer" hidden="false" profileTypeId="bc97-dea9-9e88-bb7d" profileTypeName="Psyker">
+        <profile id="8cd9-99fd-515b-6172" name="Exalted Sorcerer" hidden="false" profileTypeId="bc97-dea9-9e88-bb7d" profileTypeName="Psyker">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -5723,7 +6064,7 @@
           <characteristics>
             <characteristic name="Cast" characteristicTypeId="5afb-9914-904b-d3b3" value="2"/>
             <characteristic name="Deny" characteristicTypeId="b5ac-9c20-5d5a-6f9b" value="1"/>
-            <characteristic name="Powers Known" characteristicTypeId="69d7-b45e-00a2-7e46" value="2 Dark Hereticus"/>
+            <characteristic name="Powers Known" characteristicTypeId="69d7-b45e-00a2-7e46" value="Smite and two powers from the Dark Hereticus discipline"/>
             <characteristic name="Other" characteristicTypeId="c2e2-f115-0003-5d7b" value=""/>
           </characteristics>
         </profile>
@@ -5731,6 +6072,18 @@
       <rules/>
       <infoLinks>
         <infoLink id="ad25-8b45-55a1-6856" name="Death to the False Emperor" hidden="false" targetId="27a8-c34a-7a70-904e" type="profile">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="62f4-3439-e9e6-816a" name="Favour of Tzeentch" hidden="false" targetId="5d58-ea78-c523-b0c7" type="profile">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="79b7-084a-9b37-b780" name="Lord of the Thousand Sons" hidden="false" targetId="92a0-3a44-c95b-ecdf" type="profile">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -5790,6 +6143,20 @@
           <constraints/>
         </categoryLink>
         <categoryLink id="49d9-2d47-e707-bd01" name="New CategoryLink" hidden="false" targetId="e691-aad7-d21c-1023" primary="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
+        <categoryLink id="8712-802c-68e3-addb" name="New CategoryLink" hidden="false" targetId="0bc5-6451-5612-4a25" primary="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
+        <categoryLink id="7182-2004-8cb7-147d" name="New CategoryLink" hidden="false" targetId="ad01-caec-17d9-cb8d" primary="false">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -5867,6 +6234,28 @@
           </constraints>
           <categoryLinks/>
         </entryLink>
+        <entryLink id="f24e-0802-f9ea-b704" name="Smite" hidden="false" targetId="03fd-db47-5333-1e1f" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3d4f-6d6e-0292-42fc" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="651a-83c0-0a88-c73e" type="min"/>
+          </constraints>
+          <categoryLinks/>
+        </entryLink>
+        <entryLink id="0af9-298b-7ee3-ce8e" name="Dark Hereticus Discipline" hidden="false" targetId="cca1-01a1-45fa-e054" type="selectionEntryGroup">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a357-a618-9f58-353b" type="max"/>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4dd0-6588-c289-5df3" type="min"/>
+          </constraints>
+          <categoryLinks/>
+        </entryLink>
       </entryLinks>
       <costs>
         <cost name="pts" costTypeId="points" value="146.0"/>
@@ -5881,7 +6270,7 @@
           <infoLinks/>
           <modifiers/>
           <characteristics>
-            <characteristic name="Description" characteristicTypeId="21befb24-fc85-4f52-a745-64b2e48f8228" value="You can re-roll failed hit rolls in the Fight phase for this unit when targeting a Character."/>
+            <characteristic name="Description" characteristicTypeId="21befb24-fc85-4f52-a745-64b2e48f8228" value="You can re-roll failed hit rolls in the Fight phase for this unit when targeting a CHARACTER."/>
           </characteristics>
         </profile>
         <profile id="d181-4405-f1c0-6956" name="Aura of Dark Glory" hidden="false" profileTypeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" profileTypeName="Abilities">
@@ -5890,24 +6279,24 @@
           <infoLinks/>
           <modifiers/>
           <characteristics>
-            <characteristic name="Description" characteristicTypeId="21befb24-fc85-4f52-a745-64b2e48f8228" value="Each model in this unit has a 5++ save."/>
+            <characteristic name="Description" characteristicTypeId="21befb24-fc85-4f52-a745-64b2e48f8228" value="Each model in this unit has a 5+ invulnerable save."/>
           </characteristics>
         </profile>
       </profiles>
       <rules/>
       <infoLinks/>
       <modifiers>
-        <modifier type="increment" field="e356-c769-5920-6e14" value="3">
-          <repeats>
-            <repeat field="selections" scope="aa64-5c8e-b2d5-86b0" value="10.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="model" repeats="1" roundUp="true"/>
-          </repeats>
-          <conditions/>
-          <conditionGroups/>
-        </modifier>
-        <modifier type="decrement" field="e356-c769-5920-6e14" value="3">
+        <modifier type="set" field="e356-c769-5920-6e14" value="7">
           <repeats/>
           <conditions>
-            <condition field="selections" scope="aa64-5c8e-b2d5-86b0" value="9.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="model" type="greaterThan"/>
+            <condition field="selections" scope="aa64-5c8e-b2d5-86b0" value="10.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="model" type="greaterThan"/>
+          </conditions>
+          <conditionGroups/>
+        </modifier>
+        <modifier type="set" field="e356-c769-5920-6e14" value="10">
+          <repeats/>
+          <conditions>
+            <condition field="selections" scope="aa64-5c8e-b2d5-86b0" value="20.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="model" type="greaterThan"/>
           </conditions>
           <conditionGroups/>
         </modifier>
@@ -5930,109 +6319,6 @@
         </categoryLink>
       </categoryLinks>
       <selectionEntries>
-        <selectionEntry id="1275-e214-cb9c-9b2b" name="Tzaangor" hidden="false" collective="false" type="model">
-          <profiles>
-            <profile id="408b-3b4d-e5b1-b212" name="Tzaangor" hidden="false" profileTypeId="800f-21d0-4387-c943" profileTypeName="Unit">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <characteristics>
-                <characteristic name="M" characteristicTypeId="0bdf-a96e-9e38-7779" value="6&quot;"/>
-                <characteristic name="WS" characteristicTypeId="e7f0-1278-0250-df0c" value="3+"/>
-                <characteristic name="BS" characteristicTypeId="381b-eb28-74c3-df5f" value="4+"/>
-                <characteristic name="S" characteristicTypeId="2218-aa3c-265f-2939" value="4"/>
-                <characteristic name="T" characteristicTypeId="9c9f-9774-a358-3a39" value="4"/>
-                <characteristic name="W" characteristicTypeId="f330-5e6e-4110-0978" value="1"/>
-                <characteristic name="A" characteristicTypeId="13fc-b29b-31f2-ab9f" value="1"/>
-                <characteristic name="Ld" characteristicTypeId="00ca-f8b8-876d-b705" value="6"/>
-                <characteristic name="Save" characteristicTypeId="c0df-df94-abd7-e8d3" value="6+"/>
-              </characteristics>
-            </profile>
-          </profiles>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints>
-            <constraint field="selections" scope="parent" value="9.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="db19-3ed4-3127-a434" type="min"/>
-            <constraint field="selections" scope="parent" value="29.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c9d5-7514-d7b2-ae7c" type="max"/>
-          </constraints>
-          <categoryLinks/>
-          <selectionEntries>
-            <selectionEntry id="3660-9af0-5008-bd76" name="Improvised weapon" hidden="false" collective="true" type="upgrade">
-              <profiles>
-                <profile id="4604-6b98-920b-a70b" name="Improvised weapon" hidden="false" profileTypeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" profileTypeName="Weapon">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                  <characteristics>
-                    <characteristic name="Range" characteristicTypeId="6fa97fa8-ea74-4a27-a0fb-bc4e5f367464" value="Melee"/>
-                    <characteristic name="Type" characteristicTypeId="077c342f-d7b9-45c6-b8af-88e97cafd3a2" value="Melee"/>
-                    <characteristic name="S" characteristicTypeId="59b1-319e-ec13-d466" value="User"/>
-                    <characteristic name="AP" characteristicTypeId="75aa-a838-b675-6484" value="0"/>
-                    <characteristic name="D" characteristicTypeId="ae8a-3137-d65b-4ca7" value="1"/>
-                    <characteristic name="Abilities" characteristicTypeId="837d-5e63-aeb7-1410" value="-"/>
-                  </characteristics>
-                </profile>
-              </profiles>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="201d-55e0-aa80-afe2" type="max"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d474-1127-c661-8cb6" type="min"/>
-              </constraints>
-              <categoryLinks/>
-              <selectionEntries/>
-              <selectionEntryGroups/>
-              <entryLinks/>
-              <costs>
-                <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="0.0"/>
-                <cost name="pts" costTypeId="points" value="0.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="49c1-4f79-4031-e947" name="Tzaangor blades" hidden="false" collective="true" type="upgrade">
-              <profiles>
-                <profile id="995d-1851-929e-6931" name="Tzaangor blades" hidden="false" profileTypeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" profileTypeName="Weapon">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                  <characteristics>
-                    <characteristic name="Range" characteristicTypeId="6fa97fa8-ea74-4a27-a0fb-bc4e5f367464" value="Melee"/>
-                    <characteristic name="Type" characteristicTypeId="077c342f-d7b9-45c6-b8af-88e97cafd3a2" value="Melee"/>
-                    <characteristic name="S" characteristicTypeId="59b1-319e-ec13-d466" value="User"/>
-                    <characteristic name="AP" characteristicTypeId="75aa-a838-b675-6484" value="-1"/>
-                    <characteristic name="D" characteristicTypeId="ae8a-3137-d65b-4ca7" value="1"/>
-                    <characteristic name="Abilities" characteristicTypeId="837d-5e63-aeb7-1410" value="Each time the bearer fights, it can make 1 additional attack with this weapon."/>
-                  </characteristics>
-                </profile>
-              </profiles>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c5d2-dff0-54f5-ef9a" type="min"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f10b-3fcc-9843-0110" type="max"/>
-              </constraints>
-              <categoryLinks/>
-              <selectionEntries/>
-              <selectionEntryGroups/>
-              <entryLinks/>
-              <costs>
-                <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="0.0"/>
-                <cost name="pts" costTypeId="points" value="0.0"/>
-              </costs>
-            </selectionEntry>
-          </selectionEntries>
-          <selectionEntryGroups/>
-          <entryLinks/>
-          <costs>
-            <cost name="pts" costTypeId="points" value="7.0"/>
-            <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="0.0"/>
-          </costs>
-        </selectionEntry>
         <selectionEntry id="572c-8954-0454-31e2" name="Twistbray" page="" hidden="false" collective="false" type="model">
           <profiles>
             <profile id="1484-7f3c-1baf-754c" name="Twistbray" hidden="false" profileTypeId="800f-21d0-4387-c943" profileTypeName="Unit">
@@ -6061,84 +6347,88 @@
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="72c4-2ef3-140d-d9b2" type="max"/>
           </constraints>
           <categoryLinks/>
-          <selectionEntries>
-            <selectionEntry id="d262-97d4-e9a0-3bfc" name="Tzaangor blades" hidden="false" collective="true" type="upgrade">
-              <profiles>
-                <profile id="e14c-c885-cf97-92fd" name="Tzaangor blades" hidden="false" profileTypeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" profileTypeName="Weapon">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                  <characteristics>
-                    <characteristic name="Range" characteristicTypeId="6fa97fa8-ea74-4a27-a0fb-bc4e5f367464" value="Melee"/>
-                    <characteristic name="Type" characteristicTypeId="077c342f-d7b9-45c6-b8af-88e97cafd3a2" value="Melee"/>
-                    <characteristic name="S" characteristicTypeId="59b1-319e-ec13-d466" value="User"/>
-                    <characteristic name="AP" characteristicTypeId="75aa-a838-b675-6484" value="-1"/>
-                    <characteristic name="D" characteristicTypeId="ae8a-3137-d65b-4ca7" value="1"/>
-                    <characteristic name="Abilities" characteristicTypeId="837d-5e63-aeb7-1410" value="Each time the bearer fights, it can make 1 additional attack with this weapon."/>
-                  </characteristics>
-                </profile>
-              </profiles>
+          <selectionEntries/>
+          <selectionEntryGroups>
+            <selectionEntryGroup id="0a23-9f7f-f1cf-24a1" name="Weapon option" hidden="false" collective="false" defaultSelectionEntryId="41e3-6964-d117-f3a4">
+              <profiles/>
               <rules/>
               <infoLinks/>
               <modifiers/>
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5ec9-7fc3-da5d-1bf3" type="min"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9285-8e04-6d6e-0987" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9812-d039-32b4-e833" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4f48-93da-e4ea-495f" type="min"/>
               </constraints>
               <categoryLinks/>
-              <selectionEntries/>
+              <selectionEntries>
+                <selectionEntry id="41e3-6964-d117-f3a4" name="Tzaangor blades" hidden="false" collective="true" type="upgrade">
+                  <profiles>
+                    <profile id="e43f-5ec8-de0d-010b" name="Tzaangor blades" hidden="false" profileTypeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" profileTypeName="Weapon">
+                      <profiles/>
+                      <rules/>
+                      <infoLinks/>
+                      <modifiers/>
+                      <characteristics>
+                        <characteristic name="Range" characteristicTypeId="6fa97fa8-ea74-4a27-a0fb-bc4e5f367464" value="Melee"/>
+                        <characteristic name="Type" characteristicTypeId="077c342f-d7b9-45c6-b8af-88e97cafd3a2" value="Melee"/>
+                        <characteristic name="S" characteristicTypeId="59b1-319e-ec13-d466" value="User"/>
+                        <characteristic name="AP" characteristicTypeId="75aa-a838-b675-6484" value="-1"/>
+                        <characteristic name="D" characteristicTypeId="ae8a-3137-d65b-4ca7" value="1"/>
+                        <characteristic name="Abilities" characteristicTypeId="837d-5e63-aeb7-1410" value="Each time the bearer fights, it can make 1 additional attack with this weapon."/>
+                      </characteristics>
+                    </profile>
+                  </profiles>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6a4a-dffa-f0cf-9b47" type="max"/>
+                  </constraints>
+                  <categoryLinks/>
+                  <selectionEntries/>
+                  <selectionEntryGroups/>
+                  <entryLinks/>
+                  <costs>
+                    <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="0.0"/>
+                    <cost name="pts" costTypeId="points" value="0.0"/>
+                  </costs>
+                </selectionEntry>
+                <selectionEntry id="e527-2c9f-6c37-f5f8" name="Autopistol and chainsword" hidden="false" collective="false" type="model">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks>
+                    <infoLink id="3afb-3964-1f7b-d099" name="Autopistol" hidden="false" targetId="2481-001b-00f9-501b" type="profile">
+                      <profiles/>
+                      <rules/>
+                      <infoLinks/>
+                      <modifiers/>
+                    </infoLink>
+                    <infoLink id="fc34-073d-a883-1044" name="Chainsword" hidden="false" targetId="9b1e-61f9-4a5b-0044" type="profile">
+                      <profiles/>
+                      <rules/>
+                      <infoLinks/>
+                      <modifiers/>
+                    </infoLink>
+                  </infoLinks>
+                  <modifiers/>
+                  <constraints/>
+                  <categoryLinks/>
+                  <selectionEntries/>
+                  <selectionEntryGroups/>
+                  <entryLinks/>
+                  <costs>
+                    <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="0.0"/>
+                    <cost name="pts" costTypeId="points" value="0.0"/>
+                  </costs>
+                </selectionEntry>
+              </selectionEntries>
               <selectionEntryGroups/>
               <entryLinks/>
-              <costs>
-                <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="0.0"/>
-                <cost name="pts" costTypeId="points" value="0.0"/>
-              </costs>
-            </selectionEntry>
-          </selectionEntries>
-          <selectionEntryGroups/>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
           <entryLinks/>
           <costs>
             <cost name="pts" costTypeId="points" value="7.0"/>
             <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="0.0"/>
-          </costs>
-        </selectionEntry>
-        <selectionEntry id="7fb7-7e25-768f-474d" name="Replace Tzaangor blades with autopistol and chainsword" hidden="false" collective="false" type="upgrade">
-          <profiles/>
-          <rules/>
-          <infoLinks>
-            <infoLink id="781a-4721-4fdc-64db" name="New InfoLink" hidden="false" targetId="2481-001b-00f9-501b" type="profile">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-            </infoLink>
-            <infoLink id="45cf-97f2-51f1-36ee" name="New InfoLink" hidden="false" targetId="9b1e-61f9-4a5b-0044" type="profile">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-            </infoLink>
-          </infoLinks>
-          <modifiers>
-            <modifier type="increment" field="3b78-9e11-d96c-c54a" value="1">
-              <repeats>
-                <repeat field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="model" repeats="1" roundUp="false"/>
-              </repeats>
-              <conditions/>
-              <conditionGroups/>
-            </modifier>
-          </modifiers>
-          <constraints>
-            <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3b78-9e11-d96c-c54a" type="max"/>
-          </constraints>
-          <categoryLinks/>
-          <selectionEntries/>
-          <selectionEntryGroups/>
-          <entryLinks/>
-          <costs>
-            <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="0.0"/>
-            <cost name="pts" costTypeId="points" value="0.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="eb58-3f8d-da5d-963d" name="Instrument of Chaos" hidden="false" collective="false" type="upgrade">
@@ -6165,13 +6455,138 @@
           <entryLinks/>
           <costs>
             <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="0.0"/>
-            <cost name="pts" costTypeId="points" value="0.0"/>
+            <cost name="pts" costTypeId="points" value="10.0"/>
           </costs>
         </selectionEntry>
       </selectionEntries>
-      <selectionEntryGroups/>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="2f37-5fcf-7ef2-77d9" name="Tzaangors" hidden="false" collective="false" defaultSelectionEntryId="076e-246e-d32b-93bb">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="9.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5bb4-43e0-a594-4739" type="min"/>
+            <constraint field="selections" scope="parent" value="29.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="cc0b-a5ed-9b27-f8b5" type="max"/>
+          </constraints>
+          <categoryLinks/>
+          <selectionEntries>
+            <selectionEntry id="076e-246e-d32b-93bb" name="Tzaangor w/ Tzaangor Blades" hidden="false" collective="false" type="model">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+              <categoryLinks/>
+              <selectionEntries>
+                <selectionEntry id="d82e-5a9a-1eb0-eee3" name="Tzaangor blades" hidden="false" collective="true" type="upgrade">
+                  <profiles>
+                    <profile id="919e-0e73-890c-0e5b" name="Tzaangor blades" hidden="false" profileTypeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" profileTypeName="Weapon">
+                      <profiles/>
+                      <rules/>
+                      <infoLinks/>
+                      <modifiers/>
+                      <characteristics>
+                        <characteristic name="Range" characteristicTypeId="6fa97fa8-ea74-4a27-a0fb-bc4e5f367464" value="Melee"/>
+                        <characteristic name="Type" characteristicTypeId="077c342f-d7b9-45c6-b8af-88e97cafd3a2" value="Melee"/>
+                        <characteristic name="S" characteristicTypeId="59b1-319e-ec13-d466" value="User"/>
+                        <characteristic name="AP" characteristicTypeId="75aa-a838-b675-6484" value="-1"/>
+                        <characteristic name="D" characteristicTypeId="ae8a-3137-d65b-4ca7" value="1"/>
+                        <characteristic name="Abilities" characteristicTypeId="837d-5e63-aeb7-1410" value="Each time the bearer fights, it can make 1 additional attack with this weapon."/>
+                      </characteristics>
+                    </profile>
+                  </profiles>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d25e-126d-321a-2cec" type="min"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3761-fb36-9e2d-e070" type="max"/>
+                  </constraints>
+                  <categoryLinks/>
+                  <selectionEntries/>
+                  <selectionEntryGroups/>
+                  <entryLinks/>
+                  <costs>
+                    <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="0.0"/>
+                    <cost name="pts" costTypeId="points" value="0.0"/>
+                  </costs>
+                </selectionEntry>
+              </selectionEntries>
+              <selectionEntryGroups/>
+              <entryLinks/>
+              <costs>
+                <cost name="pts" costTypeId="points" value="7.0"/>
+                <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="6f95-8b6f-b676-4bd6" name="Tzaangor w/ autopistol and chainsword" hidden="false" collective="false" type="model">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+              <categoryLinks/>
+              <selectionEntries>
+                <selectionEntry id="db72-dcf3-790d-59d8" name="Autopistol" hidden="false" collective="true" type="upgrade">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks>
+                    <infoLink id="1331-964c-77e2-05c1" name="Autopistol" hidden="false" targetId="2481-001b-00f9-501b" type="profile">
+                      <profiles/>
+                      <rules/>
+                      <infoLinks/>
+                      <modifiers/>
+                    </infoLink>
+                  </infoLinks>
+                  <modifiers/>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="eacf-f36b-5553-589e" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="42c0-74fa-6b6e-28cd" type="min"/>
+                  </constraints>
+                  <categoryLinks/>
+                  <selectionEntries/>
+                  <selectionEntryGroups/>
+                  <entryLinks/>
+                  <costs/>
+                </selectionEntry>
+              </selectionEntries>
+              <selectionEntryGroups/>
+              <entryLinks>
+                <entryLink id="89e8-7405-89fb-2125" name="Chainsword" hidden="false" targetId="4334-d2da-32f5-dc53" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2b64-f2aa-d508-c78d" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0722-15b6-b252-c523" type="min"/>
+                  </constraints>
+                  <categoryLinks/>
+                </entryLink>
+              </entryLinks>
+              <costs>
+                <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="0.0"/>
+                <cost name="pts" costTypeId="points" value="7.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+          <selectionEntryGroups/>
+          <entryLinks/>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
       <entryLinks>
         <entryLink id="8b4f-c810-1b55-c05a" name="Icon of Flame" hidden="false" targetId="0844-29e7-5ca3-1b56" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6347-5a22-8848-0401" type="max"/>
+          </constraints>
+          <categoryLinks/>
+        </entryLink>
+        <entryLink id="2163-c762-14f8-a60a" name="Infernal Gaze" hidden="false" targetId="6c4a-1e10-1b14-8656" type="selectionEntry">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -6194,15 +6609,6 @@
           <modifiers/>
           <characteristics>
             <characteristic name="Description" characteristicTypeId="21befb24-fc85-4f52-a745-64b2e48f8228" value="Ahriman has a 4+ invulnerable save."/>
-          </characteristics>
-        </profile>
-        <profile id="d716-6db8-f706-eae0" name="Lord of the Thousand Sons" hidden="false" profileTypeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" profileTypeName="Abilities">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <characteristics>
-            <characteristic name="Description" characteristicTypeId="21befb24-fc85-4f52-a745-64b2e48f8228" value="You can re-roll invulnerable saving throws of 1 made for friendly THOUSAND SONS INFANTRY units within 6&quot; of this model."/>
           </characteristics>
         </profile>
         <profile id="26b5-45a1-6463-37cf" name="Ahriman" hidden="false" profileTypeId="800f-21d0-4387-c943" profileTypeName="Unit">
@@ -6794,7 +7200,7 @@
           <infoLinks/>
           <modifiers/>
           <characteristics>
-            <characteristic name="Capacity" characteristicTypeId="15aa-1916-a38b-d223" value="This model can transport 10 (Legion) Infantry models (each Terminator and Jump Pack model takes up the space of two other models, and each Cult of Destruction model takes up the space of three other models)."/>
+            <characteristic name="Capacity" characteristicTypeId="15aa-1916-a38b-d223" value="This model can transport 10 &lt;LEGION&gt; Infantry models (each TERMINATOR and JUMP PACK model takes up the space of two other models, and each CULT OF DESTRUCTION model takes up the space of three other models)."/>
           </characteristics>
         </profile>
       </profiles>
@@ -6804,7 +7210,7 @@
           <rules/>
           <infoLinks/>
           <modifiers/>
-          <description>If this model is reduced to 0 wounds, roll a D6 before removing the model from the battlefield and before any embarked models disembark; on a 6 it explodes, and each unit within 6&quot; suffers D6 MW.</description>
+          <description>If this model is reduced to 0 wounds, roll a D6 before removing the model from the battlefield and before any embarked models disembark; on a 6 it explodes, and each unit within 6&quot; suffers D6 mortal wounds.</description>
         </rule>
       </rules>
       <infoLinks>
@@ -7317,7 +7723,7 @@
           <characteristics>
             <characteristic name="Warp Charge" characteristicTypeId="5ffd-b800-c317-532a" value="6"/>
             <characteristic name="Range" characteristicTypeId="fd64-cbc4-94de-24cc" value="3&quot;"/>
-            <characteristic name="Details" characteristicTypeId="ad96-dfa4-b4ed-656d" value="If manifested, pick a friendly HERETIC ASTARTES unit within 3&quot; of the psyker. That unit can immediately move as if it were its Movement phase. You cannot use Warptime on a unit ,pre than once in each Psychic phase."/>
+            <characteristic name="Details" characteristicTypeId="ad96-dfa4-b4ed-656d" value="If manifested, pick a friendly HERETIC ASTARTES unit within 3&quot; of the psyker. That unit can immediately move as if it were its Movement phase. You cannot use Warptime on a unit more than once in each Psychic phase."/>
           </characteristics>
         </profile>
       </profiles>
@@ -7326,6 +7732,59 @@
       <modifiers/>
       <constraints>
         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3284-5d62-2a3f-1f5c" type="max"/>
+      </constraints>
+      <categoryLinks/>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="0.0"/>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="bad6-50db-be09-615f" name="Hellfyre Missile Rack" hidden="false" collective="false" type="upgrade">
+      <profiles>
+        <profile id="3fff-0438-4fb1-b07f" name="Hellfyre Missile Rack" hidden="false" profileTypeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" profileTypeName="Weapon">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Range" characteristicTypeId="6fa97fa8-ea74-4a27-a0fb-bc4e5f367464" value="24&quot;"/>
+            <characteristic name="Type" characteristicTypeId="077c342f-d7b9-45c6-b8af-88e97cafd3a2" value="Heavy 2"/>
+            <characteristic name="S" characteristicTypeId="59b1-319e-ec13-d466" value="8"/>
+            <characteristic name="AP" characteristicTypeId="75aa-a838-b675-6484" value="-2"/>
+            <characteristic name="D" characteristicTypeId="ae8a-3137-d65b-4ca7" value="D3"/>
+            <characteristic name="Abilities" characteristicTypeId="837d-5e63-aeb7-1410" value="-"/>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints/>
+      <categoryLinks/>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="22.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="b66a-94c9-f8bd-32f9" name="Brutal assault weapon" hidden="false" collective="true" type="upgrade">
+      <profiles/>
+      <rules/>
+      <infoLinks>
+        <infoLink id="5105-de41-3648-b05c" name="Brutal assault weapon" hidden="false" targetId="4d38-d3e5-a04b-55dc" type="profile">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b783-faff-9f46-04a0" type="max"/>
       </constraints>
       <categoryLinks/>
       <selectionEntries/>
@@ -8118,6 +8577,47 @@
       <modifiers/>
       <characteristics>
         <characteristic name="Description" characteristicTypeId="21befb24-fc85-4f52-a745-64b2e48f8228" value="This model has a 5+ invulnerable save."/>
+      </characteristics>
+    </profile>
+    <profile id="6c28-5b6b-0879-5f1d" name="Prince of Chaos" hidden="false" profileTypeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" profileTypeName="Abilities">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <characteristics>
+        <characteristic name="Description" characteristicTypeId="21befb24-fc85-4f52-a745-64b2e48f8228" value="You can re-roll hit rolls of 1 made for friendly THOUSAND SONS units within 6&quot; of this model. This ability also affects friendly TZEENTCH DAEMON units within 6&quot;."/>
+      </characteristics>
+    </profile>
+    <profile id="5d58-ea78-c523-b0c7" name="Favour of Tzeentch" hidden="false" profileTypeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" profileTypeName="Abilities">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <characteristics>
+        <characteristic name="Description" characteristicTypeId="21befb24-fc85-4f52-a745-64b2e48f8228" value="This model has a 5+ invulnerable save."/>
+      </characteristics>
+    </profile>
+    <profile id="92a0-3a44-c95b-ecdf" name="Lord of the Thousand Sons" hidden="false" profileTypeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" profileTypeName="Abilities">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <characteristics>
+        <characteristic name="Description" characteristicTypeId="21befb24-fc85-4f52-a745-64b2e48f8228" value="You can re-roll invulnerable saving throws of 1 made for friendly THOUSAND SONS INFANTRY units within 6&quot; of this model."/>
+      </characteristics>
+    </profile>
+    <profile id="4d38-d3e5-a04b-55dc" name="Brutal assault weapon" hidden="false" profileTypeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" profileTypeName="Weapon">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <characteristics>
+        <characteristic name="Range" characteristicTypeId="6fa97fa8-ea74-4a27-a0fb-bc4e5f367464" value="Melee"/>
+        <characteristic name="Type" characteristicTypeId="077c342f-d7b9-45c6-b8af-88e97cafd3a2" value="Melee"/>
+        <characteristic name="S" characteristicTypeId="59b1-319e-ec13-d466" value="User"/>
+        <characteristic name="AP" characteristicTypeId="75aa-a838-b675-6484" value="0"/>
+        <characteristic name="D" characteristicTypeId="ae8a-3137-d65b-4ca7" value="1"/>
+        <characteristic name="Abilities" characteristicTypeId="837d-5e63-aeb7-1410" value="Each time the bearer fights, it can make 1 additional attack with this weapon. This extra attack is included in its profile."/>
       </characteristics>
     </profile>
   </sharedProfiles>


### PR DESCRIPTION
- Updated profile for Chaos Cultists to auto-include extra attack for brutal assault weapon
- Deathguard refactor (rules -> profiles, unit re-implementation where needed [BREAKING CHANGE], spell check of rules, added psychic power pick lists)
- Thousand Sons refactor (rules -> profiles, unit re-implementation where needed [BREAKING CHANGE], spell check of rules, added psychic power pick lists)
- CSM refactor (rules -> profiles, unit re-implementation where needed [BREAKING CHANGE], spell check of rules, added psychic power pick lists)
- FW Heretic Astartes FAQ 1.1 changes. Fixes #810 
- Fixes #825 
- Fixes #841 