### PR TITLE
Chaos Fixes

### DIFF
--- a/Chaos - Chaos Space Marines.cat
+++ b/Chaos - Chaos Space Marines.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="cb54-c035-5759-7697" name="Chaos - Chaos Space Marines" book="" revision="19" battleScribeVersion="2.01" authorName="BSData team" authorUrl="http://battlescribedata.appspot.com/#/repo/wh40k" gameSystemId="28ec-711c-d87f-3aeb" gameSystemRevision="1" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="cb54-c035-5759-7697" name="Chaos - Chaos Space Marines" book="" revision="20" battleScribeVersion="2.01" authorName="BSData team" authorUrl="http://battlescribedata.appspot.com/#/repo/wh40k" gameSystemId="28ec-711c-d87f-3aeb" gameSystemRevision="1" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <profiles/>
   <rules/>
   <infoLinks/>
@@ -17090,7 +17090,7 @@
         </entryLink>
       </entryLinks>
     </selectionEntryGroup>
-    <selectionEntryGroup id="45e8-d3d1-105b-90a3" name="Mark of Chaos" hidden="false" collective="false">
+    <selectionEntryGroup id="45e8-d3d1-105b-90a3" name="Mark of Chaos" hidden="false" collective="false" defaultSelectionEntryId="dfe4-7311-dbd5-c9e1">
       <profiles/>
       <rules/>
       <infoLinks/>
@@ -17101,12 +17101,12 @@
       </constraints>
       <categoryLinks/>
       <selectionEntries>
-        <selectionEntry id="c919-21bc-48b7-0423" name="Khorne" hidden="false" collective="false" type="upgrade">
+        <selectionEntry id="c919-21bc-48b7-0423" name="Mark of Khorne" hidden="false" collective="false" type="upgrade">
           <profiles/>
           <rules/>
           <infoLinks/>
           <modifiers>
-            <modifier type="set" field="hidden" value="true">
+            <modifier type="set" field="2ba8-9f29-a5b3-cf0f" value="0">
               <repeats/>
               <conditions>
                 <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="60fa-a65e-c445-61d5" type="greaterThan"/>
@@ -17114,7 +17114,9 @@
               <conditionGroups/>
             </modifier>
           </modifiers>
-          <constraints/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2ba8-9f29-a5b3-cf0f" type="max"/>
+          </constraints>
           <categoryLinks>
             <categoryLink id="9abf-1e5d-c943-a32b" name="New CategoryLink" hidden="false" targetId="dfc5-aa04-9546-1b4c" primary="false">
               <profiles/>
@@ -17132,12 +17134,12 @@
             <cost name="pts" costTypeId="points" value="0.0"/>
           </costs>
         </selectionEntry>
-        <selectionEntry id="34a8-8285-a3c2-f4e6" name="Nurgle" hidden="false" collective="false" type="upgrade">
+        <selectionEntry id="34a8-8285-a3c2-f4e6" name="Mark of Nurgle" hidden="false" collective="false" type="upgrade">
           <profiles/>
           <rules/>
           <infoLinks/>
           <modifiers>
-            <modifier type="set" field="hidden" value="true">
+            <modifier type="set" field="4cd5-7999-3a9d-1cfe" value="0">
               <repeats/>
               <conditions/>
               <conditionGroups>
@@ -17151,7 +17153,9 @@
               </conditionGroups>
             </modifier>
           </modifiers>
-          <constraints/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4cd5-7999-3a9d-1cfe" type="max"/>
+          </constraints>
           <categoryLinks>
             <categoryLink id="3525-114e-c4b0-069c" name="New CategoryLink" hidden="false" targetId="dfc5-aa04-9546-1b4c" primary="false">
               <profiles/>
@@ -17169,12 +17173,12 @@
             <cost name="pts" costTypeId="points" value="0.0"/>
           </costs>
         </selectionEntry>
-        <selectionEntry id="57d0-d6cb-db5a-2142" name="Tzeentch" hidden="false" collective="false" type="upgrade">
+        <selectionEntry id="57d0-d6cb-db5a-2142" name="Mark of Tzeentch" hidden="false" collective="false" type="upgrade">
           <profiles/>
           <rules/>
           <infoLinks/>
           <modifiers>
-            <modifier type="set" field="hidden" value="true">
+            <modifier type="set" field="df71-95f8-e068-56ce" value="0">
               <repeats/>
               <conditions/>
               <conditionGroups>
@@ -17188,7 +17192,9 @@
               </conditionGroups>
             </modifier>
           </modifiers>
