### PR TITLE
Chaos Fixes

### DIFF
--- a/Chaos - Chaos Space Marines.cat
+++ b/Chaos - Chaos Space Marines.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="cb54-c035-5759-7697" name="Chaos - Chaos Space Marines" book="" revision="18" battleScribeVersion="2.01" authorName="BSData team" authorUrl="http://battlescribedata.appspot.com/#/repo/wh40k" gameSystemId="28ec-711c-d87f-3aeb" gameSystemRevision="1" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="cb54-c035-5759-7697" name="Chaos - Chaos Space Marines" book="" revision="19" battleScribeVersion="2.01" authorName="BSData team" authorUrl="http://battlescribedata.appspot.com/#/repo/wh40k" gameSystemId="28ec-711c-d87f-3aeb" gameSystemRevision="1" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <profiles/>
   <rules/>
   <infoLinks/>
@@ -2978,18 +2978,6 @@
             <characteristic name="Save" characteristicTypeId="c0df-df94-abd7-e8d3" value="3+"/>
           </characteristics>
         </profile>
-        <profile id="8a1f-70a2-8d85-8fec" name="Daemon Prince" hidden="false" profileTypeId="bc97-dea9-9e88-bb7d" profileTypeName="Psyker">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <characteristics>
-            <characteristic name="Cast" characteristicTypeId="5afb-9914-904b-d3b3" value="1"/>
-            <characteristic name="Deny" characteristicTypeId="b5ac-9c20-5d5a-6f9b" value="1"/>
-            <characteristic name="Powers Known" characteristicTypeId="69d7-b45e-00a2-7e46" value="Smite and one power from the Dark Hereticus discipline"/>
-            <characteristic name="Other" characteristicTypeId="c2e2-f115-0003-5d7b" value=""/>
-          </characteristics>
-        </profile>
       </profiles>
       <rules/>
       <infoLinks>
@@ -3696,14 +3684,14 @@
           <infoLinks/>
           <modifiers/>
           <characteristics>
-            <characteristic name="M" characteristicTypeId="0bdf-a96e-9e38-7779" value="4"/>
-            <characteristic name="WS" characteristicTypeId="e7f0-1278-0250-df0c" value="5"/>
-            <characteristic name="BS" characteristicTypeId="381b-eb28-74c3-df5f" value="4"/>
+            <characteristic name="M" characteristicTypeId="0bdf-a96e-9e38-7779" value="6&quot;"/>
+            <characteristic name="WS" characteristicTypeId="e7f0-1278-0250-df0c" value="2+"/>
+            <characteristic name="BS" characteristicTypeId="381b-eb28-74c3-df5f" value="3+"/>
             <characteristic name="S" characteristicTypeId="2218-aa3c-265f-2939" value="5"/>
             <characteristic name="T" characteristicTypeId="9c9f-9774-a358-3a39" value="4"/>
-            <characteristic name="W" characteristicTypeId="f330-5e6e-4110-0978" value="3"/>
-            <characteristic name="A" characteristicTypeId="13fc-b29b-31f2-ab9f" value="5"/>
-            <characteristic name="Ld" characteristicTypeId="00ca-f8b8-876d-b705" value="10"/>
+            <characteristic name="W" characteristicTypeId="f330-5e6e-4110-0978" value="5"/>
+            <characteristic name="A" characteristicTypeId="13fc-b29b-31f2-ab9f" value="6"/>
+            <characteristic name="Ld" characteristicTypeId="00ca-f8b8-876d-b705" value="9"/>
             <characteristic name="Save" characteristicTypeId="c0df-df94-abd7-e8d3" value="3+"/>
           </characteristics>
         </profile>
@@ -3722,7 +3710,7 @@
           <infoLinks/>
           <modifiers/>
           <characteristics>
