### PR TITLE
Fix THB cost for Tarantula turrets.

### DIFF
--- a/Imperium - FW Elysians.cat
+++ b/Imperium - FW Elysians.cat
@@ -2941,7 +2941,13 @@
                   <profiles/>
                   <rules/>
                   <infoLinks/>
-                  <modifiers/>
+                  <modifiers>
+                    <modifier type="set" field="points" value="14">
+                      <repeats/>
+                      <conditions/>
+                      <conditionGroups/>
+                    </modifier>
+                  </modifiers>
                   <constraints/>
                   <categoryLinks/>
                 </entryLink>


### PR DESCRIPTION
At least in my copy, current version is incorrectly costing at 27 total, which I believe is due to it assuming the THB costs 17, not 14.