### PR TITLE
Fix Intercessor Auxiliary Grenade Launcher cost.

### DIFF
--- a/Imperium - Space Marines.cat
+++ b/Imperium - Space Marines.cat
@@ -8782,7 +8782,7 @@
       </entryLinks>
       <costs>
         <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="5.0"/>
-        <cost name="pts" costTypeId="points" value="0.0"/>
+        <cost name="pts" costTypeId="points" value="1.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="fde4-48fe-5b25-d8c3" name="Imperial Space Marine" hidden="false" collective="false" type="upgrade">


### PR DESCRIPTION
Per the SM Codex Errata (https://17890-presscdn-0-51-pagely.netdna-ssl.com/wp-content/uploads/2017/08/40K_8th_ed_Update_Codex_Space_Marines_ver_1.0.pdf) the cost of the Auxiliary Grenade Launcher is now 1 Point.