### PR TITLE
Fix Primaris marine weapon cost updates

### DIFF
--- a/Imperium - Space Marines.cat
+++ b/Imperium - Space Marines.cat
@@ -8584,7 +8584,7 @@
           </constraints>
           <categoryLinks/>
           <selectionEntries>
-            <selectionEntry id="1df9-f4b9-0610-1c20" name="Intercessor" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="1df9-f4b9-0610-1c20" name="Intercessor" hidden="false" collective="false" type="model">
               <profiles>
                 <profile id="b4d2-3943-f5f9-95e9" name="Intercessor" hidden="false" profileTypeId="800f-21d0-4387-c943" profileTypeName="Unit">
                   <profiles/>
@@ -8642,7 +8642,7 @@
                 <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="0.0"/>
               </costs>
             </selectionEntry>
-            <selectionEntry id="b874-f903-2b36-da36" name="Intercessor Sergeant" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="b874-f903-2b36-da36" name="Intercessor Sergeant" hidden="false" collective="false" type="model">
               <profiles>
                 <profile id="379c-a32b-6ab6-b166" name="Intercessor Sergeant" hidden="false" profileTypeId="800f-21d0-4387-c943" profileTypeName="Unit">
                   <profiles/>
@@ -8735,7 +8735,7 @@
               <modifiers>
                 <modifier type="increment" field="points" value="1">
                   <repeats>
-                    <repeat field="selections" scope="e89e-4431-97de-4b38" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="318d-3021-2155-ab53" repeats="1" roundUp="false"/>
+                    <repeat field="selections" scope="e89e-4431-97de-4b38" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="model" repeats="1" roundUp="false"/>
                   </repeats>
                   <conditions/>
                   <conditionGroups/>
@@ -8759,7 +8759,7 @@
               <modifiers>
                 <modifier type="increment" field="points" value="2">
                   <repeats>
-                    <repeat field="selections" scope="e89e-4431-97de-4b38" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="318d-3021-2155-ab53" repeats="1" roundUp="false"/>
+                    <repeat field="selections" scope="e89e-4431-97de-4b38" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="model" repeats="1" roundUp="false"/>
                   </repeats>
                   <conditions/>
                   <conditionGroups/>
@@ -13337,7 +13337,7 @@
           </constraints>
           <categoryLinks/>
           <selectionEntries>
-            <selectionEntry id="8b10-aef1-d08e-1698" name="Inceptor" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="8b10-aef1-d08e-1698" name="Inceptor" hidden="false" collective="false" type="model">
               <profiles>
                 <profile id="7a44-cdbe-eadb-3a2f" name="Inceptor" hidden="false" profileTypeId="800f-21d0-4387-c943" profileTypeName="Unit">
                   <profiles/>
@@ -13372,7 +13372,7 @@
                 <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="0.0"/>
               </costs>
             </selectionEntry>
-            <selectionEntry id="828d-cc83-a4c1-432e" name="Inceptor Sergeant" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="828d-cc83-a4c1-432e" name="Inceptor Sergeant" hidden="false" collective="false" type="model">
               <profiles>
                 <profile id="0280-a132-adc0-917a" name="Inceptor Sergeant" hidden="false" profileTypeId="800f-21d0-4387-c943" profileTypeName="Unit">
                   <profiles/>
@@ -13432,7 +13432,7 @@
               <modifiers>
                 <modifier type="increment" field="points" value="15">
                   <repeats>
-                    <repeat field="selections" scope="70bc-0516-df21-bbb8" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="5c3a-3b11-6b0d-5c4d" repeats="2" roundUp="false"/>
+                    <repeat field="selections" scope="70bc-0516-df21-bbb8" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="model" repeats="2" roundUp="false"/>
                   </repeats>
                   <conditions/>
                   <conditionGroups/>
@@ -13448,7 +13448,7 @@
               <modifiers>
                 <modifier type="increment" field="points" value="28">
                   <repeats>
-                    <repeat field="selections" scope="70bc-0516-df21-bbb8" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="5c3a-3b11-6b0d-5c4d" repeats="2" roundUp="false"/>
+                    <repeat field="selections" scope="70bc-0516-df21-bbb8" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="model" repeats="2" roundUp="false"/>
                   </repeats>
                   <conditions/>
                   <conditionGroups/>
@@ -24825,7 +24825,7 @@
           </constraints>
           <categoryLinks/>
           <selectionEntries>