-          <constraints/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="df71-95f8-e068-56ce" type="max"/>
+          </constraints>
           <categoryLinks>
             <categoryLink id="004a-42f7-5b10-b1df" name="New CategoryLink" hidden="false" targetId="dfc5-aa04-9546-1b4c" primary="false">
               <profiles/>
@@ -17206,12 +17212,12 @@
             <cost name="pts" costTypeId="points" value="0.0"/>
           </costs>
         </selectionEntry>
-        <selectionEntry id="81f9-01f6-e82e-7eec" name="Slaanesh" hidden="false" collective="false" type="upgrade">
+        <selectionEntry id="81f9-01f6-e82e-7eec" name="Mark of Slaanesh" hidden="false" collective="false" type="upgrade">
           <profiles/>
           <rules/>
           <infoLinks/>
           <modifiers>
-            <modifier type="set" field="hidden" value="true">
+            <modifier type="set" field="b2af-7b7a-c24a-2ee1" value="0">
               <repeats/>
               <conditions>
                 <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ff7b-6430-03d4-ea70" type="greaterThan"/>
@@ -17219,7 +17225,9 @@
               <conditionGroups/>
             </modifier>
           </modifiers>
-          <constraints/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b2af-7b7a-c24a-2ee1" type="max"/>
+          </constraints>
           <categoryLinks>
             <categoryLink id="e351-ee58-8a97-ef08" name="New CategoryLink" hidden="false" targetId="dfc5-aa04-9546-1b4c" primary="false">
               <profiles/>
@@ -17242,7 +17250,7 @@
           <rules/>
           <infoLinks/>
           <modifiers>
-            <modifier type="set" field="hidden" value="true">
+            <modifier type="set" field="c65d-b587-b8bb-1a91" value="0">
               <repeats/>
               <conditions/>
               <conditionGroups>
@@ -17256,7 +17264,9 @@
               </conditionGroups>
             </modifier>
           </modifiers>
-          <constraints/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c65d-b587-b8bb-1a91" type="max"/>
+          </constraints>
           <categoryLinks/>
           <selectionEntries/>
           <selectionEntryGroups/>
@@ -18083,18 +18093,12 @@
               <infoLinks/>
               <modifiers/>
               <characteristics>
-                <characteristic name="Description" characteristicTypeId="21befb24-fc85-4f52-a745-64b2e48f8228" value="You can re-roll hit rolls of 1 made for friendly KHORNE DAEMON units within 6&quot;."/>
+                <characteristic name="Description" characteristicTypeId="21befb24-fc85-4f52-a745-64b2e48f8228" value="You can re-roll hit rolls of 1 made for friendly &lt;LEGION&gt; and  KHORNE DAEMON units within 6&quot;."/>
               </characteristics>
             </profile>
           </profiles>
           <rules/>
           <infoLinks>
-            <infoLink id="cbb3-90ff-01d6-ba15" name="Unstoppable Ferocity" hidden="false" targetId="0d99-a301-149f-4537" type="profile">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-            </infoLink>
             <infoLink id="d32f-d1c7-d8c2-1f2c" name="Might over Magic" hidden="false" targetId="95ad-c89a-501a-6c76" type="profile">
               <profiles/>
               <rules/>
@@ -18149,19 +18153,12 @@
               <infoLinks/>
               <modifiers/>
               <characteristics>
-                <characteristic name="Description" characteristicTypeId="21befb24-fc85-4f52-a745-64b2e48f8228" value="You can re-roll hit rolls of 1 made for friendly NURGLE DAEMON units within 6&quot;."/>
+                <characteristic name="Description" characteristicTypeId="21befb24-fc85-4f52-a745-64b2e48f8228" value="You can re-roll hit rolls of 1 made for friendly &lt;LEGION&gt; and NURGLE DAEMON units within 6&quot;."/>
               </characteristics>
             </profile>
           </profiles>
           <rules/>
-          <infoLinks>
-            <infoLink id="2e82-0d00-b031-38a9" name="Disgustingly Resilient" hidden="false" targetId="649e-7454-0be4-7a71" type="profile">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-            </infoLink>
-          </infoLinks>
+          <infoLinks/>
           <modifiers>
             <modifier type="set" field="hidden" value="true">
               <repeats/>
@@ -18260,19 +18257,12 @@
               <infoLinks/>
               <modifiers/>
               <characteristics>
