### PR TITLE
CSM Relic Validation

### DIFF
--- a/Chaos - Chaos Space Marines.cat
+++ b/Chaos - Chaos Space Marines.cat
@@ -7859,7 +7859,15 @@
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="eafb-bb02-f012-b602" type="max"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="84fe-d1f1-1850-804c" type="min"/>
           </constraints>
-          <categoryLinks/>
+          <categoryLinks>
+            <categoryLink id="b259-9204-8c12-7ec8" name="New CategoryLink" hidden="false" targetId="e691-aad7-d21c-1023" primary="false">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </categoryLink>
+          </categoryLinks>
         </entryLink>
         <entryLink id="8452-ce4b-8d4d-5116" name="Dark Hereticus discipline" hidden="false" targetId="0246-3399-3b88-44aa" type="selectionEntryGroup">
           <profiles/>
@@ -9917,7 +9925,15 @@
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0447-b343-9369-8889" type="max"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="084f-6084-b2dc-88be" type="min"/>
           </constraints>
-          <categoryLinks/>
+          <categoryLinks>
+            <categoryLink id="fc3e-0fad-3d0e-f44e" name="New CategoryLink" hidden="false" targetId="e691-aad7-d21c-1023" primary="false">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </categoryLink>
+          </categoryLinks>
         </entryLink>
         <entryLink id="57fe-e6bf-64e4-06e3" name="Dark Hereticus discipline" hidden="false" targetId="0246-3399-3b88-44aa" type="selectionEntryGroup">
           <profiles/>
@@ -10186,7 +10202,15 @@
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9f82-5fb1-9899-4e1f" type="max"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="319d-be07-d771-1627" type="min"/>
           </constraints>
-          <categoryLinks/>
+          <categoryLinks>
+            <categoryLink id="51d4-f2bc-606a-706e" name="New CategoryLink" hidden="false" targetId="e691-aad7-d21c-1023" primary="false">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </categoryLink>
+          </categoryLinks>
         </entryLink>
         <entryLink id="5cdb-36ef-5100-9389" name="Dark Hereticus discipline" hidden="false" targetId="0246-3399-3b88-44aa" type="selectionEntryGroup">
           <profiles/>
@@ -10487,7 +10511,15 @@
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="994c-072d-aad8-6036" type="max"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="54dd-9601-dad5-cadb" type="min"/>
           </constraints>
-          <categoryLinks/>
+          <categoryLinks>
+            <categoryLink id="8843-6d8d-893d-7085" name="New CategoryLink" hidden="false" targetId="e691-aad7-d21c-1023" primary="false">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </categoryLink>
+          </categoryLinks>
         </entryLink>
         <entryLink id="e242-6ad9-2692-73b5" name="Dark Hereticus discipline" hidden="false" targetId="0246-3399-3b88-44aa" type="selectionEntryGroup">
           <profiles/>
@@ -10765,7 +10797,15 @@
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2632-9309-7bb7-8b39" type="max"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1788-a3b3-7ff9-cfd5" type="min"/>
           </constraints>
-          <categoryLinks/>
+          <categoryLinks>
+            <categoryLink id="dcb2-0718-ec05-52be" name="New CategoryLink" hidden="false" targetId="e691-aad7-d21c-1023" primary="false">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </categoryLink>
+          </categoryLinks>
         </entryLink>
         <entryLink id="9128-250f-d855-99ca" name="Dark Hereticus discipline" hidden="false" targetId="0246-3399-3b88-44aa" type="selectionEntryGroup">
           <profiles/>
@@ -11049,7 +11089,15 @@
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1d1e-e8d8-9cad-e9e4" type="max"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f915-b163-a225-20d2" type="min"/>
           </constraints>
-          <categoryLinks/>
+          <categoryLinks>
+            <categoryLink id="dc1b-1cad-20e7-98ea" name="New CategoryLink" hidden="false" targetId="e691-aad7-d21c-1023" primary="false">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </categoryLink>
+          </categoryLinks>
         </entryLink>
         <entryLink id="dffd-33e0-bbe6-44db" name="Dark Hereticus discipline" hidden="false" targetId="0246-3399-3b88-44aa" type="selectionEntryGroup">
           <profiles/>
@@ -11308,7 +11356,15 @@
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0200-dc09-4ba4-027e" type="max"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8238-92c7-ebc3-b8ae" type="min"/>
           </constraints>
-          <categoryLinks/>
+          <categoryLinks>
+            <categoryLink id="bd2b-05a6-a740-74d7" name="New CategoryLink" hidden="false" targetId="e691-aad7-d21c-1023" primary="false">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </categoryLink>
+          </categoryLinks>
         </entryLink>
         <entryLink id="2fdd-a246-3db7-cccd" name="Dark Hereticus discipline" hidden="false" targetId="0246-3399-3b88-44aa" type="selectionEntryGroup">
           <profiles/>