-            <characteristic name="Description" characteristicTypeId="21befb24-fc85-4f52-a745-64b2e48f8228" value="Fabius Bile can enhance one unit of HERETIC ASTARTES INFANTRY (but not CHARACTERS, they refuse the dubious honour of Bile&apos;s gifts) that is within 1&quot; of him at the end of any Movement phase. Roll a D6 for each model in the unit; the unit suffers 1 mortal wound for each roll of 6 (only the strong survive Bile&apos;s experimental cocktails). Then roll a D3 and refer to the table below to see what bonus the survivors gain for the rest of the battle. A unit can only be enhanced once per game.  D3   Bonus 1    Swollen Musculature: +1 S 2    Calcific Growths: +1 T 3    Berserk Rage: +1 A"/>
+            <characteristic name="Description" characteristicTypeId="21befb24-fc85-4f52-a745-64b2e48f8228" value="Fabius Bile can enhance one unit of HERETIC ASTARTES INFANTRY (but not CHARACTERS, they refuse the dubious honour of Bile&apos;s gifts) that is within 1&quot; of him at the end of any Movement phase. Roll a D6 for each model in the unit; the unit suffers 1 mortal wound for each roll of 6 (only the strong survive Bile&apos;s experimental cocktails). Then roll a D3 and refer to the table below to see what bonus the survivors gain for the rest of the battle. A unit can only be enhanced once per game."/>
           </characteristics>
         </profile>
         <profile id="e74a-22a1-3f58-e7b1" name="Enhanced Warriors 1" hidden="false" profileTypeId="ecda-13fc-b1ec-ed87" profileTypeName="Enhanced Warriors">
@@ -5082,10 +5070,7 @@
                   <rules/>
                   <infoLinks/>
                   <modifiers/>
-                  <constraints>
-                    <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="477c-ad3c-d240-b6ba" type="max"/>
-                    <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ea08-8873-f9fd-94be" type="min"/>
-                  </constraints>
+                  <constraints/>
                   <categoryLinks/>
                 </entryLink>
               </entryLinks>
@@ -5173,7 +5158,7 @@
                 <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="0.0"/>
               </costs>
             </selectionEntry>
-            <selectionEntry id="db90-1a14-c826-6789" name="Berserker w/ plasma pistol" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="db90-1a14-c826-6789" name="Berserker w/ plasma pistol" hidden="false" collective="false" type="model">
               <profiles/>
               <rules/>
               <infoLinks/>
@@ -9192,18 +9177,6 @@
             <characteristic name="A" characteristicTypeId="13fc-b29b-31f2-ab9f" value="4"/>
             <characteristic name="Ld" characteristicTypeId="00ca-f8b8-876d-b705" value="10"/>
             <characteristic name="Save" characteristicTypeId="c0df-df94-abd7-e8d3" value="3+"/>
-          </characteristics>
-        </profile>
-        <profile id="4aed-f996-db96-6d4d" name="Daemon Prince" hidden="false" profileTypeId="bc97-dea9-9e88-bb7d" profileTypeName="Psyker">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <characteristics>
-            <characteristic name="Cast" characteristicTypeId="5afb-9914-904b-d3b3" value="1"/>
-            <characteristic name="Deny" characteristicTypeId="b5ac-9c20-5d5a-6f9b" value="1"/>
-            <characteristic name="Powers Known" characteristicTypeId="69d7-b45e-00a2-7e46" value="Smite and one power from the Dark Hereticus discipline"/>
-            <characteristic name="Other" characteristicTypeId="c2e2-f115-0003-5d7b" value=""/>
           </characteristics>
         </profile>
       </profiles>
@@ -18179,7 +18152,7 @@
               <characteristics>
                 <characteristic name="Cast" characteristicTypeId="5afb-9914-904b-d3b3" value="1"/>
                 <characteristic name="Deny" characteristicTypeId="b5ac-9c20-5d5a-6f9b" value="1"/>
