### PR TITLE
Death Guard fixes

### DIFF
--- a/Chaos - Death Guard.cat
+++ b/Chaos - Death Guard.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="ce57-cc1c-37cb-cb71" name="Chaos - Death Guard" book="Index: Chaos" revision="11" battleScribeVersion="2.01" authorName="BSData team" authorUrl="http://battlescribedata.appspot.com/#/repo/wh40k" gameSystemId="28ec-711c-d87f-3aeb" gameSystemRevision="1" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="ce57-cc1c-37cb-cb71" name="Chaos - Death Guard" book="Index: Chaos" revision="12" battleScribeVersion="2.01" authorName="BSData team" authorUrl="http://battlescribedata.appspot.com/#/repo/wh40k" gameSystemId="28ec-711c-d87f-3aeb" gameSystemRevision="1" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <profiles/>
   <rules/>
   <infoLinks/>
@@ -458,7 +458,7 @@
               </constraints>
               <categoryLinks/>
             </entryLink>
-            <entryLink id="2b69-d64b-4ab8-665b" name="New EntryLink" hidden="false" targetId="ce84-10ca-568c-5c48" type="selectionEntryGroup">
+            <entryLink id="2b69-d64b-4ab8-665b" name="Pistols" hidden="false" targetId="ce84-10ca-568c-5c48" type="selectionEntryGroup">
               <profiles/>
               <rules/>
               <infoLinks/>
@@ -474,7 +474,7 @@
               <constraints/>
               <categoryLinks/>
             </entryLink>
-            <entryLink id="935f-85de-d99e-3d07" name="New EntryLink" hidden="false" targetId="becb-9ac2-cb36-95f7" type="selectionEntryGroup">
+            <entryLink id="935f-85de-d99e-3d07" name="Melee Weapons" hidden="false" targetId="becb-9ac2-cb36-95f7" type="selectionEntryGroup">
               <profiles/>
               <rules/>
               <infoLinks/>
@@ -497,7 +497,7 @@
           <selectionEntries/>
           <selectionEntryGroups/>
           <entryLinks>
-            <entryLink id="ffca-3ca5-699f-c89e" name="New EntryLink" hidden="false" targetId="0dd1-2e2b-7dd1-5495" type="selectionEntry">
+            <entryLink id="ffca-3ca5-699f-c89e" name="Chainsword" hidden="false" targetId="0dd1-2e2b-7dd1-5495" type="selectionEntry">
               <profiles/>
               <rules/>
               <infoLinks/>
@@ -507,7 +507,7 @@
               </constraints>
               <categoryLinks/>
             </entryLink>
-            <entryLink id="7e06-4ec7-fd7a-ea43" name="New EntryLink" hidden="false" targetId="becb-9ac2-cb36-95f7" type="selectionEntryGroup">
+            <entryLink id="7e06-4ec7-fd7a-ea43" name="Melee Weapons" hidden="false" targetId="becb-9ac2-cb36-95f7" type="selectionEntryGroup">
               <profiles/>
               <rules/>
               <infoLinks/>
@@ -523,13 +523,13 @@
               <constraints/>
               <categoryLinks/>
             </entryLink>
-            <entryLink id="5f10-4c4d-b5d9-1a54" name="Lightning Claw (Pair)" hidden="false" targetId="7603-6241-ab8b-4603" type="selectionEntry">
+            <entryLink id="8e86-66dd-2b39-3545" name="Lightning Claw (Pair)" hidden="false" targetId="7603-6241-ab8b-4603" type="selectionEntry">
               <profiles/>
               <rules/>
               <infoLinks/>
               <modifiers/>
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="5308-24ff-064e-e41f" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="083c-c137-e269-feea" type="max"/>
               </constraints>
               <categoryLinks/>
             </entryLink>
@@ -1933,17 +1933,11 @@
               </selectionEntries>
               <selectionEntryGroups/>
               <entryLinks>