@@ -16950,7 +17006,15 @@
       </profiles>
       <rules/>
       <infoLinks/>
-      <modifiers/>
+      <modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <repeats/>
+          <conditions>
+            <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3292-34e6-f679-d5b9" type="equalTo"/>
+          </conditions>
+          <conditionGroups/>
+        </modifier>
+      </modifiers>
       <constraints/>
       <categoryLinks/>
       <selectionEntries/>
@@ -17039,7 +17103,15 @@
       </profiles>
       <rules/>
       <infoLinks/>
-      <modifiers/>
+      <modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <repeats/>
+          <conditions>
+            <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="bc9e-551d-9afb-78d5" type="equalTo"/>
+          </conditions>
+          <conditionGroups/>
+        </modifier>
+      </modifiers>
       <constraints/>
       <categoryLinks/>
       <selectionEntries/>
@@ -17103,7 +17175,15 @@
       </profiles>
       <rules/>
       <infoLinks/>
-      <modifiers/>
+      <modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <repeats/>
+          <conditions>
+            <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="6ea7-1195-7144-438e" type="equalTo"/>
+          </conditions>
+          <conditionGroups/>
+        </modifier>
+      </modifiers>
       <constraints/>
       <categoryLinks/>
       <selectionEntries/>
@@ -17167,7 +17247,15 @@
       </profiles>
       <rules/>
       <infoLinks/>
-      <modifiers/>
+      <modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <repeats/>
+          <conditions>
+            <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="bc9e-551d-9afb-78d5" type="equalTo"/>
+          </conditions>
+          <conditionGroups/>
+        </modifier>
+      </modifiers>
       <constraints/>
       <categoryLinks/>
       <selectionEntries/>
@@ -17206,7 +17294,15 @@
       </profiles>
       <rules/>
       <infoLinks/>
-      <modifiers/>
+      <modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <repeats/>
+          <conditions>
+            <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="6ea7-1195-7144-438e" type="equalTo"/>
+          </conditions>
+          <conditionGroups/>
+        </modifier>
+      </modifiers>
       <constraints/>
       <categoryLinks/>
       <selectionEntries/>
@@ -17295,7 +17391,15 @@
       </profiles>
       <rules/>
       <infoLinks/>
-      <modifiers/>
+      <modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <repeats/>
+          <conditions>
+            <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0dd1-2e2b-7dd1-5495" type="equalTo"/>
+          </conditions>
+          <conditionGroups/>
+        </modifier>
+      </modifiers>
       <constraints/>
       <categoryLinks/>
       <selectionEntries/>
@@ -17334,7 +17438,15 @@
       </profiles>
       <rules/>
       <infoLinks/>
-      <modifiers/>
+      <modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <repeats/>
+          <conditions>
+            <condition field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="72f0-6262-b417-dd10" type="lessThan"/>
+          </conditions>
+          <conditionGroups/>
+        </modifier>
+      </modifiers>
       <constraints/>
       <categoryLinks/>
       <selectionEntries/>
@@ -17373,7 +17485,15 @@
       </profiles>
       <rules/>
       <infoLinks/>
-      <modifiers/>
+      <modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <repeats/>
+          <conditions>
+            <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0334-f487-8229-0c1a" type="equalTo"/>
+          </conditions>
+          <conditionGroups/>
+        </modifier>
+      </modifiers>
       <constraints/>
       <categoryLinks/>
       <selectionEntries/>
@@ -17546,7 +17666,15 @@
           <profiles/>
           <rules/>
           <infoLinks/>
-          <modifiers/>
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <repeats/>
+              <conditions>
+                <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7d85-72b7-2fa0-6ea3" type="equalTo"/>
+              </conditions>
+              <conditionGroups/>
+            </modifier>
+          </modifiers>
         </infoLink>
       </infoLinks>
       <modifiers>
@@ -21249,6 +21377,13 @@
               <modifiers/>
               <constraints/>
             </categoryLink>
+            <categoryLink id="b561-76ff-2ea7-f70e" name="New CategoryLink" hidden="false" targetId="1da2-76db-f76f-6b6c" primary="false">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </categoryLink>
           </categoryLinks>
           <selectionEntries>
             <selectionEntry id="b4f5-5eab-f5bc-a01c" name="Smite" hidden="false" collective="false" type="upgrade">
@@ -21892,8 +22027,8 @@
               <conditionGroups>
                 <conditionGroup type="or">
                   <conditions>
-                    <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e691-aad7-d21c-1023" type="notInstanceOf"/>
                     <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="012f-abfc-397b-3519" type="equalTo"/>
+                    <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e691-aad7-d21c-1023" type="equalTo"/>
                   </conditions>
                   <conditionGroups/>
                 </conditionGroup>


### PR DESCRIPTION
Improves Relic validation. 

It will now not allow the selection of a relic weapon if the relevant base weapon has not been selected. Also fixed a couple of bugs in relic eligibility.