-                <characteristic name="Powers Known" characteristicTypeId="69d7-b45e-00a2-7e46" value="Smite and one power from the Nurgle discipline"/>
+                <characteristic name="Powers Known" characteristicTypeId="69d7-b45e-00a2-7e46" value="Smite and one power from the Dark Hereticus discipline"/>
                 <characteristic name="Other" characteristicTypeId="c2e2-f115-0003-5d7b"/>
               </characteristics>
             </profile>
@@ -18290,7 +18263,7 @@
               <characteristics>
                 <characteristic name="Cast" characteristicTypeId="5afb-9914-904b-d3b3" value="1"/>
                 <characteristic name="Deny" characteristicTypeId="b5ac-9c20-5d5a-6f9b" value="1"/>
-                <characteristic name="Powers Known" characteristicTypeId="69d7-b45e-00a2-7e46" value="Smite and one power from the Slaanesh discipline"/>
+                <characteristic name="Powers Known" characteristicTypeId="69d7-b45e-00a2-7e46" value="Smite and one power from the Dark Hereticus discipline"/>
                 <characteristic name="Other" characteristicTypeId="c2e2-f115-0003-5d7b"/>
               </characteristics>
             </profile>
@@ -18397,7 +18370,7 @@
               <characteristics>
                 <characteristic name="Cast" characteristicTypeId="5afb-9914-904b-d3b3" value="1"/>
                 <characteristic name="Deny" characteristicTypeId="b5ac-9c20-5d5a-6f9b" value="1"/>
-                <characteristic name="Powers Known" characteristicTypeId="69d7-b45e-00a2-7e46" value="Smite and one power from the Tzeentch discipline"/>
+                <characteristic name="Powers Known" characteristicTypeId="69d7-b45e-00a2-7e46" value="Smite and one power from the Dark Hereticus discipline"/>
                 <characteristic name="Other" characteristicTypeId="c2e2-f115-0003-5d7b"/>
               </characteristics>
             </profile>

--- a/Chaos - Daemons.cat
+++ b/Chaos - Daemons.cat
@@ -7429,16 +7429,7 @@
         </selectionEntry>
       </selectionEntries>
       <selectionEntryGroups/>
-      <entryLinks>
-        <entryLink id="3dc8-09d0-3dba-d9e9" name="Staff of Change" hidden="false" targetId="6658-f055-1198-176e" type="selectionEntry">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints/>
-          <categoryLinks/>
-        </entryLink>
-      </entryLinks>
+      <entryLinks/>
       <costs>
         <cost name="pts" costTypeId="points" value="98.0"/>
         <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="5.0"/>

--- a/Chaos - FW Heretic Astartes.cat
+++ b/Chaos - FW Heretic Astartes.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="2128-f196-8f1c-b352" name="Chaos - FW Heretic Astartes" revision="5" battleScribeVersion="2.01" gameSystemId="28ec-711c-d87f-3aeb" gameSystemRevision="1" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="2128-f196-8f1c-b352" name="Chaos - FW Heretic Astartes" revision="6" battleScribeVersion="2.01" gameSystemId="28ec-711c-d87f-3aeb" gameSystemRevision="1" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <profiles/>
   <rules/>
   <infoLinks/>
@@ -1994,10 +1994,10 @@
           <characteristics>
             <characteristic name="Range" characteristicTypeId="6fa97fa8-ea74-4a27-a0fb-bc4e5f367464" value="36&quot;"/>
             <characteristic name="Type" characteristicTypeId="077c342f-d7b9-45c6-b8af-88e97cafd3a2" value="Heavy 4"/>
-            <characteristic name="S" characteristicTypeId="59b1-319e-ec13-d466" value=""/>
+            <characteristic name="S" characteristicTypeId="59b1-319e-ec13-d466" value="8"/>
             <characteristic name="AP" characteristicTypeId="75aa-a838-b675-6484" value="-1"/>
             <characteristic name="D" characteristicTypeId="ae8a-3137-d65b-4ca7" value="2"/>