-                <entryLink id="7e02-404b-aa25-3e76" name="Fallen Champion Equipment" hidden="false" targetId="891c-fbf0-e426-2c15" type="selectionEntryGroup">
+                <entryLink id="7e02-404b-aa25-3e76" name="Champion Equipment" hidden="false" targetId="1912-576e-6a2b-5c6e" type="selectionEntryGroup">
                   <profiles/>
                   <rules/>
                   <infoLinks/>
-                  <modifiers>
-                    <modifier type="set" field="name" value="Champion Equipment">
-                      <repeats/>
-                      <conditions/>
-                      <conditionGroups/>
-                    </modifier>
-                  </modifiers>
+                  <modifiers/>
                   <constraints/>
                   <categoryLinks/>
                 </entryLink>
@@ -4758,7 +4752,29 @@
           <profiles/>
           <rules/>
           <infoLinks/>
-          <modifiers/>
+          <modifiers>
+            <modifier type="increment" field="13fc-b29b-31f2-ab9f" value="1">
+              <repeats/>
+              <conditions/>
+              <conditionGroups>
+                <conditionGroup type="and">
+                  <conditions>
+                    <condition field="selections" scope="5cae-15dc-4a5d-0b9b" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="b082-190f-1c58-4f3d" type="equalTo"/>
+                  </conditions>
+                  <conditionGroups>
+                    <conditionGroup type="or">
+                      <conditions>
+                        <condition field="selections" scope="5cae-15dc-4a5d-0b9b" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="ce8d-9406-bcf1-fdae" type="equalTo"/>
+                        <condition field="selections" scope="5cae-15dc-4a5d-0b9b" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="840e-6586-1162-9d68" type="equalTo"/>
+                        <condition field="selections" scope="5cae-15dc-4a5d-0b9b" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="f789-c214-2335-e2cf" type="equalTo"/>
+                      </conditions>
+                      <conditionGroups/>
+                    </conditionGroup>
+                  </conditionGroups>
+                </conditionGroup>
+              </conditionGroups>
+            </modifier>
+          </modifiers>
           <characteristics>
             <characteristic name="M" characteristicTypeId="0bdf-a96e-9e38-7779" value="8&quot;"/>
             <characteristic name="WS" characteristicTypeId="e7f0-1278-0250-df0c" value="3+"/>
@@ -4780,26 +4796,47 @@
             <characteristic name="Description" characteristicTypeId="21befb24-fc85-4f52-a745-64b2e48f8228" value="At the end of any phase in which this model suffers any unsaved wounds or mortal wounds, roll a D6. On a roll of 6, this model immediately makes a shooting attack as if it were your Shooting phase if there no enemies within 1&quot;, or a piles in and fights as if it were in the Fight phase if there are enemies within 1&quot;. If there is no visible target within range, nothing happens."/>
           </characteristics>
         </profile>
-        <profile id="a3d2-cbb8-77f5-44d3" name="Battering Onslaught" hidden="false" profileTypeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" profileTypeName="Abilities">
+        <profile id="a3d2-cbb8-77f5-44d3" name="Battering Onslaught" hidden="true" profileTypeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" profileTypeName="Abilities">
           <profiles/>
           <rules/>
           <infoLinks/>
-          <modifiers/>
+          <modifiers>
+            <modifier type="set" field="hidden" value="false">
+              <repeats/>
+              <conditions/>
+              <conditionGroups>
+                <conditionGroup type="and">
+                  <conditions>
+                    <condition field="selections" scope="5cae-15dc-4a5d-0b9b" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="b082-190f-1c58-4f3d" type="equalTo"/>
+                  </conditions>
+                  <conditionGroups>
+                    <conditionGroup type="or">
+                      <conditions>
+                        <condition field="selections" scope="5cae-15dc-4a5d-0b9b" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="f789-c214-2335-e2cf" type="equalTo"/>
+                        <condition field="selections" scope="5cae-15dc-4a5d-0b9b" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="840e-6586-1162-9d68" type="equalTo"/>
+                        <condition field="selections" scope="5cae-15dc-4a5d-0b9b" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="ce8d-9406-bcf1-fdae" type="equalTo"/>
+                      </conditions>
+                      <conditionGroups/>
+                    </conditionGroup>
+                  </conditionGroups>
+                </conditionGroup>
+              </conditionGroups>
+            </modifier>
+          </modifiers>
           <characteristics>