-                <characteristic name="Description" characteristicTypeId="21befb24-fc85-4f52-a745-64b2e48f8228" value="You can re-roll hit rolls of 1 made for friendly SLAANESH DAEMON units within 6&quot;."/>
+                <characteristic name="Description" characteristicTypeId="21befb24-fc85-4f52-a745-64b2e48f8228" value="You can re-roll hit rolls of 1 made for friendly &lt;LEGION&gt; and SLAANESH DAEMON units within 6&quot;."/>
               </characteristics>
             </profile>
           </profiles>
           <rules/>
-          <infoLinks>
-            <infoLink id="fd84-f6d6-be29-8d86" name="Quicksilver Swiftness" hidden="false" targetId="b623-8135-5aa4-d13e" type="profile">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-            </infoLink>
-          </infoLinks>
+          <infoLinks/>
           <modifiers>
             <modifier type="set" field="hidden" value="true">
               <repeats/>
@@ -18367,19 +18357,12 @@
               <infoLinks/>
               <modifiers/>
               <characteristics>
-                <characteristic name="Description" characteristicTypeId="21befb24-fc85-4f52-a745-64b2e48f8228" value="You can re-roll hit rolls of 1 made for friendly TZEENTCH DAEMON units within 6&quot;."/>
+                <characteristic name="Description" characteristicTypeId="21befb24-fc85-4f52-a745-64b2e48f8228" value="You can re-roll hit rolls of 1 made for friendly &lt;LEGION&gt; and TZEENTCH DAEMON units within 6&quot;."/>
               </characteristics>
             </profile>
           </profiles>
           <rules/>
-          <infoLinks>
-            <infoLink id="dd4b-8439-5339-0ed0" name="Ephemeral Form" hidden="false" targetId="cb03-ddea-2ac5-9879" type="profile">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-            </infoLink>
-          </infoLinks>
+          <infoLinks/>
           <modifiers>
             <modifier type="set" field="hidden" value="true">
               <repeats/>

--- a/Chaos - Daemons.cat
+++ b/Chaos - Daemons.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="422a-a40e-3f7c-e8b3" name="Chaos - Daemons" book="Index: Chaos" revision="12" battleScribeVersion="2.01" authorName="BSData team" authorUrl="http://battlescribedata.appspot.com/#/repo/wh40k" gameSystemId="28ec-711c-d87f-3aeb" gameSystemRevision="1" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="422a-a40e-3f7c-e8b3" name="Chaos - Daemons" book="Index: Chaos" revision="13" battleScribeVersion="2.01" authorName="BSData team" authorUrl="http://battlescribedata.appspot.com/#/repo/wh40k" gameSystemId="28ec-711c-d87f-3aeb" gameSystemRevision="1" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <profiles/>
   <rules/>
   <infoLinks/>
@@ -15182,7 +15182,38 @@
           <constraints/>
         </categoryLink>
       </categoryLinks>
-      <selectionEntries/>
+      <selectionEntries>
+        <selectionEntry id="f90b-fb58-57a4-3e88" name="Churning fangs and claws" hidden="false" collective="false" type="upgrade">
+          <profiles>
+            <profile id="dd45-b20c-c885-3e8d" name="Churning fangs and claws" hidden="false" profileTypeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" profileTypeName="Weapon">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <characteristics>
+                <characteristic name="Range" characteristicTypeId="6fa97fa8-ea74-4a27-a0fb-bc4e5f367464" value="Melee"/>
+                <characteristic name="Type" characteristicTypeId="077c342f-d7b9-45c6-b8af-88e97cafd3a2" value="Melee"/>
+                <characteristic name="S" characteristicTypeId="59b1-319e-ec13-d466" value="User"/>
+                <characteristic name="AP" characteristicTypeId="75aa-a838-b675-6484" value="-1"/>
+                <characteristic name="D" characteristicTypeId="ae8a-3137-d65b-4ca7" value="D3"/>
+                <characteristic name="Abilities" characteristicTypeId="837d-5e63-aeb7-1410"/>
+              </characteristics>
+            </profile>
+          </profiles>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e2db-82f6-72f3-fff4" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="25f5-acb1-bfa5-ddb0" type="min"/>
+          </constraints>
+          <categoryLinks/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks/>
+          <costs/>
+        </selectionEntry>
+      </selectionEntries>
       <selectionEntryGroups/>
       <entryLinks>
         <entryLink id="a7e0-3814-40ba-df4a" name="Daemonic Allegiance" hidden="false" targetId="d7f7-3b26-0f3a-8e1e" type="selectionEntryGroup">


### PR DESCRIPTION
- Fixes #1017 - Corrected abilities for Daemon Princes
- Fixes #1012 - Giant Chaos Spawn now has a weapon
- Changed behaviour of Marks to use constraints instead of show/hide and set default to No Mark.