-            <characteristic name="Abilities" characteristicTypeId="837d-5e63-aeb7-1410" value="if a unit has any models slain by any butcher cannon in the Shooting phase, the unit must subtract 2 from its Ld for the rest of the turn. This modifier is not cumulative."/>
+            <characteristic name="Abilities" characteristicTypeId="837d-5e63-aeb7-1410" value="If a unit has any models slain by this weapon in the Shooting phase, the unit must subtract 2 from its Leadership for the rest of the turn. This modifier is not cumulative."/>
           </characteristics>
         </profile>
       </profiles>
@@ -4205,6 +4205,17 @@
           </constraints>
           <categoryLinks/>
         </entryLink>
+        <entryLink id="43fa-703f-0544-a0c6" name="Infernal hunger" hidden="false" targetId="c040-43db-512e-6620" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6523-61ac-c51f-ef38" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fce9-6827-cf1f-d7c5" type="min"/>
+          </constraints>
+          <categoryLinks/>
+        </entryLink>
       </entryLinks>
       <costs>
         <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="12.0"/>
@@ -5551,7 +5562,7 @@
             <characteristic name="S" characteristicTypeId="59b1-319e-ec13-d466" value="8"/>
             <characteristic name="AP" characteristicTypeId="75aa-a838-b675-6484" value="-1"/>
             <characteristic name="D" characteristicTypeId="ae8a-3137-d65b-4ca7" value="2"/>
-            <characteristic name="Abilities" characteristicTypeId="837d-5e63-aeb7-1410" value="If a unit has any models slain by any butcher cannon in the Shooting phase, the unit subtracts 2 from its Ld for the rest of the turn. This modifier is not cumulative."/>
+            <characteristic name="Abilities" characteristicTypeId="837d-5e63-aeb7-1410" value="If a unit has any models slain bythis weapon in the Shooting phase, the unit subtracts 2 from its Leadership for the rest of the turn. This modifier is not cumulative"/>
           </characteristics>
         </profile>
       </profiles>
@@ -14333,7 +14344,10 @@
           <selectionEntries/>
           <selectionEntryGroups/>
           <entryLinks/>
-          <costs/>
+          <costs>
+            <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="0.0"/>
+            <cost name="pts" costTypeId="points" value="0.0"/>
+          </costs>
         </selectionEntry>
         <selectionEntry id="ca12-0f7f-200b-d442" name="Nurgle" hidden="false" collective="false" type="upgrade">
           <profiles/>
@@ -14345,7 +14359,10 @@
           <selectionEntries/>
           <selectionEntryGroups/>
           <entryLinks/>
-          <costs/>
+          <costs>
+            <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="0.0"/>
+            <cost name="pts" costTypeId="points" value="0.0"/>
+          </costs>
         </selectionEntry>
         <selectionEntry id="9142-b5d9-442a-bcb9" name="Slaanesh" hidden="false" collective="false" type="upgrade">
           <profiles/>
@@ -14357,7 +14374,10 @@
           <selectionEntries/>
           <selectionEntryGroups/>
           <entryLinks/>
-          <costs/>
+          <costs>
+            <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="0.0"/>
+            <cost name="pts" costTypeId="points" value="0.0"/>
+          </costs>
         </selectionEntry>
         <selectionEntry id="cd53-1b66-5a28-7e42" name="Tzeentch" hidden="false" collective="false" type="upgrade">
           <profiles/>
@@ -14369,7 +14389,10 @@
           <selectionEntries/>
           <selectionEntryGroups/>
           <entryLinks/>
-          <costs/>
+          <costs>
+            <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="0.0"/>
+            <cost name="pts" costTypeId="points" value="0.0"/>
+          </costs>
         </selectionEntry>
       </selectionEntries>
       <selectionEntryGroups/>


### PR DESCRIPTION
Fixes #966 - Added Infernal Hunger to Scorpius
Fixes #969 - Removed Staff of Change option
Fixes #972 - Corrected statline
Fixes #973 - Removed duplicate Psyker profile
Fixes #978 - Added Strength to Butcher cannon
Fixes #980 - FIxed Plasma zerker being an upgrade.