-            <characteristic name="Description" characteristicTypeId="21befb24-fc85-4f52-a745-64b2e48f8228" value="Add 1 to this model&apos;s Attacks characteristic if it is equipped with two melee weapons."/>
+            <characteristic name="Description" characteristicTypeId="21befb24-fc85-4f52-a745-64b2e48f8228" value="Add 1 to this model&apos;s Attacks characteristic if it is equipped with two melee weapons. This extra attack has been added to its profile."/>
           </characteristics>
         </profile>
       </profiles>
-      <rules>
-        <rule id="14a6-e40d-31fb-7010" name="Explodes" hidden="false">
+      <rules/>
+      <infoLinks>
+        <infoLink id="e4fe-c10e-22f9-8378" name="Explodes" hidden="false" targetId="9446-1148-da70-4028" type="profile">
           <profiles/>
           <rules/>
           <infoLinks/>
           <modifiers/>
-          <description>If this model is reduced to 0 wounds, roll a D6 before removing the model from the battlefield; on a 6 is explodes, and each unit within 3&quot; suffers D3 MW.</description>
-        </rule>
-      </rules>
-      <infoLinks/>
+        </infoLink>
+      </infoLinks>
       <modifiers/>
       <constraints/>
       <categoryLinks>
@@ -5587,7 +5624,10 @@
           <rules/>
           <infoLinks/>
           <modifiers/>
-          <constraints/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a65b-1f5b-dbe8-5a5f" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bbd8-2194-6984-9469" type="min"/>
+          </constraints>
           <categoryLinks/>
         </entryLink>
       </entryLinks>
@@ -5927,7 +5967,10 @@
           <rules/>
           <infoLinks/>
           <modifiers/>
-          <constraints/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f7a5-f5d8-0541-8dbc" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ff92-3edb-328b-95ee" type="min"/>
+          </constraints>
           <categoryLinks/>
         </entryLink>
         <entryLink id="8bf0-7cd1-5502-5319" name="Blight Grenades" hidden="false" targetId="922e-5c7d-e439-842b" type="selectionEntry">
@@ -5935,7 +5978,10 @@
           <rules/>
           <infoLinks/>
           <modifiers/>
-          <constraints/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3473-a1f7-212f-78c4" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="93ed-7cd0-e0da-ed2b" type="min"/>
+          </constraints>
           <categoryLinks/>
         </entryLink>
         <entryLink id="fed4-d88a-e3c0-7a6f" name="Krak grenade" hidden="false" targetId="0f23-cd69-d106-371e" type="selectionEntry">
@@ -5967,7 +6013,25 @@
       </costs>
     </selectionEntry>
     <selectionEntry id="605b-3c14-2a67-f8e4" name="Chaos Cultists" page="" hidden="false" collective="false" type="unit">
-      <profiles/>
+      <profiles>
+        <profile id="81c5-c341-84c1-b0ac" name="Chaos Cultist" hidden="false" profileTypeId="800f-21d0-4387-c943" profileTypeName="Unit">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="M" characteristicTypeId="0bdf-a96e-9e38-7779" value="6&quot;"/>
+            <characteristic name="WS" characteristicTypeId="e7f0-1278-0250-df0c" value="4+"/>
+            <characteristic name="BS" characteristicTypeId="381b-eb28-74c3-df5f" value="4+"/>
+            <characteristic name="S" characteristicTypeId="2218-aa3c-265f-2939" value="3"/>
+            <characteristic name="T" characteristicTypeId="9c9f-9774-a358-3a39" value="3"/>
+            <characteristic name="W" characteristicTypeId="f330-5e6e-4110-0978" value="1"/>
+            <characteristic name="A" characteristicTypeId="13fc-b29b-31f2-ab9f" value="1"/>
+            <characteristic name="Ld" characteristicTypeId="00ca-f8b8-876d-b705" value="5"/>
+            <characteristic name="Save" characteristicTypeId="c0df-df94-abd7-e8d3" value="6+"/>
+          </characteristics>
+        </profile>
+      </profiles>
       <rules/>
       <infoLinks/>
       <modifiers>