-            <selectionEntry id="f2d4-2dfd-1e03-93c1" name="Aggressor Sergeant" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="f2d4-2dfd-1e03-93c1" name="Aggressor Sergeant" hidden="false" collective="false" type="model">
               <profiles>
                 <profile id="01de-dfa3-143e-0d4d" name="Aggressor Sergeant" hidden="false" profileTypeId="800f-21d0-4387-c943" profileTypeName="Unit">
                   <profiles/>
@@ -24861,7 +24861,7 @@
                 <cost name="pts" costTypeId="points" value="25.0"/>
               </costs>
             </selectionEntry>
-            <selectionEntry id="88f6-18a6-66f0-55ba" name="Aggressor" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="88f6-18a6-66f0-55ba" name="Aggressor" hidden="false" collective="false" type="model">
               <profiles>
                 <profile id="309a-bf97-0ea9-520f" name="Aggressor" hidden="false" profileTypeId="800f-21d0-4387-c943" profileTypeName="Unit">
                   <profiles/>
@@ -24918,7 +24918,7 @@
               <modifiers>
                 <modifier type="increment" field="points" value="18">
                   <repeats>
-                    <repeat field="selections" scope="0f7e-ce51-f92d-0138" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="f214-ecfb-ec13-7e73" repeats="1" roundUp="false"/>
+                    <repeat field="selections" scope="0f7e-ce51-f92d-0138" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="model" repeats="1" roundUp="false"/>
                   </repeats>
                   <conditions/>
                   <conditionGroups/>
@@ -24973,7 +24973,7 @@
               <modifiers>
                 <modifier type="increment" field="points" value="18">
                   <repeats>
-                    <repeat field="selections" scope="0f7e-ce51-f92d-0138" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="f214-ecfb-ec13-7e73" repeats="1" roundUp="false"/>
+                    <repeat field="selections" scope="0f7e-ce51-f92d-0138" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="model" repeats="1" roundUp="false"/>
                   </repeats>
                   <conditions/>
                   <conditionGroups/>

--- a/Imperium - Space Marines.cat
+++ b/Imperium - Space Marines.cat
@@ -16502,7 +16502,7 @@
           </constraints>
           <categoryLinks/>
           <selectionEntries>
-            <selectionEntry id="ae3a-fe94-c886-2bb7" name="Hellblaster" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="ae3a-fe94-c886-2bb7" name="Hellblaster" hidden="false" collective="false" type="model">
               <profiles/>
               <rules/>
               <infoLinks/>
@@ -16542,7 +16542,7 @@
                 <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="0.0"/>
               </costs>
             </selectionEntry>
-            <selectionEntry id="0f59-8790-8702-8d7a" name="Hellblaster Sergeant" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="0f59-8790-8702-8d7a" name="Hellblaster Sergeant" hidden="false" collective="false" type="model">
               <profiles/>
               <rules/>
               <infoLinks/>
@@ -16628,7 +16628,7 @@
               <modifiers>
                 <modifier type="increment" field="points" value="15">
                   <repeats>
-                    <repeat field="selections" scope="ac7e-23cf-be74-f957" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="d54d-ae3f-5bbf-c95c" repeats="1" roundUp="false"/>
+                    <repeat field="selections" scope="ac7e-23cf-be74-f957" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="model" repeats="1" roundUp="false"/>
                   </repeats>
                   <conditions/>
                   <conditionGroups/>
@@ -16644,7 +16644,7 @@
               <modifiers>
                 <modifier type="increment" field="points" value="16">
                   <repeats>
-                    <repeat field="selections" scope="ac7e-23cf-be74-f957" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="d54d-ae3f-5bbf-c95c" repeats="1" roundUp="false"/>
+                    <repeat field="selections" scope="ac7e-23cf-be74-f957" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="model" repeats="1" roundUp="false"/>
                   </repeats>
                   <conditions/>
                   <conditionGroups/>
@@ -16660,7 +16660,7 @@
               <modifiers>
                 <modifier type="increment" field="points" value="17">
                   <repeats>
-                    <repeat field="selections" scope="ac7e-23cf-be74-f957" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="d54d-ae3f-5bbf-c95c" repeats="1" roundUp="false"/>
+                    <repeat field="selections" scope="ac7e-23cf-be74-f957" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="model" repeats="1" roundUp="false"/>
                   </repeats>
                   <conditions/>
                   <conditionGroups/>


### PR DESCRIPTION
Set Hellblaster troopers and sergeant to type "Model", and have the weapon cost formula based on number of models.  This seems to live-update correctly, and does not require switching weapon types or reloading the list in order to update cost when the number of troopers changes.