@@ -6062,7 +6126,7 @@
           <categoryLinks/>
           <selectionEntries/>
           <selectionEntryGroups>
-            <selectionEntryGroup id="7b1e-3784-730c-1224" name="Autogun options" hidden="false" collective="false">
+            <selectionEntryGroup id="7b1e-3784-730c-1224" name="Autogun options" hidden="false" collective="false" defaultSelectionEntryId="ca8d-5feb-8bfd-9777">
               <profiles/>
               <rules/>
               <infoLinks/>
@@ -6138,137 +6202,190 @@
             <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="0.0"/>
           </costs>
         </selectionEntry>
-        <selectionEntry id="1272-7156-c850-4ddf" name="Chaos Cultist" hidden="false" collective="false" type="model">
-          <profiles>
-            <profile id="9780-e097-785f-250f" name="Chaos Cultist" hidden="false" profileTypeId="800f-21d0-4387-c943" profileTypeName="Unit">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <characteristics>
-                <characteristic name="M" characteristicTypeId="0bdf-a96e-9e38-7779" value="6&quot;"/>
-                <characteristic name="WS" characteristicTypeId="e7f0-1278-0250-df0c" value="4+"/>
-                <characteristic name="BS" characteristicTypeId="381b-eb28-74c3-df5f" value="4+"/>
-                <characteristic name="S" characteristicTypeId="2218-aa3c-265f-2939" value="3"/>
-                <characteristic name="T" characteristicTypeId="9c9f-9774-a358-3a39" value="3"/>
-                <characteristic name="W" characteristicTypeId="f330-5e6e-4110-0978" value="1"/>
-                <characteristic name="A" characteristicTypeId="13fc-b29b-31f2-ab9f" value="1"/>
-                <characteristic name="Ld" characteristicTypeId="00ca-f8b8-876d-b705" value="5"/>
-                <characteristic name="Save" characteristicTypeId="c0df-df94-abd7-e8d3" value="6+"/>
-              </characteristics>
-            </profile>
-          </profiles>
+      </selectionEntries>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="2321-2cbb-4da2-fcbe" name="Cultists" hidden="false" collective="false" defaultSelectionEntryId="1d7d-fd1a-264d-0691">
+          <profiles/>
           <rules/>
           <infoLinks/>
           <modifiers/>
           <constraints>
-            <constraint field="selections" scope="parent" value="9.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="af3a-4adc-f9cc-6b0b" type="min"/>
-            <constraint field="selections" scope="parent" value="39.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="56f0-34e0-af5b-c86a" type="max"/>
+            <constraint field="selections" scope="parent" value="39.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f368-e3e5-92c0-3e56" type="max"/>
+            <constraint field="selections" scope="parent" value="9.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="abc6-95e5-4d34-76dd" type="min"/>
           </constraints>
           <categoryLinks/>
           <selectionEntries>
-            <selectionEntry id="0317-a9b0-e3e7-02be" name="Autogun" hidden="false" collective="true" type="upgrade">
+            <selectionEntry id="4c67-ed33-d92a-7a53" name="Chaos Cultist w/ special weapon" hidden="false" collective="false" type="upgrade">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers>
+                <modifier type="increment" field="67fb-9b07-883c-25e3" value="1">
+                  <repeats>
+                    <repeat field="selections" scope="605b-3c14-2a67-f8e4" value="10.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="model" repeats="1" roundUp="false"/>
+                  </repeats>
+                  <conditions/>
+                  <conditionGroups/>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="67fb-9b07-883c-25e3" type="max"/>
+              </constraints>
+              <categoryLinks/>
+              <selectionEntries/>
+              <selectionEntryGroups>
+                <selectionEntryGroup id="2944-de80-7f3f-5758" name="Weapon option" hidden="false" collective="false">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="806a-2609-13e6-ce1b" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5e67-8479-a6c3-1fb8" type="min"/>
+                  </constraints>
+                  <categoryLinks/>
+                  <selectionEntries/>
+                  <selectionEntryGroups/>
+                  <entryLinks>
+                    <entryLink id="1893-4379-67e3-7765" name="Flamer" hidden="false" targetId="fd22-6743-2d4c-dd62" type="selectionEntry">
+                      <profiles/>
+                      <rules/>
+                      <infoLinks/>
+                      <modifiers/>
+                      <constraints/>
+                      <categoryLinks/>
+                    </entryLink>
+                    <entryLink id="6ec7-2b94-02c6-5890" name="Heavy stubber" hidden="false" targetId="cfa3-5fcd-af10-5520" type="selectionEntry">
+                      <profiles/>
+                      <rules/>
+                      <infoLinks/>
+                      <modifiers/>
+                      <constraints/>
+                      <categoryLinks/>
+                    </entryLink>
+                  </entryLinks>
+                </selectionEntryGroup>
+              </selectionEntryGroups>
+              <entryLinks/>
+              <costs>
+                <cost name="pts" costTypeId="points" value="5.0"/>
+                <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="1d7d-fd1a-264d-0691" name="Chaos Cultist w/ autopistol and brutal assault weapon" hidden="false" collective="false" type="model">
+              <profiles>
+                <profile id="2910-f488-0eb2-b32c" name="Chaos Cultist w/ Brutal assault weapon" hidden="false" profileTypeId="800f-21d0-4387-c943" profileTypeName="Unit">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <characteristics>
+                    <characteristic name="M" characteristicTypeId="0bdf-a96e-9e38-7779" value="6&quot;"/>
+                    <characteristic name="WS" characteristicTypeId="e7f0-1278-0250-df0c" value="4+"/>
+                    <characteristic name="BS" characteristicTypeId="381b-eb28-74c3-df5f" value="4+"/>
+                    <characteristic name="S" characteristicTypeId="2218-aa3c-265f-2939" value="3"/>
+                    <characteristic name="T" characteristicTypeId="9c9f-9774-a358-3a39" value="3"/>
+                    <characteristic name="W" characteristicTypeId="f330-5e6e-4110-0978" value="1"/>
+                    <characteristic name="A" characteristicTypeId="13fc-b29b-31f2-ab9f" value="2"/>
+                    <characteristic name="Ld" characteristicTypeId="00ca-f8b8-876d-b705" value="5"/>
+                    <characteristic name="Save" characteristicTypeId="c0df-df94-abd7-e8d3" value="6+"/>
+                  </characteristics>
+                </profile>
+              </profiles>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+              <categoryLinks/>
+              <selectionEntries>
+                <selectionEntry id="1266-4f55-36a1-c982" name="Autopistol" hidden="false" collective="true" type="upgrade">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks>
+                    <infoLink id="3577-6ba6-b9c3-e6ac" name="Autopistol" hidden="false" targetId="2481-001b-00f9-501b" type="profile">
+                      <profiles/>
+                      <rules/>
+                      <infoLinks/>
+                      <modifiers/>
+                    </infoLink>
+                  </infoLinks>
+                  <modifiers/>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a25b-f3c6-9a84-9bd3" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a740-46e3-66ad-6a5e" type="min"/>
+                  </constraints>
+                  <categoryLinks/>
+                  <selectionEntries/>
+                  <selectionEntryGroups/>
+                  <entryLinks/>
+                  <costs>
+                    <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="0.0"/>
+                    <cost name="pts" costTypeId="points" value="0.0"/>
+                  </costs>
+                </selectionEntry>
+              </selectionEntries>
+              <selectionEntryGroups/>
+              <entryLinks>
+                <entryLink id="f7d8-0867-c740-7925" name="Brutal assault weapon" hidden="false" targetId="b26c-9e69-51a0-2fbf" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="432d-0fa9-879f-ec64" type="min"/>
+                  </constraints>
+                  <categoryLinks/>
+                </entryLink>
+              </entryLinks>
+              <costs>
+                <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="0.0"/>
+                <cost name="pts" costTypeId="points" value="5.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="1dd1-500a-fb2a-2942" name="Chaos Cultist w/ Autogun" hidden="false" collective="false" type="model">
               <profiles/>
               <rules/>
               <infoLinks/>
               <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3b3f-9562-0c64-c18d" type="min"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ed5b-9fb7-3eb8-ccba" type="max"/>
-              </constraints>
+              <constraints/>
               <categoryLinks/>
-              <selectionEntries/>
+              <selectionEntries>
+                <selectionEntry id="526d-46db-4ecf-6b9f" name="Autogun" hidden="false" collective="true" type="upgrade">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks>
+                    <infoLink id="f7c3-e621-fa6f-31b5" name="New InfoLink" hidden="false" targetId="fcde-3e6a-e240-1157" type="profile">
+                      <profiles/>
+                      <rules/>
+                      <infoLinks/>
+                      <modifiers/>
+                    </infoLink>
+                  </infoLinks>
+                  <modifiers/>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="87ab-428e-e445-0f04" type="min"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b0bd-c50a-dae4-5f96" type="max"/>
+                  </constraints>
+                  <categoryLinks/>
+                  <selectionEntries/>
+                  <selectionEntryGroups/>
+                  <entryLinks/>
+                  <costs>
+                    <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="0.0"/>
+                    <cost name="pts" costTypeId="points" value="0.0"/>
+                  </costs>
+                </selectionEntry>
+              </selectionEntries>
               <selectionEntryGroups/>
               <entryLinks/>
               <costs>
                 <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="0.0"/>
-                <cost name="pts" costTypeId="points" value="0.0"/>
+                <cost name="pts" costTypeId="points" value="5.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
           <selectionEntryGroups/>
           <entryLinks/>
-          <costs>
-            <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="0.0"/>
-            <cost name="pts" costTypeId="points" value="5.0"/>
-          </costs>
-        </selectionEntry>
-        <selectionEntry id="7701-5999-9a60-826a" name="Replace autogun with autopistol and brutal assault weapon" hidden="false" collective="false" type="upgrade">
-          <profiles>
-            <profile id="281c-8fb6-c94b-e6cf" name="Brutal assault weapon" hidden="false" profileTypeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" profileTypeName="Weapon">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <characteristics>
-                <characteristic name="Range" characteristicTypeId="6fa97fa8-ea74-4a27-a0fb-bc4e5f367464" value="Melee"/>
-                <characteristic name="Type" characteristicTypeId="077c342f-d7b9-45c6-b8af-88e97cafd3a2" value="Melee"/>
-                <characteristic name="S" characteristicTypeId="59b1-319e-ec13-d466" value="User"/>
-                <characteristic name="AP" characteristicTypeId="75aa-a838-b675-6484" value="0"/>
-                <characteristic name="D" characteristicTypeId="ae8a-3137-d65b-4ca7" value="1"/>
-                <characteristic name="Abilities" characteristicTypeId="837d-5e63-aeb7-1410" value="Each time the bearer fights, it can make 1 additional attack with this weapon."/>
-              </characteristics>
-            </profile>
-          </profiles>
-          <rules/>
-          <infoLinks>
-            <infoLink id="4657-a7b1-0fd4-7e0b" name="New InfoLink" hidden="false" targetId="fcde-3e6a-e240-1157" type="profile">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-            </infoLink>
-          </infoLinks>
-          <modifiers/>
-          <constraints/>
-          <categoryLinks/>
-          <selectionEntries/>
-          <selectionEntryGroups/>
-          <entryLinks/>
-          <costs>
-            <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="0.0"/>
-            <cost name="pts" costTypeId="points" value="0.0"/>
-          </costs>
-        </selectionEntry>
-      </selectionEntries>
-      <selectionEntryGroups>
-        <selectionEntryGroup id="b8bb-47f8-5a06-053d" name="Special weapon" hidden="false" collective="false">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers>
-            <modifier type="increment" field="70c1-652f-c4d2-ae65" value="1">
-              <repeats>
-                <repeat field="selections" scope="parent" value="10.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="model" repeats="1" roundUp="true"/>
-              </repeats>
-              <conditions/>
-              <conditionGroups/>
-            </modifier>
-          </modifiers>
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="70c1-652f-c4d2-ae65" type="max"/>
-          </constraints>
-          <categoryLinks/>
-          <selectionEntries/>
-          <selectionEntryGroups/>
-          <entryLinks>
-            <entryLink id="2699-a726-b3e2-3173" name="Heavy stubber" hidden="false" targetId="cfa3-5fcd-af10-5520" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints/>
-              <categoryLinks/>
-            </entryLink>
-            <entryLink id="eb32-ead3-325e-6d64" name="Flamer" hidden="false" targetId="fd22-6743-2d4c-dd62" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints/>
-              <categoryLinks/>
-            </entryLink>
-          </entryLinks>
         </selectionEntryGroup>
       </selectionEntryGroups>
       <entryLinks/>
@@ -7193,6 +7310,30 @@
         <cost name="pts" costTypeId="points" value="0.0"/>
       </costs>
     </selectionEntry>
+    <selectionEntry id="b26c-9e69-51a0-2fbf" name="Brutal assault weapon" hidden="false" collective="true" type="upgrade">
+      <profiles/>
+      <rules/>
+      <infoLinks>
+        <infoLink id="db6b-6b5a-0ae4-0b97" name="Brutal assault weapon" hidden="false" targetId="df9c-41ec-8b5e-b19c" type="profile">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bad0-98ad-dced-8edf" type="max"/>
+      </constraints>
+      <categoryLinks/>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="0.0"/>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
   </sharedSelectionEntries>
   <sharedSelectionEntryGroups>
     <selectionEntryGroup id="1912-576e-6a2b-5c6e" name="Champion Equipment" hidden="false" collective="false" defaultSelectionEntryId="fdb4-16ca-f677-e192">
@@ -7380,7 +7521,7 @@
       <infoLinks/>
       <modifiers/>
       <constraints>
-        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ab85-5973-ed13-106a" type="max"/>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="ab85-5973-ed13-106a" type="max"/>
       </constraints>
       <categoryLinks/>
       <selectionEntries/>
@@ -7410,7 +7551,7 @@
       <infoLinks/>
       <modifiers/>
       <constraints>
-        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d64f-a953-8bc4-0da2" type="max"/>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="d64f-a953-8bc4-0da2" type="max"/>
       </constraints>
       <categoryLinks/>
       <selectionEntries/>
@@ -8192,6 +8333,20 @@
       <modifiers/>
       <characteristics>
         <characteristic name="Description" characteristicTypeId="21befb24-fc85-4f52-a745-64b2e48f8228" value="When this model Advances, add 6&quot; to its Move characteristic for that Movement phase instead of rolling a dice."/>
+      </characteristics>
+    </profile>
+    <profile id="df9c-41ec-8b5e-b19c" name="Brutal assault weapon" hidden="false" profileTypeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" profileTypeName="Weapon">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <characteristics>
+        <characteristic name="Range" characteristicTypeId="6fa97fa8-ea74-4a27-a0fb-bc4e5f367464" value="Melee"/>
+        <characteristic name="Type" characteristicTypeId="077c342f-d7b9-45c6-b8af-88e97cafd3a2" value="Melee"/>
+        <characteristic name="S" characteristicTypeId="59b1-319e-ec13-d466" value="User"/>
+        <characteristic name="AP" characteristicTypeId="75aa-a838-b675-6484" value="0"/>
+        <characteristic name="D" characteristicTypeId="ae8a-3137-d65b-4ca7" value="1"/>
+        <characteristic name="Abilities" characteristicTypeId="837d-5e63-aeb7-1410" value="Each time the bearer fights, it can make 1 additional attack with this weapon. This extra attack is included in its profile."/>
       </characteristics>
     </profile>
   </sharedProfiles>


### PR DESCRIPTION
Fixes for #906 
- Chaos Lords can now take 2 pistols.
- Cultists reimplemented, copied from Chaos Space Marines
- Missing constraints for grenades and Smite fixed on various units.
- Helbrute auto-increment of attacks if two melee weapons.