### PR TITLE
Slight improvements, Knights update

### DIFF
--- a/Imperium - Adeptus Titanicus.cat
+++ b/Imperium - Adeptus Titanicus.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="f944-98a5-b73d-f132" name="Imperium - Adeptus Titanicus" revision="2" battleScribeVersion="2.01" authorName="Crowbar90" gameSystemId="28ec-711c-d87f-3aeb" gameSystemRevision="10" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="f944-98a5-b73d-f132" name="Imperium - Adeptus Titanicus" revision="3" battleScribeVersion="2.01" authorName="Crowbar90" gameSystemId="28ec-711c-d87f-3aeb" gameSystemRevision="10" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <profiles/>
   <rules/>
   <infoLinks/>
@@ -696,6 +696,16 @@
             <characteristic name="Void Shield" characteristicTypeId="6635-b157-0e68-49a4" value="7+"/>
           </characteristics>
         </profile>
+        <profile id="6e3c-700a-af35-2639" name="Keywords" hidden="false" profileTypeId="b900-0afb-e411-2cbb" profileTypeName="Keywords">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Keywords (Faction)" characteristicTypeId="6b92-2d97-5144-62bc" value="IMPERIUM, ADEPTUS TITANICUS, &lt;TITAN LEGION&gt;"/>
+            <characteristic name="Keywords (Basic)" characteristicTypeId="ce6c-4765-4bb8-bd49" value="TITANIC, VEHICLE, GOD-ENGINE, WARHOUND SCOUT TITAN"/>
+          </characteristics>
+        </profile>
       </profiles>
       <rules/>
       <infoLinks>
@@ -931,6 +941,16 @@
             <characteristic name="WS" characteristicTypeId="4091-938f-6dde-201f" value="6+"/>
             <characteristic name="BS" characteristicTypeId="cf3d-e3af-f39b-e247" value="6+"/>
             <characteristic name="Void Shield" characteristicTypeId="6635-b157-0e68-49a4" value="7+"/>
+          </characteristics>
+        </profile>
+        <profile id="6da2-eef1-b418-aa43" name="Keywords" hidden="false" profileTypeId="b900-0afb-e411-2cbb" profileTypeName="Keywords">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Keywords (Faction)" characteristicTypeId="6b92-2d97-5144-62bc" value="IMPERIUM, ADEPTUS TITANICUS, &lt;TITAN LEGION&gt;"/>
+            <characteristic name="Keywords (Basic)" characteristicTypeId="ce6c-4765-4bb8-bd49" value="TITANIC, VEHICLE, GOD-ENGINE, REAVER BATTLE TITAN"/>
           </characteristics>
         </profile>
       </profiles>
@@ -1269,6 +1289,16 @@
             <characteristic name="WS" characteristicTypeId="4091-938f-6dde-201f" value="6+"/>
             <characteristic name="BS" characteristicTypeId="cf3d-e3af-f39b-e247" value="5+"/>
             <characteristic name="Void Shield" characteristicTypeId="6635-b157-0e68-49a4" value="6+"/>
+          </characteristics>
+        </profile>
+        <profile id="149e-4343-d093-5264" name="Keywords" hidden="false" profileTypeId="b900-0afb-e411-2cbb" profileTypeName="Keywords">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Keywords (Faction)" characteristicTypeId="6b92-2d97-5144-62bc" value="IMPERIUM, ADEPTUS TITANICUS, &lt;TITAN LEGION&gt;"/>
+            <characteristic name="Keywords (Basic)" characteristicTypeId="ce6c-4765-4bb8-bd49" value="TITANIC, VEHICLE, GOD-ENGINE, WARLORD BATTLE TITAN"/>
           </characteristics>
         </profile>
       </profiles>
@@ -1690,7 +1720,7 @@
         <characteristic name="S" characteristicTypeId="59b1-319e-ec13-d466" value="6"/>
         <characteristic name="AP" characteristicTypeId="75aa-a838-b675-6484" value="-2"/>
         <characteristic name="D" characteristicTypeId="ae8a-3137-d65b-4ca7" value="2"/>
-        <characteristic name="Abilities" characteristicTypeId="837d-5e63-aeb7-1410" value="Against &lt;b&gt;INFANTRY&lt;/b&gt;, the number of successful hits rolled for this weapon is doubled. Units attacked by this weapon do not gain any bonus to their saving throws for being in cover. This weapon can target units which are not visible to the bearer."/>
+        <characteristic name="Abilities" characteristicTypeId="837d-5e63-aeb7-1410" value="Against INFANTRY, the number of successful hits rolled for this weapon is doubled. Units attacked by this weapon do not gain any bonus to their saving throws for being in cover. This weapon can target units which are not visible to the bearer."/>
       </characteristics>
     </profile>
     <profile id="d3bb-042f-419a-34dd" name="Mori quake cannon" hidden="false" profileTypeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" profileTypeName="Weapon">
@@ -1718,7 +1748,7 @@
         <characteristic name="S" characteristicTypeId="59b1-319e-ec13-d466" value="8"/>
         <characteristic name="AP" characteristicTypeId="75aa-a838-b675-6484" value="-3"/>
         <characteristic name="D" characteristicTypeId="ae8a-3137-d65b-4ca7" value="3"/>
-        <characteristic name="Abilities" characteristicTypeId="837d-5e63-aeb7-1410" value="Against &lt;b&gt;INFANTRY&lt;/b&gt; units, each successful hit roll inflicted by this weapon instead becomes 3 hits."/>
+        <characteristic name="Abilities" characteristicTypeId="837d-5e63-aeb7-1410" value="Against INFANTRY units, each successful hit roll inflicted by this weapon instead becomes 3 hits."/>
       </characteristics>
     </profile>
     <profile id="885f-b2dd-1c8d-a2e8" name="Reaver laser blaster" hidden="false" profileTypeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" profileTypeName="Weapon">
@@ -1788,7 +1818,7 @@
         <characteristic name="S" characteristicTypeId="59b1-319e-ec13-d466" value="20"/>
         <characteristic name="AP" characteristicTypeId="75aa-a838-b675-6484" value="-5"/>
         <characteristic name="D" characteristicTypeId="ae8a-3137-d65b-4ca7" value="12"/>
-        <characteristic name="Abilities" characteristicTypeId="837d-5e63-aeb7-1410" value="You may re-roll failed hit rolls for this weapon against targets with the &lt;b&gt;MONSTER&lt;/b&gt;, &lt;b&gt;BUILDING&lt;/b&gt; or &lt;b&gt;VEHICLE&lt;/b&gt; keyword."/>
+        <characteristic name="Abilities" characteristicTypeId="837d-5e63-aeb7-1410" value="You may re-roll failed hit rolls for this weapon against targets with the MONSTER, BUILDING or VEHICLE keyword."/>
       </characteristics>
     </profile>
     <profile id="a0a3-d27d-8604-08b5" name="Sunfury plasma annihilator" hidden="false" profileTypeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" profileTypeName="Weapon">
@@ -1900,7 +1930,7 @@
         <characteristic name="S" characteristicTypeId="59b1-319e-ec13-d466" value="8"/>
         <characteristic name="AP" characteristicTypeId="75aa-a838-b675-6484" value="-3"/>
         <characteristic name="D" characteristicTypeId="ae8a-3137-d65b-4ca7" value="3"/>
-        <characteristic name="Abilities" characteristicTypeId="837d-5e63-aeb7-1410" value="Against &lt;b&gt;INFANTRY&lt;/b&gt; units, each successful hit inflicted by this weapon instead becomes 3 hits."/>
+        <characteristic name="Abilities" characteristicTypeId="837d-5e63-aeb7-1410" value="Against INFANTRY units, each successful hit inflicted by this weapon instead becomes 3 hits."/>
       </characteristics>
     </profile>
     <profile id="9c96-2c60-c4b7-3c4e" name="Arioch Titan power claw" hidden="false" profileTypeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" profileTypeName="Weapon">
@@ -1914,7 +1944,7 @@
         <characteristic name="S" characteristicTypeId="59b1-319e-ec13-d466" value="x2"/>
         <characteristic name="AP" characteristicTypeId="75aa-a838-b675-6484" value="-5"/>
         <characteristic name="D" characteristicTypeId="ae8a-3137-d65b-4ca7" value="12"/>
-        <characteristic name="Abilities" characteristicTypeId="837d-5e63-aeb7-1410" value="If you slay a &lt;b&gt;VEHICLE&lt;/b&gt; or &lt;b&gt;MONSTER&lt;/b&gt; that does not have the &lt;b&gt;TITANIC&lt;/b&gt; keyword with the Arioch Titan power claw, select an enemy unit within 12&quot; and roll a D6; on a 4+ that unit suffers D6 mortal wounds as the dead body or debris is thrown at it."/>
+        <characteristic name="Abilities" characteristicTypeId="837d-5e63-aeb7-1410" value="If you slay a VEHICLE or MONSTER that does not have the TITANIC keyword with the Arioch Titan power claw, select an enemy unit within 12&quot; and roll a D6; on a 4+ that unit suffers D6 mortal wounds as the dead body or debris is thrown at it."/>
       </characteristics>
     </profile>
     <profile id="4f97-0be0-94ca-81eb" name="Greater titanic stride" hidden="false" profileTypeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" profileTypeName="Weapon">
@@ -1942,7 +1972,7 @@
         <characteristic name="S" characteristicTypeId="59b1-319e-ec13-d466" value="x2"/>
         <characteristic name="AP" characteristicTypeId="75aa-a838-b675-6484" value="-5"/>
         <characteristic name="D" characteristicTypeId="ae8a-3137-d65b-4ca7" value="10"/>
-        <characteristic name="Abilities" characteristicTypeId="837d-5e63-aeb7-1410" value="Subtract 1 from hit rolls made with this weapon. Any wound roll of a 6 made with this attack on any &lt;b&gt;VEHICLE&lt;/b&gt;, &lt;b&gt;MONSTER&lt;/b&gt; or &lt;b&gt;BUILDING&lt;/b&gt; automatically inflicts an additional 2D6 mortal wounds on the target."/>
+        <characteristic name="Abilities" characteristicTypeId="837d-5e63-aeb7-1410" value="Subtract 1 from hit rolls made with this weapon. Any wound roll of a 6 made with this attack on any VEHICLE, MONSTER or BUILDING automatically inflicts an additional 2D6 mortal wounds on the target."/>
       </characteristics>
     </profile>
     <profile id="2e60-e92b-79a0-0809" name="Reaver power fist" hidden="false" profileTypeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" profileTypeName="Weapon">
@@ -1956,7 +1986,7 @@
         <characteristic name="S" characteristicTypeId="59b1-319e-ec13-d466" value="x2"/>
         <characteristic name="AP" characteristicTypeId="75aa-a838-b675-6484" value="-5"/>
         <characteristic name="D" characteristicTypeId="ae8a-3137-d65b-4ca7" value="10"/>
-        <characteristic name="Abilities" characteristicTypeId="837d-5e63-aeb7-1410" value="If you slay a &lt;b&gt;VEHICLE&lt;/b&gt; or &lt;b&gt;MONSTER&lt;/b&gt; that does not have the &lt;b&gt;TITANIC&lt;/b&gt; keyword with the Reaver power fist, select an enemy unit within 12&quot; and roll a D6; on a 4+ that unit suffers D6 mortal wounds as the dead body or debris is thrown at it."/>
+        <characteristic name="Abilities" characteristicTypeId="837d-5e63-aeb7-1410" value="If you slay a VEHICLE or MONSTER that does not have the TITANIC keyword with the Reaver power fist, select an enemy unit within 12&quot; and roll a D6; on a 4+ that unit suffers D6 mortal wounds as the dead body or debris is thrown at it."/>
       </characteristics>
     </profile>
     <profile id="40f2-f9f9-74cd-fa1b" name="Titanic stride" hidden="false" profileTypeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" profileTypeName="Weapon">
@@ -1999,7 +2029,7 @@
       <infoLinks/>
       <modifiers/>
       <characteristics>
-        <characteristic name="Description" characteristicTypeId="21befb24-fc85-4f52-a745-64b2e48f8228" value="This model can Fall Back in the Movement phase and still shoot and/or charge during its turn. When this model Falls Back, it can move over enemy &lt;b&gt;INFANTRY&lt;/b&gt; models, though at the end of its move it must be more than 1&quot; away from all enemy units. This model can fire its shooting weapons even if there are enemy models within 1&quot; unless those enemy models are &lt;b&gt;TITANIC&lt;/b&gt;. In this case, it can shoot the enemy unit that is within 1&quot; of it or any other visible enemy unit that is within range and more than 1&quot; away from any friendly models. In addition, this model can move and fire Heavy weapons without any penalty to its hit rolls. Finally, this model only gains a bonus to its save in cover if at least half of the model is obscured from the firer."/>
+        <characteristic name="Description" characteristicTypeId="21befb24-fc85-4f52-a745-64b2e48f8228" value="This model can Fall Back in the Movement phase and still shoot and/or charge during its turn. When this model Falls Back, it can move over enemy INFANTRY models, though at the end of its move it must be more than 1&quot; away from all enemy units. This model can fire its shooting weapons even if there are enemy models within 1&quot; unless those enemy models are TITANIC. In this case, it can shoot the enemy unit that is within 1&quot; of it or any other visible enemy unit that is within range and more than 1&quot; away from any friendly models. In addition, this model can move and fire Heavy weapons without any penalty to its hit rolls. Finally, this model only gains a bonus to its save in cover if at least half of the model is obscured from the firer."/>
       </characteristics>
     </profile>
     <profile id="b18f-3b99-479f-3612" name="Titan Void Shields" hidden="false" profileTypeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" profileTypeName="Abilities">

--- a/Imperium - Blood Angels.cat
+++ b/Imperium - Blood Angels.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="eb0f-c144-a282-8bdc" name="Imperium - Blood Angels" book="Index: Imperium 1" revision="21" battleScribeVersion="2.01" authorName="Crowbar90" gameSystemId="28ec-711c-d87f-3aeb" gameSystemRevision="1" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="eb0f-c144-a282-8bdc" name="Imperium - Blood Angels" book="Index: Imperium 1" revision="22" battleScribeVersion="2.01" authorName="Crowbar90" gameSystemId="28ec-711c-d87f-3aeb" gameSystemRevision="1" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <profiles/>
   <rules/>
   <infoLinks/>
@@ -5255,7 +5255,7 @@
           <infoLinks/>
           <modifiers/>
           <characteristics>
-            <characteristic name="Capacity" characteristicTypeId="15aa-1916-a38b-d223" value="This model can transport 10 &lt;b&gt;BLOOD ANGELS&lt;/b&gt; &lt;b&gt;INFANTRY&lt;/b&gt; models. It cannot transport &lt;b&gt;JUMP PACK&lt;/b&gt;, &lt;b&gt;TERMINATOR&lt;/b&gt;, &lt;b&gt;PRIMARIS&lt;/b&gt; or &lt;b&gt;CENTURION&lt;/b&gt; models."/>
+            <characteristic name="Capacity" characteristicTypeId="15aa-1916-a38b-d223" value="This model can transport 10 BLOOD ANGELS INFANTRY models. It cannot transport JUMP PACK, TERMINATOR, PRIMARIS or CENTURION models."/>
           </characteristics>
         </profile>
       </profiles>
@@ -6497,7 +6497,7 @@
           <infoLinks/>
           <modifiers/>
           <characteristics>
-            <characteristic name="Capacity" characteristicTypeId="15aa-1916-a38b-d223" value="This model can transport 10 &lt;b&gt;BLOOD ANGELS&lt;/b&gt; &lt;b&gt;INFANTRY&lt;/b&gt; models. Each &lt;b&gt;JUMP PACK&lt;/b&gt; or &lt;b&gt;TERMINATOR&lt;/b&gt; model takes the space of two other models and each &lt;b&gt;CENTURION&lt;/b&gt; takes the space of three other models. It cannot transport &lt;b&gt;PRIMARIS&lt;/b&gt; models."/>
+            <characteristic name="Capacity" characteristicTypeId="15aa-1916-a38b-d223" value="This model can transport 10 BLOOD ANGELS INFANTRY models. Each JUMP PACK or TERMINATOR model takes the space of two other models and each CENTURION takes the space of three other models. It cannot transport PRIMARIS models."/>
           </characteristics>
         </profile>
         <profile id="7b36-f5f8-3546-26bc" name="Land Raider" hidden="false" profileTypeId="5f4f-ea74-0630-4afe" profileTypeName="Wound Track">
@@ -6701,7 +6701,7 @@
           <infoLinks/>
           <modifiers/>
           <characteristics>
-            <characteristic name="Capacity" characteristicTypeId="15aa-1916-a38b-d223" value="This model can transport 16 &lt;b&gt;BLOOD ANGELS&lt;/b&gt; &lt;b&gt;INFANTRY&lt;/b&gt; models. Each &lt;b&gt;JUMP PACK&lt;/b&gt; or &lt;b&gt;TERMINATOR&lt;/b&gt; model takes the space of two other models and each &lt;b&gt;CENTURION&lt;/b&gt; takes the space of three other models. It cannot transport &lt;b&gt;PRIMARIS&lt;/b&gt; models."/>
+            <characteristic name="Capacity" characteristicTypeId="15aa-1916-a38b-d223" value="This model can transport 16 BLOOD ANGELS INFANTRY models. Each JUMP PACK or TERMINATOR model takes the space of two other models and each CENTURION takes the space of three other models. It cannot transport PRIMARIS models."/>
           </characteristics>
         </profile>
         <profile id="13c1-d82c-c8c0-2c95" name="Land Raider Crusader" hidden="false" profileTypeId="5f4f-ea74-0630-4afe" profileTypeName="Wound Track">
@@ -6918,7 +6918,7 @@
           <infoLinks/>
           <modifiers/>
           <characteristics>
-            <characteristic name="Capacity" characteristicTypeId="15aa-1916-a38b-d223" value="This model can transport 12 &lt;b&gt;BLOOD ANGELS&lt;/b&gt; &lt;b&gt;INFANTRY&lt;/b&gt; models. Each &lt;b&gt;JUMP PACK&lt;/b&gt; or &lt;b&gt;TERMINATOR&lt;/b&gt; model takes the space of two other models and each &lt;b&gt;CENTURION&lt;/b&gt; takes the space of three other models. It cannot transport &lt;b&gt;PRIMARIS&lt;/b&gt; models."/>
+            <characteristic name="Capacity" characteristicTypeId="15aa-1916-a38b-d223" value="This model can transport 12 BLOOD ANGELS INFANTRY models. Each JUMP PACK or TERMINATOR model takes the space of two other models and each CENTURION takes the space of three other models. It cannot transport PRIMARIS models."/>
           </characteristics>
         </profile>
         <profile id="e962-f90a-22a8-f304" name="Land Raider Redeemer" hidden="false" profileTypeId="5f4f-ea74-0630-4afe" profileTypeName="Wound Track">
@@ -7135,7 +7135,7 @@
           <infoLinks/>
           <modifiers/>
           <characteristics>
-            <characteristic name="Capacity" characteristicTypeId="15aa-1916-a38b-d223" value="This model can transport 10 &lt;b&gt;BLOOD ANGELS&lt;/b&gt; &lt;b&gt;INFANTRY&lt;/b&gt; models. Each &lt;b&gt;JUMP PACK&lt;/b&gt; or &lt;b&gt;TERMINATOR&lt;/b&gt; model takes the space of two other models and each &lt;b&gt;CENTURION&lt;/b&gt; takes the space of three other models. It cannot transport &lt;b&gt;PRIMARIS&lt;/b&gt; models."/>
+            <characteristic name="Capacity" characteristicTypeId="15aa-1916-a38b-d223" value="This model can transport 10 BLOOD ANGELS INFANTRY models. Each JUMP PACK or TERMINATOR model takes the space of two other models and each CENTURION takes the space of three other models. It cannot transport PRIMARIS models."/>
           </characteristics>
         </profile>
         <profile id="3189-16b9-bebb-d4ce" name="Land Raider Excelsior" hidden="false" profileTypeId="5f4f-ea74-0630-4afe" profileTypeName="Wound Track">
@@ -7201,7 +7201,7 @@
           <infoLinks/>
           <modifiers/>
           <characteristics>
-            <characteristic name="Description" characteristicTypeId="21befb24-fc85-4f52-a745-64b2e48f8228" value="While this model is within 24&quot; of any friendly &lt;b&gt;BLOOD ANGELS&lt;/b&gt; Rhinos Primaris, add 1 to its hit rolls for shooting attacks."/>
+            <characteristic name="Description" characteristicTypeId="21befb24-fc85-4f52-a745-64b2e48f8228" value="While this model is within 24&quot; of any friendly BLOOD ANGELS Rhinos Primaris, add 1 to its hit rolls for shooting attacks."/>
           </characteristics>
         </profile>
       </profiles>
@@ -7623,14 +7623,14 @@
           <rules/>
           <infoLinks/>
           <modifiers>
-            <modifier type="set" field="ad96-dfa4-b4ed-656d" value="Select a friendly &lt;b&gt;FLESH TEARERS&lt;/b&gt; unit within 12&quot; of the psyker. Until the start of your next Psychic phase, that unit has a 4+ invulnerable save.">
+            <modifier type="set" field="ad96-dfa4-b4ed-656d" value="Select a friendly FLESH TEARERS unit within 12&quot; of the psyker. Until the start of your next Psychic phase, that unit has a 4+ invulnerable save.">
               <repeats/>
               <conditions>
                 <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="bc53-ab33-e8f1-679b" type="equalTo"/>
               </conditions>
               <conditionGroups/>
             </modifier>
-            <modifier type="set" field="ad96-dfa4-b4ed-656d" value="Select a friendly &lt;b&gt;BLOOD ANGELS&lt;/b&gt; unit within 12&quot; of the psyker. Until the start of your next Psychic phase, that unit has a 4+ invulnerable save.">
+            <modifier type="set" field="ad96-dfa4-b4ed-656d" value="Select a friendly BLOOD ANGELS unit within 12&quot; of the psyker. Until the start of your next Psychic phase, that unit has a 4+ invulnerable save.">
               <repeats/>
               <conditions>
                 <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f7d8-a545-2f41-e170" type="equalTo"/>
@@ -7641,7 +7641,7 @@
           <characteristics>
             <characteristic name="Warp Charge" characteristicTypeId="5ffd-b800-c317-532a" value="6"/>
             <characteristic name="Range" characteristicTypeId="fd64-cbc4-94de-24cc" value="12&quot;"/>
-            <characteristic name="Details" characteristicTypeId="ad96-dfa4-b4ed-656d" value="Select a friendly &lt;b&gt;&amp;lt;CHAPTER&amp;gt;&lt;/b&gt; unit within 12&quot; of the psyker. Until the start of your next Psychic phase, that unit has a 4+ invulnerable save."/>
+            <characteristic name="Details" characteristicTypeId="ad96-dfa4-b4ed-656d" value="Select a friendly &amp;lt;CHAPTER&amp;gt; unit within 12&quot; of the psyker. Until the start of your next Psychic phase, that unit has a 4+ invulnerable save."/>
           </characteristics>
         </profile>
         <profile id="970b-a55e-4672-3edc" name="Sanguinary 3 - Unleash Rage" hidden="false" profileTypeId="ae70-4738-0161-bec0" profileTypeName="Psychic Power">
@@ -7649,14 +7649,14 @@
           <rules/>
           <infoLinks/>
           <modifiers>
-            <modifier type="set" field="ad96-dfa4-b4ed-656d" value="Select a friendly &lt;b&gt;FLESH TEARERS&lt;/b&gt; unit within 12&quot; of the psyker. Until the start of your next Psychic phase, that unit has +1 Attack.">
+            <modifier type="set" field="ad96-dfa4-b4ed-656d" value="Select a friendly FLESH TEARERS unit within 12&quot; of the psyker. Until the start of your next Psychic phase, that unit has +1 Attack.">
               <repeats/>
               <conditions>
                 <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="bc53-ab33-e8f1-679b" type="equalTo"/>
               </conditions>
               <conditionGroups/>
             </modifier>
-            <modifier type="set" field="ad96-dfa4-b4ed-656d" value="Select a friendly &lt;b&gt;BLOOD ANGELS&lt;/b&gt; unit within 12&quot; of the psyker. Until the start of your next Psychic phase, that unit has +1 Attack.">
+            <modifier type="set" field="ad96-dfa4-b4ed-656d" value="Select a friendly BLOOD ANGELS unit within 12&quot; of the psyker. Until the start of your next Psychic phase, that unit has +1 Attack.">
               <repeats/>
               <conditions>
                 <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f7d8-a545-2f41-e170" type="equalTo"/>
@@ -7667,7 +7667,7 @@
           <characteristics>
             <characteristic name="Warp Charge" characteristicTypeId="5ffd-b800-c317-532a" value="6"/>
             <characteristic name="Range" characteristicTypeId="fd64-cbc4-94de-24cc" value="12&quot;"/>
-            <characteristic name="Details" characteristicTypeId="ad96-dfa4-b4ed-656d" value="Select a friendly &lt;b&gt;&amp;lt;CHAPTER&amp;gt;&lt;/b&gt; unit within 12&quot; of the psyker. Until the start of your next Psychic phase, that unit has +1 Attack."/>
+            <characteristic name="Details" characteristicTypeId="ad96-dfa4-b4ed-656d" value="Select a friendly &amp;lt;CHAPTER&amp;gt; unit within 12&quot; of the psyker. Until the start of your next Psychic phase, that unit has +1 Attack."/>
           </characteristics>
         </profile>
       </profiles>
@@ -9107,7 +9107,7 @@
           <infoLinks/>
           <modifiers/>
           <characteristics>
-            <characteristic name="Capacity" characteristicTypeId="15aa-1916-a38b-d223" value="This model can transport 6 &lt;b&gt;BLOOD ANGELS&lt;/b&gt; &lt;b&gt;INFANTRY&lt;/b&gt; models. It cannot transport &lt;b&gt;JUMP PACK&lt;/b&gt;, &lt;b&gt;TERMINATOR&lt;/b&gt;, &lt;b&gt;PRIMARIS&lt;/b&gt; or &lt;b&gt;CENTURION&lt;/b&gt; models."/>
+            <characteristic name="Capacity" characteristicTypeId="15aa-1916-a38b-d223" value="This model can transport 6 BLOOD ANGELS INFANTRY models. It cannot transport JUMP PACK, TERMINATOR, PRIMARIS or CENTURION models."/>
           </characteristics>
         </profile>
       </profiles>
@@ -9377,7 +9377,7 @@
           <infoLinks/>
           <modifiers/>
           <characteristics>
-            <characteristic name="Capacity" characteristicTypeId="15aa-1916-a38b-d223" value="This model can transport 10 &lt;b&gt;BLOOD ANGELS&lt;/b&gt; &lt;b&gt;INFANTRY&lt;/b&gt; models. It cannot transport &lt;b&gt;JUMP PACK&lt;/b&gt;, &lt;b&gt;TERMINATOR&lt;/b&gt;, &lt;b&gt;PRIMARIS&lt;/b&gt; or &lt;b&gt;CENTURION&lt;/b&gt; models."/>
+            <characteristic name="Capacity" characteristicTypeId="15aa-1916-a38b-d223" value="This model can transport 10 BLOOD ANGELS INFANTRY models. It cannot transport JUMP PACK, TERMINATOR, PRIMARIS or CENTURION models."/>
           </characteristics>
         </profile>
       </profiles>
@@ -9557,7 +9557,7 @@
           <infoLinks/>
           <modifiers/>
           <characteristics>
-            <characteristic name="Capacity" characteristicTypeId="15aa-1916-a38b-d223" value="This model can transport 6 &lt;b&gt;BLOOD ANGELS&lt;/b&gt; &lt;b&gt;INFANTRY&lt;/b&gt; models. It cannot transport &lt;b&gt;JUMP PACK&lt;/b&gt;, &lt;b&gt;TERMINATOR&lt;/b&gt;, &lt;b&gt;PRIMARIS&lt;/b&gt; or &lt;b&gt;CENTURION&lt;/b&gt; models."/>
+            <characteristic name="Capacity" characteristicTypeId="15aa-1916-a38b-d223" value="This model can transport 6 BLOOD ANGELS INFANTRY models. It cannot transport JUMP PACK, TERMINATOR, PRIMARIS or CENTURION models."/>
           </characteristics>
         </profile>
         <profile id="318d-1dc6-b15d-1a42" name="Servo-skull Hub" hidden="false" profileTypeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" profileTypeName="Abilities">
@@ -9566,7 +9566,7 @@
           <infoLinks/>
           <modifiers/>
           <characteristics>
-            <characteristic name="Description" characteristicTypeId="21befb24-fc85-4f52-a745-64b2e48f8228" value="In each of your Shooting phases, choose one of the following effects:  Targeting Data Skull: Add 1 to hit rolls made for a single friendly &lt;b&gt;BLOOD ANGELS&lt;/b&gt; unit within 12&quot; of this model until the end of the phase.  Repair Skull: Choose a single &lt;b&gt;BLOOD ANGELS&lt;/b&gt; &lt;b&gt;VEHICLE&lt;/b&gt; within 12&quot; of this model. That model regains 1 lost wound.  Vox Skull: Subtract 1 from morale tests taken for friendly &lt;b&gt;BLOOD ANGELS&lt;/b&gt; units within 12&quot; of this model until your next Shooting phase."/>
+            <characteristic name="Description" characteristicTypeId="21befb24-fc85-4f52-a745-64b2e48f8228" value="In each of your Shooting phases, choose one of the following effects:  Targeting Data Skull: Add 1 to hit rolls made for a single friendly BLOOD ANGELS unit within 12&quot; of this model until the end of the phase.  Repair Skull: Choose a single BLOOD ANGELS VEHICLE within 12&quot; of this model. That model regains 1 lost wound.  Vox Skull: Subtract 1 from morale tests taken for friendly BLOOD ANGELS units within 12&quot; of this model until your next Shooting phase."/>
           </characteristics>
         </profile>
       </profiles>
@@ -10683,7 +10683,7 @@
           <infoLinks/>
           <modifiers/>
           <characteristics>
-            <characteristic name="Description" characteristicTypeId="21befb24-fc85-4f52-a745-64b2e48f8228" value="Servitors improve both their Weapon Skill and Ballistic Skill to 4+, and their Leadership to 9, whilst they are within 6&quot; of any friendly &lt;b&gt;TECHMARINES&lt;/b&gt;."/>
+            <characteristic name="Description" characteristicTypeId="21befb24-fc85-4f52-a745-64b2e48f8228" value="Servitors improve both their Weapon Skill and Ballistic Skill to 4+, and their Leadership to 9, whilst they are within 6&quot; of any friendly TECHMARINES."/>
           </characteristics>
         </profile>
       </profiles>
@@ -11627,7 +11627,7 @@
           <infoLinks/>
           <modifiers/>
           <characteristics>
-            <characteristic name="Description" characteristicTypeId="21befb24-fc85-4f52-a745-64b2e48f8228" value="This model cannot charge, can only be charged by units that can &lt;b&gt;FLY&lt;/b&gt;, and can only attack or be attacked in the Fight phase by units that can &lt;b&gt;FLY&lt;/b&gt;."/>
+            <characteristic name="Description" characteristicTypeId="21befb24-fc85-4f52-a745-64b2e48f8228" value="This model cannot charge, can only be charged by units that can FLY, and can only attack or be attacked in the Fight phase by units that can FLY."/>
           </characteristics>
         </profile>
         <profile id="0ef8-30e9-229b-09d7" name="Supersonic" hidden="false" profileTypeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" profileTypeName="Abilities">
@@ -11672,7 +11672,7 @@
           <infoLinks/>
           <modifiers/>
           <characteristics>
-            <characteristic name="Capacity" characteristicTypeId="15aa-1916-a38b-d223" value="This model can transport 12 &lt;b&gt;BLOOD ANGELS&lt;/b&gt; &lt;b&gt;INFANTRY&lt;/b&gt; models and 1 &lt;b&gt;BLOOD ANGELS&lt;/b&gt; &lt;b&gt;DREADNOUGHT&lt;/b&gt;. Each &lt;b&gt; JUMP PACK&lt;/b&gt; or &lt;b&gt;TERMINATOR&lt;/b&gt; model takes the space of two other infantry models and each &lt;b&gt;CENTURION&lt;/b&gt; takes the space of 3 other infantry models. It cannot transport &lt;b&gt;PRIMARIS&lt;/b&gt; models."/>
+            <characteristic name="Capacity" characteristicTypeId="15aa-1916-a38b-d223" value="This model can transport 12 BLOOD ANGELS INFANTRY models and 1 BLOOD ANGELS DREADNOUGHT. Each  JUMP PACK or TERMINATOR model takes the space of two other infantry models and each CENTURION takes the space of 3 other infantry models. It cannot transport PRIMARIS models."/>
           </characteristics>
         </profile>
         <profile id="21ad-c738-5c82-c22b" name="Stormraven Gunship" hidden="false" profileTypeId="5f4f-ea74-0630-4afe" profileTypeName="Wound Track">
@@ -14657,7 +14657,7 @@
           <infoLinks/>
           <modifiers/>
           <characteristics>
-            <characteristic name="Description" characteristicTypeId="21befb24-fc85-4f52-a745-64b2e48f8228" value="You can re-roll failed hit rolls for friendly &lt;b&gt;BLOOD ANGELS&lt;/b&gt; units within 6&quot; of Commander Dante."/>
+            <characteristic name="Description" characteristicTypeId="21befb24-fc85-4f52-a745-64b2e48f8228" value="You can re-roll failed hit rolls for friendly BLOOD ANGELS units within 6&quot; of Commander Dante."/>
           </characteristics>
         </profile>
       </profiles>
@@ -14900,7 +14900,7 @@
           <infoLinks/>
           <modifiers/>
           <characteristics>
-            <characteristic name="Description" characteristicTypeId="21befb24-fc85-4f52-a745-64b2e48f8228" value="Captain Tycho may make D3 additional close combat attacks if he is within 1&quot; of any enemy &lt;b&gt;ORKS&lt;/b&gt; after he has piled in during the Fight phase."/>
+            <characteristic name="Description" characteristicTypeId="21befb24-fc85-4f52-a745-64b2e48f8228" value="Captain Tycho may make D3 additional close combat attacks if he is within 1&quot; of any enemy ORKS after he has piled in during the Fight phase."/>
           </characteristics>
         </profile>
       </profiles>
@@ -15114,7 +15114,7 @@
           <infoLinks/>
           <modifiers/>
           <characteristics>
-            <characteristic name="Description" characteristicTypeId="21befb24-fc85-4f52-a745-64b2e48f8228" value="Captain Tycho may make D3 additional close combat attacks if he is within 1&quot; of any enemy &lt;b&gt;ORKS&lt;/b&gt; after he has piled in during the Fight phase."/>
+            <characteristic name="Description" characteristicTypeId="21befb24-fc85-4f52-a745-64b2e48f8228" value="Captain Tycho may make D3 additional close combat attacks if he is within 1&quot; of any enemy ORKS after he has piled in during the Fight phase."/>
           </characteristics>
         </profile>
       </profiles>
@@ -15809,7 +15809,7 @@
           <infoLinks/>
           <modifiers/>
           <characteristics>
-            <characteristic name="Description" characteristicTypeId="21befb24-fc85-4f52-a745-64b2e48f8228" value="You can add 1 to the Attacks characteristic of friendly &lt;b&gt;BLOOD ANGELS&lt;/b&gt; &lt;b&gt;INFANTRY&lt;/b&gt; units within 6&quot; of the Sanguinor."/>
+            <characteristic name="Description" characteristicTypeId="21befb24-fc85-4f52-a745-64b2e48f8228" value="You can add 1 to the Attacks characteristic of friendly BLOOD ANGELS INFANTRY units within 6&quot; of the Sanguinor."/>
           </characteristics>
         </profile>
         <profile id="978b-d6c8-6386-036e" name="Avenging Angel" hidden="false" profileTypeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" profileTypeName="Abilities">
@@ -16037,7 +16037,7 @@
           <infoLinks/>
           <modifiers/>
           <characteristics>
-            <characteristic name="Description" characteristicTypeId="21befb24-fc85-4f52-a745-64b2e48f8228" value="All friendly &lt;b&gt;BLOOD ANGELS&lt;/b&gt; units within 6&quot; of Astorath can use his Leadership instead of their own. In addition, friendly &lt;b&gt;DEATH COMPANY&lt;/b&gt; units automatically pass Morale tests if they are within 6&quot; of Astorath."/>
+            <characteristic name="Description" characteristicTypeId="21befb24-fc85-4f52-a745-64b2e48f8228" value="All friendly BLOOD ANGELS units within 6&quot; of Astorath can use his Leadership instead of their own. In addition, friendly DEATH COMPANY units automatically pass Morale tests if they are within 6&quot; of Astorath."/>
           </characteristics>
         </profile>
         <profile id="0f9d-d5d0-8746-1db5" name="Mass of Doom" hidden="false" profileTypeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" profileTypeName="Abilities">
@@ -16046,7 +16046,7 @@
           <infoLinks/>
           <modifiers/>
           <characteristics>
-            <characteristic name="Description" characteristicTypeId="21befb24-fc85-4f52-a745-64b2e48f8228" value="Once per battle, at the start of your Movement phase, Astorath may chant the Mass of Doom. Roll a D6 for each friendly &lt;b&gt;BLOOD ANGELS&lt;/b&gt; &lt;b&gt;INFANTRY&lt;/b&gt; unit within 6&quot; of Astorath and apply the result below:  1 - Frenzied Death Throes: The unit suffers a mortal wound. 2-5 - Dark Wrath: You can add 1 to hit rolls made for this unit in the Fight phase until the end of your turn. 6 - Vessel of Sanguinius: You can add 1 to hit rolls made for this unit in the Fight phase until the end of your turn. In addition, the unit has a 4+ invulnerable save until the end of your turn."/>
+            <characteristic name="Description" characteristicTypeId="21befb24-fc85-4f52-a745-64b2e48f8228" value="Once per battle, at the start of your Movement phase, Astorath may chant the Mass of Doom. Roll a D6 for each friendly BLOOD ANGELS INFANTRY unit within 6&quot; of Astorath and apply the result below:  1 - Frenzied Death Throes: The unit suffers a mortal wound. 2-5 - Dark Wrath: You can add 1 to hit rolls made for this unit in the Fight phase until the end of your turn. 6 - Vessel of Sanguinius: You can add 1 to hit rolls made for this unit in the Fight phase until the end of your turn. In addition, the unit has a 4+ invulnerable save until the end of your turn."/>
           </characteristics>
         </profile>
       </profiles>
@@ -16712,7 +16712,7 @@
           <infoLinks/>
           <modifiers/>
           <characteristics>
-            <characteristic name="Description" characteristicTypeId="21befb24-fc85-4f52-a745-64b2e48f8228" value="Friendly &lt;b&gt;BLOOD ANGELS&lt;/b&gt; &lt;b&gt;INFANTRY&lt;/b&gt; and &lt;b&gt;BIKER&lt;/b&gt; units increase their Strength characteristic by 1 whilst they are within 6&quot; of any &lt;b&gt;SANGUINARY PRIESTS&lt;/b&gt;. In addition, each time you make a hit roll of 6+ in the Fight phase for a model in a friendly &lt;b&gt;BLOOD ANGELS&lt;/b&gt; unit that is within 6&quot; of Brother Corbulo, that model may immediately make another close combat attack using the same weapons. These bonus attacks cannot themselves generate any additional close combat attacks."/>
+            <characteristic name="Description" characteristicTypeId="21befb24-fc85-4f52-a745-64b2e48f8228" value="Friendly BLOOD ANGELS INFANTRY and BIKER units increase their Strength characteristic by 1 whilst they are within 6&quot; of any SANGUINARY PRIESTS. In addition, each time you make a hit roll of 6+ in the Fight phase for a model in a friendly BLOOD ANGELS unit that is within 6&quot; of Brother Corbulo, that model may immediately make another close combat attack using the same weapons. These bonus attacks cannot themselves generate any additional close combat attacks."/>
           </characteristics>
         </profile>
       </profiles>
@@ -16927,14 +16927,14 @@
               </conditions>
               <conditionGroups/>
             </modifier>
-            <modifier type="set" field="21befb24-fc85-4f52-a745-64b2e48f8228" value="Friendly &lt;b&gt;BLOOD ANGELS&lt;/b&gt; units within 6&quot; of a Blood Angels Chapter Banner do not need to take Morale tests and re-roll wounds roll of 1 in the Fight phase.">
+            <modifier type="set" field="21befb24-fc85-4f52-a745-64b2e48f8228" value="Friendly BLOOD ANGELS units within 6&quot; of a Blood Angels Chapter Banner do not need to take Morale tests and re-roll wounds roll of 1 in the Fight phase.">
               <repeats/>
               <conditions>
                 <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f7d8-a545-2f41-e170" type="equalTo"/>
               </conditions>
               <conditionGroups/>
             </modifier>
-            <modifier type="set" field="21befb24-fc85-4f52-a745-64b2e48f8228" value="Friendly &lt;b&gt;FLESH TEARERS&lt;/b&gt; units within 6&quot; of a Flesh Tearers Chapter Banner do not need to take Morale tests and re-roll wounds roll of 1 in the Fight phase.">
+            <modifier type="set" field="21befb24-fc85-4f52-a745-64b2e48f8228" value="Friendly FLESH TEARERS units within 6&quot; of a Flesh Tearers Chapter Banner do not need to take Morale tests and re-roll wounds roll of 1 in the Fight phase.">
               <repeats/>
               <conditions>
                 <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="bc53-ab33-e8f1-679b" type="equalTo"/>
@@ -16943,7 +16943,7 @@
             </modifier>
           </modifiers>
           <characteristics>
-            <characteristic name="Description" characteristicTypeId="21befb24-fc85-4f52-a745-64b2e48f8228" value="Friendly &lt;b&gt;&amp;lt;CHAPTER&amp;gt;&lt;/b&gt; units within 6&quot; of a Chapter Banner do not need to take Morale tests and re-roll wounds roll of 1 in the Fight phase."/>
+            <characteristic name="Description" characteristicTypeId="21befb24-fc85-4f52-a745-64b2e48f8228" value="Friendly &amp;lt;CHAPTER&amp;gt; units within 6&quot; of a Chapter Banner do not need to take Morale tests and re-roll wounds roll of 1 in the Fight phase."/>
           </characteristics>
         </profile>
       </profiles>
@@ -17208,7 +17208,7 @@
           <infoLinks/>
           <modifiers/>
           <characteristics>
-            <characteristic name="Description" characteristicTypeId="21befb24-fc85-4f52-a745-64b2e48f8228" value="Friendly &lt;b&gt;&amp;lt;CHAPTER&amp;gt;&lt;/b&gt; units within 6&quot; of an Archangel standard add 1 to their Leadership characteristic, and you can re-roll failed hit rolls for them in the Fight phase."/>
+            <characteristic name="Description" characteristicTypeId="21befb24-fc85-4f52-a745-64b2e48f8228" value="Friendly &amp;lt;CHAPTER&amp;gt; units within 6&quot; of an Archangel standard add 1 to their Leadership characteristic, and you can re-roll failed hit rolls for them in the Fight phase."/>
           </characteristics>
         </profile>
       </profiles>
@@ -17803,7 +17803,7 @@
           <infoLinks/>
           <modifiers/>
           <characteristics>
-            <characteristic name="Description" characteristicTypeId="21befb24-fc85-4f52-a745-64b2e48f8228" value="All friendly &lt;b&gt;DEATH COMPANY&lt;/b&gt; units within 6&quot; of Lemartes can use his Leadership instead of their own."/>
+            <characteristic name="Description" characteristicTypeId="21befb24-fc85-4f52-a745-64b2e48f8228" value="All friendly DEATH COMPANY units within 6&quot; of Lemartes can use his Leadership instead of their own."/>
           </characteristics>
         </profile>
         <profile id="45e4-e44c-be82-b186" name="Fury Unbound" hidden="false" profileTypeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" profileTypeName="Abilities">
@@ -17812,7 +17812,7 @@
           <infoLinks/>
           <modifiers/>
           <characteristics>
-            <characteristic name="Description" characteristicTypeId="21befb24-fc85-4f52-a745-64b2e48f8228" value="You can re-roll failed charge rolls and failed hit rolls in the Fight phase for friendly &lt;b&gt;DEATH COMPANY&lt;/b&gt; units within 6&quot; of Lemartes."/>
+            <characteristic name="Description" characteristicTypeId="21befb24-fc85-4f52-a745-64b2e48f8228" value="You can re-roll failed charge rolls and failed hit rolls in the Fight phase for friendly DEATH COMPANY units within 6&quot; of Lemartes."/>
           </characteristics>
         </profile>
       </profiles>
@@ -19157,7 +19157,7 @@
           <infoLinks/>
           <modifiers/>
           <characteristics>
-            <characteristic name="Description" characteristicTypeId="21befb24-fc85-4f52-a745-64b2e48f8228" value="You can re-roll failed hit rolls for friendly &lt;b&gt;FLESH TEARERS&lt;/b&gt; within 6&quot; of Gabriel Seth."/>
+            <characteristic name="Description" characteristicTypeId="21befb24-fc85-4f52-a745-64b2e48f8228" value="You can re-roll failed hit rolls for friendly FLESH TEARERS within 6&quot; of Gabriel Seth."/>
           </characteristics>
         </profile>
         <profile id="43ba-5534-7af7-4956" name="Whirlwind of Gore" hidden="false" profileTypeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" profileTypeName="Abilities">
@@ -19166,7 +19166,7 @@
           <infoLinks/>
           <modifiers/>
           <characteristics>
-            <characteristic name="Description" characteristicTypeId="21befb24-fc85-4f52-a745-64b2e48f8228" value="Roll a D6 each time a friendly &lt;b&gt;FLESH TEARERS&lt;/b&gt; unit finishes its move within 6&quot; of Gabriel Seth when it consolidates; on a 6 that unit can immediately fight for a second and final time."/>
+            <characteristic name="Description" characteristicTypeId="21befb24-fc85-4f52-a745-64b2e48f8228" value="Roll a D6 each time a friendly FLESH TEARERS unit finishes its move within 6&quot; of Gabriel Seth when it consolidates; on a 6 that unit can immediately fight for a second and final time."/>
           </characteristics>
         </profile>
       </profiles>
@@ -25927,14 +25927,14 @@
       <rules/>
       <infoLinks/>
       <modifiers>
-        <modifier type="set" field="21befb24-fc85-4f52-a745-64b2e48f8228" value="&lt;b&gt;BLOOD ANGELS&lt;/b&gt; units within 6&quot; of any friendly &lt;b&gt;BLOOD ANGELS&lt;/b&gt; &lt;b&gt;ANCIENTS&lt;/b&gt; add 1 to their Leadership. In addition, roll a D6 each time a &lt;b&gt;BLOOD ANGELS&lt;/b&gt; &lt;b&gt;INFANTRY&lt;/b&gt; model is destroyed within 6&quot; of any friendly &lt;b&gt;BLOOD ANGELS&lt;/b&gt; &lt;b&gt;ANCIENTS&lt;/b&gt;, before removing the model as a casualty. On a 4+ that model musters one last surge of strength before succumbing to its wounds; it can either shoot with one of its weapons as if it were the Shooting phase, or make a single attack as if it were the Fight phase. ">
+        <modifier type="set" field="21befb24-fc85-4f52-a745-64b2e48f8228" value="BLOOD ANGELS units within 6&quot; of any friendly BLOOD ANGELS ANCIENTS add 1 to their Leadership. In addition, roll a D6 each time a BLOOD ANGELS INFANTRY model is destroyed within 6&quot; of any friendly BLOOD ANGELS ANCIENTS, before removing the model as a casualty. On a 4+ that model musters one last surge of strength before succumbing to its wounds; it can either shoot with one of its weapons as if it were the Shooting phase, or make a single attack as if it were the Fight phase. ">
           <repeats/>
           <conditions>
             <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f7d8-a545-2f41-e170" type="equalTo"/>
           </conditions>
           <conditionGroups/>
         </modifier>
-        <modifier type="set" field="21befb24-fc85-4f52-a745-64b2e48f8228" value="&lt;b&gt;FLESH TEARERS&lt;/b&gt; units within 6&quot; of any friendly &lt;b&gt;FLESH TEARERS&lt;/b&gt; &lt;b&gt;ANCIENTS&lt;/b&gt; add 1 to their Leadership. In addition, roll a D6 each time a &lt;b&gt;FLESH TEARERS&lt;/b&gt; &lt;b&gt;INFANTRY&lt;/b&gt; model is destroyed within 6&quot; of any friendly &lt;b&gt;FLESH TEARERS&lt;/b&gt; &lt;b&gt;ANCIENTS&lt;/b&gt;, before removing the model as a casualty. On a 4+ that model musters one last surge of strength before succumbing to its wounds; it can either shoot with one of its weapons as if it were the Shooting phase, or make a single attack as if it were the Fight phase. ">
+        <modifier type="set" field="21befb24-fc85-4f52-a745-64b2e48f8228" value="FLESH TEARERS units within 6&quot; of any friendly FLESH TEARERS ANCIENTS add 1 to their Leadership. In addition, roll a D6 each time a FLESH TEARERS INFANTRY model is destroyed within 6&quot; of any friendly FLESH TEARERS ANCIENTS, before removing the model as a casualty. On a 4+ that model musters one last surge of strength before succumbing to its wounds; it can either shoot with one of its weapons as if it were the Shooting phase, or make a single attack as if it were the Fight phase. ">
           <repeats/>
           <conditions>
             <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="bc53-ab33-e8f1-679b" type="equalTo"/>
@@ -25943,7 +25943,7 @@
         </modifier>
       </modifiers>
       <characteristics>
-        <characteristic name="Description" characteristicTypeId="21befb24-fc85-4f52-a745-64b2e48f8228" value="&lt;b&gt;&amp;lt;CHAPTER&amp;gt;&lt;/b&gt; units within 6&quot; of any friendly &lt;b&gt;&amp;lt;CHAPTER&amp;gt;&lt;/b&gt; &lt;b&gt;ANCIENTS&lt;/b&gt; add 1 to their Leadership. In addition, roll a D6 each time a &lt;b&gt;&amp;lt;CHAPTER&amp;gt;&lt;/b&gt; &lt;b&gt;INFANTRY&lt;/b&gt; model is destroyed within 6&quot; of any friendly &lt;b&gt;&amp;lt;CHAPTER&amp;gt;&lt;/b&gt; &lt;b&gt;ANCIENTS&lt;/b&gt;, before removing the model as a casualty. On a 4+ that model musters one last surge of strength before succumbing to its wounds; it can either shoot with one of its weapons as if it were the Shooting phase, or make a single attack as if it were the Fight phase. "/>
+        <characteristic name="Description" characteristicTypeId="21befb24-fc85-4f52-a745-64b2e48f8228" value="&amp;lt;CHAPTER&amp;gt; units within 6&quot; of any friendly &amp;lt;CHAPTER&amp;gt; ANCIENTS add 1 to their Leadership. In addition, roll a D6 each time a &amp;lt;CHAPTER&amp;gt; INFANTRY model is destroyed within 6&quot; of any friendly &amp;lt;CHAPTER&amp;gt; ANCIENTS, before removing the model as a casualty. On a 4+ that model musters one last surge of strength before succumbing to its wounds; it can either shoot with one of its weapons as if it were the Shooting phase, or make a single attack as if it were the Fight phase. "/>
       </characteristics>
     </profile>
     <profile id="bbbc-22c8-630e-2c99" name="Command Squad Bodyguard" hidden="false" profileTypeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" profileTypeName="Abilities">
@@ -25951,14 +25951,14 @@
       <rules/>
       <infoLinks/>
       <modifiers>
-        <modifier type="set" field="21befb24-fc85-4f52-a745-64b2e48f8228" value="Roll a dice each time a friendly &lt;b&gt;BLOOD ANGELS&lt;/b&gt; &lt;b&gt;CHARACTER&lt;/b&gt; loses a wound whilst they are within 3&quot; of this unit; on a 2+ a model from this squad can intercept that hit - the character does not lose a wound but this unit suffers a mortal wound.">
+        <modifier type="set" field="21befb24-fc85-4f52-a745-64b2e48f8228" value="Roll a dice each time a friendly BLOOD ANGELS CHARACTER loses a wound whilst they are within 3&quot; of this unit; on a 2+ a model from this squad can intercept that hit - the character does not lose a wound but this unit suffers a mortal wound.">
           <repeats/>
           <conditions>
             <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f7d8-a545-2f41-e170" type="equalTo"/>
           </conditions>
           <conditionGroups/>
         </modifier>
-        <modifier type="set" field="21befb24-fc85-4f52-a745-64b2e48f8228" value="Roll a dice each time a friendly &lt;b&gt;FLESH TEARERS&lt;/b&gt; &lt;b&gt;CHARACTER&lt;/b&gt; loses a wound whilst they are within 3&quot; of this unit; on a 2+ a model from this squad can intercept that hit - the character does not lose a wound but this unit suffers a mortal wound.">
+        <modifier type="set" field="21befb24-fc85-4f52-a745-64b2e48f8228" value="Roll a dice each time a friendly FLESH TEARERS CHARACTER loses a wound whilst they are within 3&quot; of this unit; on a 2+ a model from this squad can intercept that hit - the character does not lose a wound but this unit suffers a mortal wound.">
           <repeats/>
           <conditions>
             <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="bc53-ab33-e8f1-679b" type="equalTo"/>
@@ -25967,7 +25967,7 @@
         </modifier>
       </modifiers>
       <characteristics>
-        <characteristic name="Description" characteristicTypeId="21befb24-fc85-4f52-a745-64b2e48f8228" value="Roll a dice each time a friendly &lt;b&gt;&amp;lt;CHAPTER&amp;gt;&lt;/b&gt; &lt;b&gt;CHARACTER&lt;/b&gt; loses a wound whilst they are within 3&quot; of this unit; on a 2+ a model from this squad can intercept that hit - the character does not lose a wound but this unit suffers a mortal wound."/>
+        <characteristic name="Description" characteristicTypeId="21befb24-fc85-4f52-a745-64b2e48f8228" value="Roll a dice each time a friendly &amp;lt;CHAPTER&amp;gt; CHARACTER loses a wound whilst they are within 3&quot; of this unit; on a 2+ a model from this squad can intercept that hit - the character does not lose a wound but this unit suffers a mortal wound."/>
       </characteristics>
     </profile>
     <profile id="8d72-906f-dbea-c860" name="Black Rage" hidden="false" profileTypeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" profileTypeName="Abilities">
@@ -25985,7 +25985,7 @@
       <infoLinks/>
       <modifiers/>
       <characteristics>
-        <characteristic name="Description" characteristicTypeId="21befb24-fc85-4f52-a745-64b2e48f8228" value="This model must make a Heroic Intervention if it is able to do so. In addition, you can re-roll any failed hit rolls for this model in the Fight phase when targeting a &lt;b&gt;CHARACTER&lt;/b&gt;."/>
+        <characteristic name="Description" characteristicTypeId="21befb24-fc85-4f52-a745-64b2e48f8228" value="This model must make a Heroic Intervention if it is able to do so. In addition, you can re-roll any failed hit rolls for this model in the Fight phase when targeting a CHARACTER."/>
       </characteristics>
     </profile>
     <profile id="8742-48fe-7dfc-a1c0" name="Iron Halo" hidden="false" profileTypeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" profileTypeName="Abilities">
@@ -26011,14 +26011,14 @@
       <rules/>
       <infoLinks/>
       <modifiers>
-        <modifier type="set" field="21befb24-fc85-4f52-a745-64b2e48f8228" value="You can re-roll failed hit rolls in the Fight phase for friendly &lt;b&gt;BLOOD ANGELS&lt;/b&gt; units within 6&quot; of this model.">
+        <modifier type="set" field="21befb24-fc85-4f52-a745-64b2e48f8228" value="You can re-roll failed hit rolls in the Fight phase for friendly BLOOD ANGELS units within 6&quot; of this model.">
           <repeats/>
           <conditions>
             <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f7d8-a545-2f41-e170" type="equalTo"/>
           </conditions>
           <conditionGroups/>
         </modifier>
-        <modifier type="set" field="21befb24-fc85-4f52-a745-64b2e48f8228" value="You can re-roll failed hit rolls in the Fight phase for friendly &lt;b&gt;FLESH TEARERS&lt;/b&gt; units within 6&quot; of this model.">
+        <modifier type="set" field="21befb24-fc85-4f52-a745-64b2e48f8228" value="You can re-roll failed hit rolls in the Fight phase for friendly FLESH TEARERS units within 6&quot; of this model.">
           <repeats/>
           <conditions>
             <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="bc53-ab33-e8f1-679b" type="equalTo"/>
@@ -26027,7 +26027,7 @@
         </modifier>
       </modifiers>
       <characteristics>
-        <characteristic name="Description" characteristicTypeId="21befb24-fc85-4f52-a745-64b2e48f8228" value="You can re-roll failed hit rolls in the Fight phase for friendly &lt;b&gt;&amp;lt;CHAPTER&amp;gt;&lt;/b&gt; units within 6&quot; of this model."/>
+        <characteristic name="Description" characteristicTypeId="21befb24-fc85-4f52-a745-64b2e48f8228" value="You can re-roll failed hit rolls in the Fight phase for friendly &amp;lt;CHAPTER&amp;gt; units within 6&quot; of this model."/>
       </characteristics>
     </profile>
     <profile id="cf04-2c83-f5e1-9fb4" name="Rites of Battle" hidden="false" profileTypeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" profileTypeName="Abilities">
@@ -26035,14 +26035,14 @@
       <rules/>
       <infoLinks/>
       <modifiers>
-        <modifier type="set" field="21befb24-fc85-4f52-a745-64b2e48f8228" value="You can re-roll hit rolls of 1 made for friendly &lt;b&gt;BLOOD ANGELS&lt;/b&gt; units within 6&quot; of this model.">
+        <modifier type="set" field="21befb24-fc85-4f52-a745-64b2e48f8228" value="You can re-roll hit rolls of 1 made for friendly BLOOD ANGELS units within 6&quot; of this model.">
           <repeats/>
           <conditions>
             <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f7d8-a545-2f41-e170" type="equalTo"/>
           </conditions>
           <conditionGroups/>
         </modifier>
-        <modifier type="set" field="21befb24-fc85-4f52-a745-64b2e48f8228" value="You can re-roll hit rolls of 1 made for friendly &lt;b&gt;FLESH TEARERS&lt;/b&gt; units within 6&quot; of this model.">
+        <modifier type="set" field="21befb24-fc85-4f52-a745-64b2e48f8228" value="You can re-roll hit rolls of 1 made for friendly FLESH TEARERS units within 6&quot; of this model.">
           <repeats/>
           <conditions>
             <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="bc53-ab33-e8f1-679b" type="equalTo"/>
@@ -26051,7 +26051,7 @@
         </modifier>
       </modifiers>
       <characteristics>
-        <characteristic name="Description" characteristicTypeId="21befb24-fc85-4f52-a745-64b2e48f8228" value="You can re-roll hit rolls of 1 made for friendly &lt;b&gt;&amp;lt;CHAPTER&amp;gt;&lt;/b&gt; units within 6&quot; of this model."/>
+        <characteristic name="Description" characteristicTypeId="21befb24-fc85-4f52-a745-64b2e48f8228" value="You can re-roll hit rolls of 1 made for friendly &amp;lt;CHAPTER&amp;gt; units within 6&quot; of this model."/>
       </characteristics>
     </profile>
     <profile id="1291-2924-8f8a-105c" name="Rosarius" hidden="false" profileTypeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" profileTypeName="Abilities">
@@ -26077,14 +26077,14 @@
       <rules/>
       <infoLinks/>
       <modifiers>
-        <modifier type="set" field="21befb24-fc85-4f52-a745-64b2e48f8228" value="All friendly &lt;b&gt;BLOOD ANGELS&lt;/b&gt; units within 6&quot; of this model can use the Chaplain&apos;s Leadership instead of their own.">
+        <modifier type="set" field="21befb24-fc85-4f52-a745-64b2e48f8228" value="All friendly BLOOD ANGELS units within 6&quot; of this model can use the Chaplain&apos;s Leadership instead of their own.">
           <repeats/>
           <conditions>
             <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f7d8-a545-2f41-e170" type="equalTo"/>
           </conditions>
           <conditionGroups/>
         </modifier>
-        <modifier type="set" field="21befb24-fc85-4f52-a745-64b2e48f8228" value="All friendly &lt;b&gt;FLESH TEARERS&lt;/b&gt; units within 6&quot; of this model can use the Chaplain&apos;s Leadership instead of their own.">
+        <modifier type="set" field="21befb24-fc85-4f52-a745-64b2e48f8228" value="All friendly FLESH TEARERS units within 6&quot; of this model can use the Chaplain&apos;s Leadership instead of their own.">
           <repeats/>
           <conditions>
             <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="bc53-ab33-e8f1-679b" type="equalTo"/>
@@ -26093,7 +26093,7 @@
         </modifier>
       </modifiers>
       <characteristics>
-        <characteristic name="Description" characteristicTypeId="21befb24-fc85-4f52-a745-64b2e48f8228" value="All friendly &lt;b&gt;&amp;lt;CHAPTER&amp;gt;&lt;/b&gt; units within 6&quot; of this model can use the Chaplain&apos;s Leadership instead of their own."/>
+        <characteristic name="Description" characteristicTypeId="21befb24-fc85-4f52-a745-64b2e48f8228" value="All friendly &amp;lt;CHAPTER&amp;gt; units within 6&quot; of this model can use the Chaplain&apos;s Leadership instead of their own."/>
       </characteristics>
     </profile>
     <profile id="4243-5016-c4d9-2b6b" name="Teleport Strike" hidden="false" profileTypeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" profileTypeName="Abilities">
@@ -26429,7 +26429,7 @@
       <infoLinks/>
       <modifiers/>
       <characteristics>
-        <characteristic name="Description" characteristicTypeId="21befb24-fc85-4f52-a745-64b2e48f8228" value="You can add 1 to Deny the Witch tests you take for this model against enemy &lt;b&gt;PSYKERS&lt;/b&gt; within 12&quot;."/>
+        <characteristic name="Description" characteristicTypeId="21befb24-fc85-4f52-a745-64b2e48f8228" value="You can add 1 to Deny the Witch tests you take for this model against enemy PSYKERS within 12&quot;."/>
       </characteristics>
     </profile>
     <profile id="7db2-d937-f095-bb3a" name="Librarian in Terminator Armour" hidden="false" profileTypeId="800f-21d0-4387-c943" profileTypeName="Unit">
@@ -26523,7 +26523,7 @@
       <infoLinks/>
       <modifiers/>
       <characteristics>
-        <characteristic name="Description" characteristicTypeId="21befb24-fc85-4f52-a745-64b2e48f8228" value="You can re-roll wound rolls of 1 for friendly &lt;b&gt;&amp;lt;CHAPTER&amp;gt;&lt;/b&gt; units that are within 6&quot; of this model."/>
+        <characteristic name="Description" characteristicTypeId="21befb24-fc85-4f52-a745-64b2e48f8228" value="You can re-roll wound rolls of 1 for friendly &amp;lt;CHAPTER&amp;gt; units that are within 6&quot; of this model."/>
       </characteristics>
     </profile>
     <profile id="6e55-5deb-c20c-ae39" name="Razorback" hidden="false" profileTypeId="800f-21d0-4387-c943" profileTypeName="Unit">
@@ -26608,14 +26608,14 @@
       <rules/>
       <infoLinks/>
       <modifiers>
-        <modifier type="set" field="21befb24-fc85-4f52-a745-64b2e48f8228" value="At the end of any of your Movement phases, the Apothecary can attempt to heal or revive a single model. Select a friendly &lt;b&gt;BLOOD ANGELS&lt;/b&gt; &lt;b&gt;INFANTRY&lt;/b&gt; or &lt;b&gt;BIKER&lt;/b&gt; unit within 3&quot; of the Apothecary. If that unit contains a wounded model, it immediately regains D3 lost wounds. If the chosen unit contains no wounded models but one or more of its models have been slain during the battle, roll a D6. On a 4+ a single slain model is returned to the unit with 1 wound remaining. If the Apothecary fails to revive a model he can do nothing else for the remainder of the turn (shoot, charge, fight, etc.) as he recovers the gene-seed of the fallen warrior. A unit can only be the target of the Narthecium ability once in each turn.">
+        <modifier type="set" field="21befb24-fc85-4f52-a745-64b2e48f8228" value="At the end of any of your Movement phases, the Apothecary can attempt to heal or revive a single model. Select a friendly BLOOD ANGELS INFANTRY or BIKER unit within 3&quot; of the Apothecary. If that unit contains a wounded model, it immediately regains D3 lost wounds. If the chosen unit contains no wounded models but one or more of its models have been slain during the battle, roll a D6. On a 4+ a single slain model is returned to the unit with 1 wound remaining. If the Apothecary fails to revive a model he can do nothing else for the remainder of the turn (shoot, charge, fight, etc.) as he recovers the gene-seed of the fallen warrior. A unit can only be the target of the Narthecium ability once in each turn.">
           <repeats/>
           <conditions>
             <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f7d8-a545-2f41-e170" type="equalTo"/>
           </conditions>
           <conditionGroups/>
         </modifier>
-        <modifier type="set" field="21befb24-fc85-4f52-a745-64b2e48f8228" value="At the end of any of your Movement phases, the Apothecary can attempt to heal or revive a single model. Select a friendly &lt;b&gt;FLESH TEARERS&lt;/b&gt; &lt;b&gt;INFANTRY&lt;/b&gt; or &lt;b&gt;BIKER&lt;/b&gt; unit within 3&quot; of the Apothecary. If that unit contains a wounded model, it immediately regains D3 lost wounds. If the chosen unit contains no wounded models but one or more of its models have been slain during the battle, roll a D6. On a 4+ a single slain model is returned to the unit with 1 wound remaining. If the Apothecary fails to revive a model he can do nothing else for the remainder of the turn (shoot, charge, fight, etc.) as he recovers the gene-seed of the fallen warrior. A unit can only be the target of the Narthecium ability once in each turn.">
+        <modifier type="set" field="21befb24-fc85-4f52-a745-64b2e48f8228" value="At the end of any of your Movement phases, the Apothecary can attempt to heal or revive a single model. Select a friendly FLESH TEARERS INFANTRY or BIKER unit within 3&quot; of the Apothecary. If that unit contains a wounded model, it immediately regains D3 lost wounds. If the chosen unit contains no wounded models but one or more of its models have been slain during the battle, roll a D6. On a 4+ a single slain model is returned to the unit with 1 wound remaining. If the Apothecary fails to revive a model he can do nothing else for the remainder of the turn (shoot, charge, fight, etc.) as he recovers the gene-seed of the fallen warrior. A unit can only be the target of the Narthecium ability once in each turn.">
           <repeats/>
           <conditions>
             <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="bc53-ab33-e8f1-679b" type="equalTo"/>
@@ -26624,7 +26624,7 @@
         </modifier>
       </modifiers>
       <characteristics>
-        <characteristic name="Description" characteristicTypeId="21befb24-fc85-4f52-a745-64b2e48f8228" value="At the end of any of your Movement phases, the Apothecary can attempt to heal or revive a single model. Select a friendly &lt;b&gt;&amp;lt;CHAPTER&amp;gt;&lt;/b&gt; &lt;b&gt;INFANTRY&lt;/b&gt; or &lt;b&gt;BIKER&lt;/b&gt; unit within 3&quot; of the Apothecary. If that unit contains a wounded model, it immediately regains D3 lost wounds. If the chosen unit contains no wounded models but one or more of its models have been slain during the battle, roll a D6. On a 4+ a single slain model is returned to the unit with 1 wound remaining. If the Apothecary fails to revive a model he can do nothing else for the remainder of the turn (shoot, charge, fight, etc.) as he recovers the gene-seed of the fallen warrior. A unit can only be the target of the Narthecium ability once in each turn."/>
+        <characteristic name="Description" characteristicTypeId="21befb24-fc85-4f52-a745-64b2e48f8228" value="At the end of any of your Movement phases, the Apothecary can attempt to heal or revive a single model. Select a friendly &amp;lt;CHAPTER&amp;gt; INFANTRY or BIKER unit within 3&quot; of the Apothecary. If that unit contains a wounded model, it immediately regains D3 lost wounds. If the chosen unit contains no wounded models but one or more of its models have been slain during the battle, roll a D6. On a 4+ a single slain model is returned to the unit with 1 wound remaining. If the Apothecary fails to revive a model he can do nothing else for the remainder of the turn (shoot, charge, fight, etc.) as he recovers the gene-seed of the fallen warrior. A unit can only be the target of the Narthecium ability once in each turn."/>
       </characteristics>
     </profile>
     <profile id="c4a1-ef2a-655c-23a6" name="Scout Biker" hidden="false" profileTypeId="800f-21d0-4387-c943" profileTypeName="Unit">
@@ -26761,7 +26761,7 @@
       <infoLinks/>
       <modifiers/>
       <characteristics>
-        <characteristic name="Description" characteristicTypeId="21befb24-fc85-4f52-a745-64b2e48f8228" value="At the end of your Movement phase this model can repair a single &lt;b&gt;BLOOD ANGELS&lt;/b&gt; &lt;b&gt;VEHICLE&lt;/b&gt; within 1&quot;. That model regains D3 lost wounds. A model can only be repaired once per turn."/>
+        <characteristic name="Description" characteristicTypeId="21befb24-fc85-4f52-a745-64b2e48f8228" value="At the end of your Movement phase this model can repair a single BLOOD ANGELS VEHICLE within 1&quot;. That model regains D3 lost wounds. A model can only be repaired once per turn."/>
       </characteristics>
     </profile>
     <profile id="be94-de20-55b3-5e4b" name="Techmarine on Bike" hidden="false" profileTypeId="800f-21d0-4387-c943" profileTypeName="Unit">
@@ -26796,7 +26796,7 @@
       <infoLinks/>
       <modifiers/>
       <characteristics>
-        <characteristic name="Description" characteristicTypeId="21befb24-fc85-4f52-a745-64b2e48f8228" value="If this unit has a teleport homer, place it anywhere in your deployment zone when your army deploys. If an enemy model is ever within 9&quot; of the teleport homer, it is deactivated and removed from the battlefield. Whilst there are any friendly &lt;b&gt;&amp;lt;CHAPTER&amp;gt;&lt;/b&gt; teleport homers on the battlefield, this unit can perform an emergency teleport instead of moving in its Movement phase. At the end of the Movement phase, remove this unit and then set it up with all models within 6&quot; of a friendly &lt;b&gt;&amp;lt;CHAPTER&amp;gt;&lt;/b&gt; teleport homer. That teleport homer is then removed from the battlefield."/>
+        <characteristic name="Description" characteristicTypeId="21befb24-fc85-4f52-a745-64b2e48f8228" value="If this unit has a teleport homer, place it anywhere in your deployment zone when your army deploys. If an enemy model is ever within 9&quot; of the teleport homer, it is deactivated and removed from the battlefield. Whilst there are any friendly &amp;lt;CHAPTER&amp;gt; teleport homers on the battlefield, this unit can perform an emergency teleport instead of moving in its Movement phase. At the end of the Movement phase, remove this unit and then set it up with all models within 6&quot; of a friendly &amp;lt;CHAPTER&amp;gt; teleport homer. That teleport homer is then removed from the battlefield."/>
       </characteristics>
     </profile>
     <profile id="34e6-6d54-fe10-c7d3" name="Terminator" hidden="false" profileTypeId="800f-21d0-4387-c943" profileTypeName="Unit">
@@ -26906,7 +26906,7 @@
         <characteristic name="S" characteristicTypeId="59b1-319e-ec13-d466" value="+2"/>
         <characteristic name="AP" characteristicTypeId="75aa-a838-b675-6484" value="-3"/>
         <characteristic name="D" characteristicTypeId="ae8a-3137-d65b-4ca7" value="D3"/>
-        <characteristic name="Abilities" characteristicTypeId="837d-5e63-aeb7-1410" value="You can re-roll failed wound rolls for this weapon if the target is a &lt;b&gt;CHARACTER&lt;/b&gt;."/>
+        <characteristic name="Abilities" characteristicTypeId="837d-5e63-aeb7-1410" value="You can re-roll failed wound rolls for this weapon if the target is a CHARACTER."/>
       </characteristics>
     </profile>
     <profile id="800f-fd1d-4eaf-8b88" name="The Blood Crozius" hidden="false" profileTypeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" profileTypeName="Weapon">
@@ -27213,14 +27213,14 @@
       <rules/>
       <infoLinks/>
       <modifiers>
-        <modifier type="set" field="21befb24-fc85-4f52-a745-64b2e48f8228" value="Friendly &lt;b&gt;BLOOD ANGELS&lt;/b&gt; &lt;b&gt;INFANTRY&lt;/b&gt; and &lt;b&gt;BIKER&lt;/b&gt; units increase their Strength characteristic by 1 whilst they are within 6&quot; of any &lt;b&gt;SANGUINARY PRIESTS&lt;/b&gt;.">
+        <modifier type="set" field="21befb24-fc85-4f52-a745-64b2e48f8228" value="Friendly BLOOD ANGELS INFANTRY and BIKER units increase their Strength characteristic by 1 whilst they are within 6&quot; of any SANGUINARY PRIESTS.">
           <repeats/>
           <conditions>
             <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f7d8-a545-2f41-e170" type="equalTo"/>
           </conditions>
           <conditionGroups/>
         </modifier>
-        <modifier type="set" field="21befb24-fc85-4f52-a745-64b2e48f8228" value="Friendly &lt;b&gt;FLESH TEARERS&lt;/b&gt; &lt;b&gt;INFANTRY&lt;/b&gt; and &lt;b&gt;BIKER&lt;/b&gt; units increase their Strength characteristic by 1 whilst they are within 6&quot; of any &lt;b&gt;SANGUINARY PRIESTS&lt;/b&gt;.">
+        <modifier type="set" field="21befb24-fc85-4f52-a745-64b2e48f8228" value="Friendly FLESH TEARERS INFANTRY and BIKER units increase their Strength characteristic by 1 whilst they are within 6&quot; of any SANGUINARY PRIESTS.">
           <repeats/>
           <conditions>
             <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="bc53-ab33-e8f1-679b" type="equalTo"/>
@@ -27229,7 +27229,7 @@
         </modifier>
       </modifiers>
       <characteristics>
-        <characteristic name="Description" characteristicTypeId="21befb24-fc85-4f52-a745-64b2e48f8228" value="Friendly &lt;b&gt;&amp;lt;CHAPTER&amp;gt;&lt;/b&gt; &lt;b&gt;INFANTRY&lt;/b&gt; and &lt;b&gt;BIKER&lt;/b&gt; units increase their Strength characteristic by 1 whilst they are within 6&quot; of any &lt;b&gt;SANGUINARY PRIESTS&lt;/b&gt;."/>
+        <characteristic name="Description" characteristicTypeId="21befb24-fc85-4f52-a745-64b2e48f8228" value="Friendly &amp;lt;CHAPTER&amp;gt; INFANTRY and BIKER units increase their Strength characteristic by 1 whilst they are within 6&quot; of any SANGUINARY PRIESTS."/>
       </characteristics>
     </profile>
     <profile id="88e8-08cf-db87-aa86" name="Sanguinary Priest on Bike" hidden="false" profileTypeId="800f-21d0-4387-c943" profileTypeName="Unit">
@@ -27288,14 +27288,14 @@
       <rules/>
       <infoLinks/>
       <modifiers>
-        <modifier type="set" field="21befb24-fc85-4f52-a745-64b2e48f8228" value="You can re-roll failed hit rolls for this model if it is within 6&quot; of a &lt;b&gt;BLOOD ANGELS&lt;/b&gt; Warlord.">
+        <modifier type="set" field="21befb24-fc85-4f52-a745-64b2e48f8228" value="You can re-roll failed hit rolls for this model if it is within 6&quot; of a BLOOD ANGELS Warlord.">
           <repeats/>
           <conditions>
             <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f7d8-a545-2f41-e170" type="equalTo"/>
           </conditions>
           <conditionGroups/>
         </modifier>
-        <modifier type="set" field="21befb24-fc85-4f52-a745-64b2e48f8228" value="You can re-roll failed hit rolls for this model if it is within 6&quot; of a &lt;b&gt;FLESH TEARERS&lt;/b&gt; Warlord.">
+        <modifier type="set" field="21befb24-fc85-4f52-a745-64b2e48f8228" value="You can re-roll failed hit rolls for this model if it is within 6&quot; of a FLESH TEARERS Warlord.">
           <repeats/>
           <conditions>
             <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="bc53-ab33-e8f1-679b" type="equalTo"/>
@@ -27304,7 +27304,7 @@
         </modifier>
       </modifiers>
       <characteristics>
-        <characteristic name="Description" characteristicTypeId="21befb24-fc85-4f52-a745-64b2e48f8228" value="You can re-roll failed hit rolls for this model if it is within 6&quot; of a &lt;b&gt;&amp;lt;CHAPTER&amp;gt;&lt;/b&gt; Warlord."/>
+        <characteristic name="Description" characteristicTypeId="21befb24-fc85-4f52-a745-64b2e48f8228" value="You can re-roll failed hit rolls for this model if it is within 6&quot; of a &amp;lt;CHAPTER&amp;gt; Warlord."/>
       </characteristics>
     </profile>
     <profile id="eb92-1b6d-b645-12ad" name="Terminator Ancient" hidden="false" profileTypeId="800f-21d0-4387-c943" profileTypeName="Unit">
@@ -27398,7 +27398,7 @@
       <infoLinks/>
       <modifiers/>
       <characteristics>
-        <characteristic name="Description" characteristicTypeId="21befb24-fc85-4f52-a745-64b2e48f8228" value="If a model with a magna-grapple targets a &lt;b&gt;VEHICLE&lt;/b&gt; in the Charge phase, you can add 2 to its charge roll."/>
+        <characteristic name="Description" characteristicTypeId="21befb24-fc85-4f52-a745-64b2e48f8228" value="If a model with a magna-grapple targets a VEHICLE in the Charge phase, you can add 2 to its charge roll."/>
       </characteristics>
     </profile>
     <profile id="79b1-6a5e-70fc-d572" name="Furioso Dreadnought" hidden="false" profileTypeId="800f-21d0-4387-c943" profileTypeName="Unit">

--- a/Imperium - Legion of the Damned.cat
+++ b/Imperium - Legion of the Damned.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="d360-802a-45b3-4f4a" name="Imperium - Legion of the Damned" book="Index: Imperium 1" revision="3" battleScribeVersion="2.01" authorName="Crowbar90" gameSystemId="28ec-711c-d87f-3aeb" gameSystemRevision="1" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="d360-802a-45b3-4f4a" name="Imperium - Legion of the Damned" book="Index: Imperium 1" revision="4" battleScribeVersion="2.01" authorName="Crowbar90" gameSystemId="28ec-711c-d87f-3aeb" gameSystemRevision="1" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <profiles/>
   <rules/>
   <infoLinks/>
@@ -57,7 +57,18 @@
   </entryLinks>
   <sharedSelectionEntries>
     <selectionEntry id="61a6-2734-a069-1ba7" name="Damned Legionnaires" book="Index: Imperium 1" page="87" hidden="false" collective="false" type="unit">
-      <profiles/>
+      <profiles>
+        <profile id="7f49-034c-ef08-45b0" name="Keywords" hidden="false" profileTypeId="b900-0afb-e411-2cbb" profileTypeName="Keywords">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Keywords (Faction)" characteristicTypeId="6b92-2d97-5144-62bc" value="IMPERIUM, ADEPTUS ASTARTES, LEGION OF THE DAMNED"/>
+            <characteristic name="Keywords (Basic)" characteristicTypeId="ce6c-4765-4bb8-bd49" value="INFANTRY, DAMNED LEGIONNAIRES"/>
+          </characteristics>
+        </profile>
+      </profiles>
       <rules/>
       <infoLinks>
         <infoLink id="5ac2-2b88-93b3-3449" name="New InfoLink" hidden="false" targetId="4ea8-94d3-ba39-042f" type="rule">

--- a/Imperium - Questor Imperialis.cat
+++ b/Imperium - Questor Imperialis.cat
@@ -1,10 +1,18 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="82cd-d24f-9f22-11f3" name="Imperium - Questor Imperialis" book="Index: Imperium 2" revision="2" battleScribeVersion="2.01" authorName="Crowbar90" gameSystemId="28ec-711c-d87f-3aeb" gameSystemRevision="1" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="82cd-d24f-9f22-11f3" name="Imperium - Questor Imperialis" book="Index: Imperium 2" revision="3" battleScribeVersion="2.01" authorName="Crowbar90" gameSystemId="28ec-711c-d87f-3aeb" gameSystemRevision="1" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <profiles/>
   <rules/>
   <infoLinks/>
   <costTypes/>
-  <profileTypes/>
+  <profileTypes>
+    <profileType id="6535-c5b9-7431-63ec" name="Explosion">
+      <characteristicTypes>
+        <characteristicType id="3684-f9d8-8984-a2bc" name="Dice roll"/>
+        <characteristicType id="0cfb-ee72-50d6-0cfb" name="Distance"/>
+        <characteristicType id="a56d-fa6c-e1ee-bbe0" name="Mortal wounds"/>
+      </characteristicTypes>
+    </profileType>
+  </profileTypes>
   <categoryEntries>
     <categoryEntry id="0dcf-a7d7-3f80-b95e" name="Faction: Imperium" hidden="false">
       <profiles/>
@@ -461,6 +469,31 @@
             <characteristic name="Characteristic 3" characteristicTypeId="df06-8eca-150f-90ba" value="5+"/>
           </characteristics>
         </profile>
+        <profile id="e086-1abc-fdc6-7a10" name="Keywords" hidden="false" profileTypeId="b900-0afb-e411-2cbb" profileTypeName="Keywords">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers>
+            <modifier type="set" field="6b92-2d97-5144-62bc" value="IMPERIUM, QUESTOR MECHANICUS, &lt;HOUSEHOLD&gt;">
+              <repeats/>
+              <conditions>
+                <condition field="selections" scope="bce6-bc24-a327-fc1c" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="5b8e-edbb-3261-b3e4" type="equalTo"/>
+              </conditions>
+              <conditionGroups/>
+            </modifier>
+            <modifier type="set" field="6b92-2d97-5144-62bc" value="IMPERIUM, QUESTOR IMPERIALIS, &lt;HOUSEHOLD&gt;">
+              <repeats/>
+              <conditions>
+                <condition field="selections" scope="bce6-bc24-a327-fc1c" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="39cf-6a3d-eb18-3381" type="equalTo"/>
+              </conditions>
+              <conditionGroups/>
+            </modifier>
+          </modifiers>
+          <characteristics>
+            <characteristic name="Keywords (Faction)" characteristicTypeId="6b92-2d97-5144-62bc" value="IMPERIUM, QUESTOR IMPERIALIS, &lt;HOUSEHOLD&gt;"/>
+            <characteristic name="Keywords (Basic)" characteristicTypeId="ce6c-4765-4bb8-bd49" value="TITANIC, VEHICLE, KNIGHT CRUSADER"/>
+          </characteristics>
+        </profile>
       </profiles>
       <rules/>
       <infoLinks>
@@ -476,7 +509,7 @@
           <infoLinks/>
           <modifiers/>
         </infoLink>
-        <infoLink id="9e74-4583-ba06-9daa" name="New InfoLink" hidden="false" targetId="383d-e9e6-b605-f6a9" type="profile">
+        <infoLink id="9e74-4583-ba06-9daa" name="Explodes" hidden="false" targetId="383d-e9e6-b605-f6a9" type="profile">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -556,7 +589,7 @@
           </constraints>
           <categoryLinks/>
         </entryLink>
-        <entryLink id="be91-76ac-9fe0-a3d1" name="New EntryLink" hidden="false" targetId="acd0-640d-3a46-780c" type="selectionEntryGroup">
+        <entryLink id="be91-76ac-9fe0-a3d1" name="Heavy Stubber/Meltagun" hidden="false" targetId="acd0-640d-3a46-780c" type="selectionEntryGroup">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -578,7 +611,7 @@
           </constraints>
           <categoryLinks/>
         </entryLink>
-        <entryLink id="6ce9-e48f-13a0-0338" name="New EntryLink" hidden="false" targetId="4524-229a-e82e-a647" type="selectionEntry">
+        <entryLink id="6ce9-e48f-13a0-0338" name="Titanic feet" hidden="false" targetId="4524-229a-e82e-a647" type="selectionEntry">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -608,6 +641,17 @@
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bc2a-a04d-c3be-7cf0" type="min"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d13b-dcf5-c254-cfb0" type="max"/>
+          </constraints>
+          <categoryLinks/>
+        </entryLink>
+        <entryLink id="1ad2-23e5-94da-18b8" name="Allegiance" hidden="false" targetId="088d-9d8c-e3ae-a1cd" type="selectionEntryGroup">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5285-82ca-963f-fac5" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b6e2-0f2b-acb1-f230" type="max"/>
           </constraints>
           <categoryLinks/>
         </entryLink>
@@ -703,6 +747,31 @@
             <characteristic name="Characteristic 1" characteristicTypeId="bf41-c860-50bc-2a7e" value="6&quot;"/>
             <characteristic name="Characteristic 2" characteristicTypeId="dc18-e51f-309b-8efa" value="5+"/>
             <characteristic name="Characteristic 3" characteristicTypeId="df06-8eca-150f-90ba" value="5+"/>
+          </characteristics>
+        </profile>
+        <profile id="1061-14b6-0713-7b46" name="Keywords" hidden="false" profileTypeId="b900-0afb-e411-2cbb" profileTypeName="Keywords">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers>
+            <modifier type="set" field="6b92-2d97-5144-62bc" value="IMPERIUM, QUESTOR IMPERIALIS, &lt;HOUSEHOLD&gt;">
+              <repeats/>
+              <conditions>
+                <condition field="selections" scope="85f3-42d9-9d08-f487" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="39cf-6a3d-eb18-3381" type="equalTo"/>
+              </conditions>
+              <conditionGroups/>
+            </modifier>
+            <modifier type="set" field="6b92-2d97-5144-62bc" value="IMPERIUM, QUESTOR MECHANICUS, &lt;HOUSEHOLD&gt;">
+              <repeats/>
+              <conditions>
+                <condition field="selections" scope="85f3-42d9-9d08-f487" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="5b8e-edbb-3261-b3e4" type="equalTo"/>
+              </conditions>
+              <conditionGroups/>
+            </modifier>
+          </modifiers>
+          <characteristics>
+            <characteristic name="Keywords (Faction)" characteristicTypeId="6b92-2d97-5144-62bc" value="IMPERIUM, QUESTOR IMPERIALIS, &lt;HOUSEHOLD&gt;"/>
+            <characteristic name="Keywords (Basic)" characteristicTypeId="ce6c-4765-4bb8-bd49" value="TITANIC, VEHICLE, KNIGHT ERRANT"/>
           </characteristics>
         </profile>
       </profiles>
@@ -844,6 +913,17 @@
           </constraints>
           <categoryLinks/>
         </entryLink>
+        <entryLink id="96ea-552e-3adf-6f3d" name="Allegiance" hidden="false" targetId="088d-9d8c-e3ae-a1cd" type="selectionEntryGroup">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="68f5-00f1-3f69-166f" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="782b-a6ee-8077-9f57" type="max"/>
+          </constraints>
+          <categoryLinks/>
+        </entryLink>
       </entryLinks>
       <costs>
         <cost name="pts" costTypeId="points" value="320.0"/>
@@ -898,6 +978,31 @@
             <characteristic name="Characteristic 1" characteristicTypeId="bf41-c860-50bc-2a7e" value="6&quot;"/>
             <characteristic name="Characteristic 2" characteristicTypeId="dc18-e51f-309b-8efa" value="5+"/>
             <characteristic name="Characteristic 3" characteristicTypeId="df06-8eca-150f-90ba" value="5+"/>
+          </characteristics>
+        </profile>
+        <profile id="8d0a-d14b-5cb5-a406" name="Keywords" hidden="false" profileTypeId="b900-0afb-e411-2cbb" profileTypeName="Keywords">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers>
+            <modifier type="set" field="6b92-2d97-5144-62bc" value="IMPERIUM, QUESTOR IMPERIALIS, &lt;HOUSEHOLD&gt;">
+              <repeats/>
+              <conditions>
+                <condition field="selections" scope="602c-d7c6-68b2-0f26" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="39cf-6a3d-eb18-3381" type="equalTo"/>
+              </conditions>
+              <conditionGroups/>
+            </modifier>
+            <modifier type="set" field="6b92-2d97-5144-62bc" value="IMPERIUM, QUESTOR MECHANICUS, &lt;HOUSEHOLD&gt;">
+              <repeats/>
+              <conditions>
+                <condition field="selections" scope="602c-d7c6-68b2-0f26" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="5b8e-edbb-3261-b3e4" type="equalTo"/>
+              </conditions>
+              <conditionGroups/>
+            </modifier>
+          </modifiers>
+          <characteristics>
+            <characteristic name="Keywords (Faction)" characteristicTypeId="6b92-2d97-5144-62bc" value="IMPERIUM, QUESTOR IMPERIALIS, &lt;HOUSEHOLD&gt;"/>
+            <characteristic name="Keywords (Basic)" characteristicTypeId="ce6c-4765-4bb8-bd49" value="TITANIC, VEHICLE, KNIGHT GALLANT"/>
           </characteristics>
         </profile>
       </profiles>
@@ -1017,7 +1122,7 @@
           </constraints>
           <categoryLinks/>
         </entryLink>
-        <entryLink id="ad42-8a5a-f3d5-2c2d" name="New EntryLink" hidden="false" targetId="c239-09b7-6bfc-4ab8" type="selectionEntry">
+        <entryLink id="ad42-8a5a-f3d5-2c2d" name="Reaper chainsword" hidden="false" targetId="c239-09b7-6bfc-4ab8" type="selectionEntry">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -1036,6 +1141,17 @@
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="038b-aa85-8f84-366e" type="min"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6746-9aae-8cbb-2659" type="max"/>
+          </constraints>
+          <categoryLinks/>
+        </entryLink>
+        <entryLink id="8630-1099-b693-7ab8" name="Allegiance" hidden="false" targetId="088d-9d8c-e3ae-a1cd" type="selectionEntryGroup">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b5ee-13b7-74d3-cbd9" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4b60-ea96-8e3f-6c92" type="max"/>
           </constraints>
           <categoryLinks/>
         </entryLink>
@@ -1095,10 +1211,35 @@
             <characteristic name="Characteristic 3" characteristicTypeId="df06-8eca-150f-90ba" value="5+"/>
           </characteristics>
         </profile>
+        <profile id="8d38-e1a4-36e0-109a" name="Keywords" hidden="false" profileTypeId="b900-0afb-e411-2cbb" profileTypeName="Keywords">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers>
+            <modifier type="set" field="6b92-2d97-5144-62bc" value="IMPERIUM, QUESTOR IMPERIALIS, &lt;HOUSEHOLD&gt;">
+              <repeats/>
+              <conditions>
+                <condition field="selections" scope="89d4-63ea-2c6f-4b49" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="39cf-6a3d-eb18-3381" type="equalTo"/>
+              </conditions>
+              <conditionGroups/>
+            </modifier>
+            <modifier type="set" field="6b92-2d97-5144-62bc" value="IMPERIUM, QUESTOR MECHANICUS, &lt;HOUSEHOLD&gt;">
+              <repeats/>
+              <conditions>
+                <condition field="selections" scope="89d4-63ea-2c6f-4b49" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="5b8e-edbb-3261-b3e4" type="equalTo"/>
+              </conditions>
+              <conditionGroups/>
+            </modifier>
+          </modifiers>
+          <characteristics>
+            <characteristic name="Keywords (Faction)" characteristicTypeId="6b92-2d97-5144-62bc" value="IMPERIUM, QUESTOR IMPERIALIS, &lt;HOUSEHOLD&gt;"/>
+            <characteristic name="Keywords (Basic)" characteristicTypeId="ce6c-4765-4bb8-bd49" value="TITANIC, VEHICLE, KNIGHT PALADIN"/>
+          </characteristics>
+        </profile>
       </profiles>
       <rules/>
       <infoLinks>
-        <infoLink id="13d0-4cf2-c055-a4f5" name="New InfoLink" hidden="false" targetId="db40-2166-fcdb-cd1a" type="profile">
+        <infoLink id="13d0-4cf2-c055-a4f5" name="Knight Paladin" hidden="false" targetId="db40-2166-fcdb-cd1a" type="profile">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -1245,6 +1386,17 @@
           </constraints>
           <categoryLinks/>
         </entryLink>
+        <entryLink id="25b2-3f73-4b02-cf33" name="Allegiance" hidden="false" targetId="088d-9d8c-e3ae-a1cd" type="selectionEntryGroup">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2ec2-a5e7-7eed-36f0" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7a07-d67b-8d20-ed9d" type="max"/>
+          </constraints>
+          <categoryLinks/>
+        </entryLink>
       </entryLinks>
       <costs>
         <cost name="pts" costTypeId="points" value="320.0"/>
@@ -1299,6 +1451,31 @@
             <characteristic name="Characteristic 1" characteristicTypeId="bf41-c860-50bc-2a7e" value="6&quot;"/>
             <characteristic name="Characteristic 2" characteristicTypeId="dc18-e51f-309b-8efa" value="5+"/>
             <characteristic name="Characteristic 3" characteristicTypeId="df06-8eca-150f-90ba" value="5+"/>
+          </characteristics>
+        </profile>
+        <profile id="14fb-68f8-801c-02c4" name="Keywords" hidden="false" profileTypeId="b900-0afb-e411-2cbb" profileTypeName="Keywords">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers>
+            <modifier type="set" field="6b92-2d97-5144-62bc" value="IMPERIUM, QUESTOR MECHANICUS, &lt;HOUSEHOLD&gt;">
+              <repeats/>
+              <conditions>
+                <condition field="selections" scope="d00a-1a85-1c0b-c4ac" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="5b8e-edbb-3261-b3e4" type="equalTo"/>
+              </conditions>
+              <conditionGroups/>
+            </modifier>
+            <modifier type="set" field="6b92-2d97-5144-62bc" value="IMPERIUM, QUESTOR IMPERIALIS, &lt;HOUSEHOLD&gt;">
+              <repeats/>
+              <conditions>
+                <condition field="selections" scope="d00a-1a85-1c0b-c4ac" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="39cf-6a3d-eb18-3381" type="equalTo"/>
+              </conditions>
+              <conditionGroups/>
+            </modifier>
+          </modifiers>
+          <characteristics>
+            <characteristic name="Keywords (Faction)" characteristicTypeId="6b92-2d97-5144-62bc" value="IMPERIUM, QUESTOR IMPERIALIS, &lt;HOUSEHOLD&gt;"/>
+            <characteristic name="Keywords (Basic)" characteristicTypeId="ce6c-4765-4bb8-bd49" value="TITANIC, VEHICLE, KNIGHT WARDEN"/>
           </characteristics>
         </profile>
       </profiles>
@@ -1429,7 +1606,7 @@
           </constraints>
           <categoryLinks/>
         </entryLink>
-        <entryLink id="f2cb-3cbc-b2d3-0d00" name="New EntryLink" hidden="false" targetId="534b-82a7-2512-10e3" type="selectionEntry">
+        <entryLink id="f2cb-3cbc-b2d3-0d00" name="Avenger gatling cannon" hidden="false" targetId="534b-82a7-2512-10e3" type="selectionEntry">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -1448,6 +1625,17 @@
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a38f-2415-1d80-7a44" type="min"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b37d-018f-67fc-088a" type="max"/>
+          </constraints>
+          <categoryLinks/>
+        </entryLink>
+        <entryLink id="3674-72f3-5de3-7642" name="Allegiance" hidden="false" targetId="088d-9d8c-e3ae-a1cd" type="selectionEntryGroup">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="805c-715f-fa8c-c58c" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="32c3-1939-d3c8-ede9" type="max"/>
           </constraints>
           <categoryLinks/>
         </entryLink>
@@ -1549,6 +1737,16 @@
             <characteristic name="Characteristic 1" characteristicTypeId="bf41-c860-50bc-2a7e" value="6&quot;"/>
             <characteristic name="Characteristic 2" characteristicTypeId="dc18-e51f-309b-8efa" value="5+"/>
             <characteristic name="Characteristic 3" characteristicTypeId="df06-8eca-150f-90ba" value="5+"/>
+          </characteristics>
+        </profile>
+        <profile id="4b50-d682-0c89-4b7d" name="Keywords" hidden="false" profileTypeId="b900-0afb-e411-2cbb" profileTypeName="Keywords">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Keywords (Faction)" characteristicTypeId="6b92-2d97-5144-62bc" value="IMPERIUM, QUESTOR IMPERIALIS, &lt;HOUSEHOLD&gt;"/>
+            <characteristic name="Keywords (Basic)" characteristicTypeId="ce6c-4765-4bb8-bd49" value="TITANIC, VEHICLE, CERASTUS KNIGHT-ATROPOS"/>
           </characteristics>
         </profile>
       </profiles>
@@ -2178,6 +2376,16 @@
             <characteristic name="Characteristic 3" characteristicTypeId="df06-8eca-150f-90ba" value="5+"/>
           </characteristics>
         </profile>
+        <profile id="88b3-f742-a1f6-8a59" name="Keywords" hidden="false" profileTypeId="b900-0afb-e411-2cbb" profileTypeName="Keywords">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Keywords (Faction)" characteristicTypeId="6b92-2d97-5144-62bc" value="IMPERIUM, QUESTOR IMPERIALIS, &lt;HOUSEHOLD&gt;"/>
+            <characteristic name="Keywords (Basic)" characteristicTypeId="ce6c-4765-4bb8-bd49" value="TITANIC, VEHICLE, ACASTUS KNIGHT PORPHYRION"/>
+          </characteristics>
+        </profile>
       </profiles>
       <rules/>
       <infoLinks>
@@ -2187,7 +2395,7 @@
           <infoLinks/>
           <modifiers/>
         </infoLink>
-        <infoLink id="0c62-c668-6585-20d2" name="Explodes (Unstable Reactor)" hidden="false" targetId="77eb-2a36-2c78-02d7" type="profile">
+        <infoLink id="0c62-c668-6585-20d2" name="Explodes (Unstable Reactor) (Acastus Knight Porphyrion)" hidden="false" targetId="fa1d-76c9-a3fb-7adf" type="profile">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -2417,6 +2625,16 @@
             <characteristic name="Characteristic 3" characteristicTypeId="df06-8eca-150f-90ba" value="5+"/>
           </characteristics>
         </profile>
+        <profile id="665c-5c1b-ebdc-b9ce" name="Keywords" hidden="false" profileTypeId="b900-0afb-e411-2cbb" profileTypeName="Keywords">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Keywords (Faction)" characteristicTypeId="6b92-2d97-5144-62bc" value="IMPERIUM, QUESTOR IMPERIALIS, &lt;HOUSEHOLD&gt;"/>
+            <characteristic name="Keywords (Basic)" characteristicTypeId="ce6c-4765-4bb8-bd49" value="TITANIC, VEHICLE, CERASTUS KNIGHT-ACHERON"/>
+          </characteristics>
+        </profile>
       </profiles>
       <rules/>
       <infoLinks>
@@ -2613,6 +2831,16 @@
             <characteristic name="Characteristic 3" characteristicTypeId="df06-8eca-150f-90ba" value="5+"/>
           </characteristics>
         </profile>
+        <profile id="a917-ed49-55bc-6487" name="Keywords" hidden="false" profileTypeId="b900-0afb-e411-2cbb" profileTypeName="Keywords">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Keywords (Faction)" characteristicTypeId="6b92-2d97-5144-62bc" value="IMPERIUM, QUESTOR IMPERIALIS, &lt;HOUSEHOLD&gt;"/>
+            <characteristic name="Keywords (Basic)" characteristicTypeId="ce6c-4765-4bb8-bd49" value="TITANIC, VEHICLE, CERASTUS KNIGHT-CASTIGATOR"/>
+          </characteristics>
+        </profile>
       </profiles>
       <rules/>
       <infoLinks>
@@ -2796,6 +3024,16 @@
             <characteristic name="Characteristic 1" characteristicTypeId="bf41-c860-50bc-2a7e" value="6&quot;"/>
             <characteristic name="Characteristic 2" characteristicTypeId="dc18-e51f-309b-8efa" value="5+"/>
             <characteristic name="Characteristic 3" characteristicTypeId="df06-8eca-150f-90ba" value="5+"/>
+          </characteristics>
+        </profile>
+        <profile id="fd6d-7a62-70d7-c7f2" name="Keywords" hidden="false" profileTypeId="b900-0afb-e411-2cbb" profileTypeName="Keywords">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Keywords (Faction)" characteristicTypeId="6b92-2d97-5144-62bc" value="IMPERIUM, QUESTOR IMPERIALIS, &lt;HOUSEHOLD&gt;"/>
+            <characteristic name="Keywords (Basic)" characteristicTypeId="ce6c-4765-4bb8-bd49" value="TITANIC, VEHICLE, CERASTUS KNIGHT-LANCER"/>
           </characteristics>
         </profile>
       </profiles>
@@ -2983,6 +3221,16 @@
             <characteristic name="Characteristic 3" characteristicTypeId="df06-8eca-150f-90ba" value="5+"/>
           </characteristics>
         </profile>
+        <profile id="3b02-6f16-5a1c-e7af" name="Keywords" hidden="false" profileTypeId="b900-0afb-e411-2cbb" profileTypeName="Keywords">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Keywords (Faction)" characteristicTypeId="6b92-2d97-5144-62bc" value="IMPERIUM, QUESTOR IMPERIALIS, &lt;HOUSEHOLD&gt;"/>
+            <characteristic name="Keywords (Basic)" characteristicTypeId="ce6c-4765-4bb8-bd49" value="TITANIC, VEHICLE, QUESTORIS KNIGHT MAGAERA"/>
+          </characteristics>
+        </profile>
       </profiles>
       <rules/>
       <infoLinks>
@@ -3126,6 +3374,7 @@
               </entryLinks>
               <costs>
                 <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="1.0"/>
+                <cost name="pts" costTypeId="points" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -3232,6 +3481,16 @@
             <characteristic name="Characteristic 1" characteristicTypeId="bf41-c860-50bc-2a7e" value="6&quot;"/>
             <characteristic name="Characteristic 2" characteristicTypeId="dc18-e51f-309b-8efa" value="5+"/>
             <characteristic name="Characteristic 3" characteristicTypeId="df06-8eca-150f-90ba" value="5+"/>
+          </characteristics>
+        </profile>
+        <profile id="f260-3252-44e8-4618" name="Keywords" hidden="false" profileTypeId="b900-0afb-e411-2cbb" profileTypeName="Keywords">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Keywords (Faction)" characteristicTypeId="6b92-2d97-5144-62bc" value="IMPERIUM, QUESTOR IMPERIALIS, &lt;HOUSEHOLD&gt;"/>
+            <characteristic name="Keywords (Basic)" characteristicTypeId="ce6c-4765-4bb8-bd49" value="TITANIC, VEHICLE, QUESTORIS KNIGHT STYRIX"/>
           </characteristics>
         </profile>
       </profiles>
@@ -3377,6 +3636,7 @@
               </entryLinks>
               <costs>
                 <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="1.0"/>
+                <cost name="pts" costTypeId="points" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -3434,6 +3694,30 @@
         <cost name="pts" costTypeId="points" value="340.0"/>
         <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="24.0"/>
       </costs>
+    </selectionEntry>
+    <selectionEntry id="39cf-6a3d-eb18-3381" name="Questor Imperialis" hidden="false" collective="false" type="upgrade">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints/>
+      <categoryLinks/>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs/>
+    </selectionEntry>
+    <selectionEntry id="5b8e-edbb-3261-b3e4" name="Questor Mechanicus" hidden="false" collective="false" type="upgrade">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints/>
+      <categoryLinks/>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs/>
     </selectionEntry>
   </sharedSelectionEntries>
   <sharedSelectionEntryGroups>
@@ -3557,6 +3841,38 @@
         </entryLink>
       </entryLinks>
     </selectionEntryGroup>
+    <selectionEntryGroup id="088d-9d8c-e3ae-a1cd" name="Allegiance" hidden="false" collective="false" defaultSelectionEntryId="dbf0-bdff-ea9a-b1e3">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints/>
+      <categoryLinks/>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks>
+        <entryLink id="dbf0-bdff-ea9a-b1e3" name="Questor Imperialis" hidden="false" targetId="39cf-6a3d-eb18-3381" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b2df-5b7c-cf5d-1e8d" type="max"/>
+          </constraints>
+          <categoryLinks/>
+        </entryLink>
+        <entryLink id="8971-7906-8c01-a5e9" name="Questor Mechanicus" hidden="false" targetId="5b8e-edbb-3261-b3e4" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e3eb-9bc7-3886-0e37" type="max"/>
+          </constraints>
+          <categoryLinks/>
+        </entryLink>
+      </entryLinks>
+    </selectionEntryGroup>
   </sharedSelectionEntryGroups>
   <sharedRules/>
   <sharedProfiles>
@@ -3641,7 +3957,7 @@
         <characteristic name="S" characteristicTypeId="59b1-319e-ec13-d466" value="7"/>
         <characteristic name="AP" characteristicTypeId="75aa-a838-b675-6484" value="-1"/>
         <characteristic name="D" characteristicTypeId="ae8a-3137-d65b-4ca7" value="2"/>
-        <characteristic name="Abilities" characteristicTypeId="837d-5e63-aeb7-1410" value="Add 1 to all hit rolls made for this weapon against targets that can &lt;b&gt;FLY&lt;/b&gt;. Subtract 1 from the hit rolls made for this weapon against all other targets."/>
+        <characteristic name="Abilities" characteristicTypeId="837d-5e63-aeb7-1410" value="Add 1 to all hit rolls made for this weapon against targets that can FLY. Subtract 1 from the hit rolls made for this weapon against all other targets."/>
       </characteristics>
     </profile>
     <profile id="ee70-067f-9240-1d9a" name="Reaper chainsword" book="Index: Imperium 2" hidden="false" profileTypeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" profileTypeName="Weapon">
@@ -3669,7 +3985,7 @@
         <characteristic name="S" characteristicTypeId="59b1-319e-ec13-d466" value="x2"/>
         <characteristic name="AP" characteristicTypeId="75aa-a838-b675-6484" value="-4"/>
         <characteristic name="D" characteristicTypeId="ae8a-3137-d65b-4ca7" value="6"/>
-        <characteristic name="Abilities" characteristicTypeId="837d-5e63-aeb7-1410" value="When attacking with this weapon, you must subtract 1 from the hit roll. If a &lt;b&gt;VEHICLE&lt;/b&gt; or &lt;b&gt;MONSTER&lt;/b&gt; is slain by this weapon, pick an enemy unit within 9&quot; of the bearer and roll a D6. On a 4+ that unit suffers D3 mortal wounds."/>
+        <characteristic name="Abilities" characteristicTypeId="837d-5e63-aeb7-1410" value="When attacking with this weapon, you must subtract 1 from the hit roll. If a VEHICLE or MONSTER is slain by this weapon, pick an enemy unit within 9&quot; of the bearer and roll a D6. On a 4+ that unit suffers D3 mortal wounds."/>
       </characteristics>
     </profile>
     <profile id="c356-bb44-78f4-f4dc" name="Titanic feet" book="Index: Imperium 2" hidden="false" profileTypeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" profileTypeName="Weapon">
@@ -3771,13 +4087,15 @@
         <characteristic name="Save" characteristicTypeId="c0df-df94-abd7-e8d3" value="3+"/>
       </characteristics>
     </profile>
-    <profile id="383d-e9e6-b605-f6a9" name="Explodes" hidden="false" profileTypeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" profileTypeName="Abilities">
+    <profile id="383d-e9e6-b605-f6a9" name="Explodes" hidden="false" profileTypeId="6535-c5b9-7431-63ec" profileTypeName="Explosion">
       <profiles/>
       <rules/>
       <infoLinks/>
       <modifiers/>
       <characteristics>
-        <characteristic name="Description" characteristicTypeId="21befb24-fc85-4f52-a745-64b2e48f8228" value="If this model is reduced to 0 wounds, roll a D6 before removing it from the battlefield. On a 6 it explodes, and each unit within 2D6&quot; suffers D6 mortal wounds."/>
+        <characteristic name="Dice roll" characteristicTypeId="3684-f9d8-8984-a2bc" value="6+"/>
+        <characteristic name="Distance" characteristicTypeId="0cfb-ee72-50d6-0cfb" value="2D6&quot;"/>
+        <characteristic name="Mortal wounds" characteristicTypeId="a56d-fa6c-e1ee-bbe0" value="D6"/>
       </characteristics>
     </profile>
     <profile id="7d1d-e7ee-9a4e-2821" name="Ion Shield" hidden="false" profileTypeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" profileTypeName="Abilities">
@@ -3795,7 +4113,7 @@
       <infoLinks/>
       <modifiers/>
       <characteristics>
-        <characteristic name="Description" characteristicTypeId="21befb24-fc85-4f52-a745-64b2e48f8228" value="This model can Fall Back in the Movement phase and still shoot and/or charge in the same turn. When this model Falls Back, it can move over enemy &lt;b&gt;INFANTRY&lt;/b&gt; models, thought it must end its move more than 1&quot; from any enemy units. In addition, this model can move and fire Heavy weapons without suffering the penalty to its hit rolls. Finally, this model only gains a bonus to its save for being in cover if at least half of the model is obscured from the firer."/>
+        <characteristic name="Description" characteristicTypeId="21befb24-fc85-4f52-a745-64b2e48f8228" value="This model can Fall Back in the Movement phase and still shoot and/or charge in the same turn. When this model Falls Back, it can move over enemy INFANTRY models, thought it must end its move more than 1&quot; from any enemy units. In addition, this model can move and fire Heavy weapons without suffering the penalty to its hit rolls. Finally, this model only gains a bonus to its save for being in cover if at least half of the model is obscured from the firer."/>
       </characteristics>
     </profile>
     <profile id="b4f7-1007-957b-07ce" name="Cerastus Knight-Atropos" book="Imperial Armour - Index: Astra Militarum" page="97" hidden="false" profileTypeId="800f-21d0-4387-c943" profileTypeName="Unit">
@@ -3824,13 +4142,15 @@
         <characteristic name="Description" characteristicTypeId="21befb24-fc85-4f52-a745-64b2e48f8228" value="At the beginning of each of your turns, roll a D6; on the result of 5+ the model heals one wound."/>
       </characteristics>
     </profile>
-    <profile id="77eb-2a36-2c78-02d7" name="Explodes (Unstable Reactor)" hidden="false" profileTypeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" profileTypeName="Abilities">
+    <profile id="77eb-2a36-2c78-02d7" name="Explodes (Unstable Reactor)" hidden="false" profileTypeId="6535-c5b9-7431-63ec" profileTypeName="Explosion">
       <profiles/>
       <rules/>
       <infoLinks/>
       <modifiers/>
       <characteristics>
-        <characteristic name="Description" characteristicTypeId="21befb24-fc85-4f52-a745-64b2e48f8228" value="If this model is reduced to 0 wounds, roll a D6 before removing the model from the battlefield; on a 6+ it explodes and each unit within 2D6&quot; suffers D6 mortal wounds."/>
+        <characteristic name="Dice roll" characteristicTypeId="3684-f9d8-8984-a2bc" value="6+"/>
+        <characteristic name="Distance" characteristicTypeId="0cfb-ee72-50d6-0cfb" value="2D6&quot;"/>
+        <characteristic name="Mortal wounds" characteristicTypeId="a56d-fa6c-e1ee-bbe0" value="D6"/>
       </characteristics>
     </profile>
     <profile id="eda1-ba88-7192-826e" name="Flank Speed" hidden="false" profileTypeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" profileTypeName="Abilities">
@@ -3880,7 +4200,7 @@
         <characteristic name="S" characteristicTypeId="59b1-319e-ec13-d466" value="12"/>
         <characteristic name="AP" characteristicTypeId="75aa-a838-b675-6484" value="-4"/>
         <characteristic name="D" characteristicTypeId="ae8a-3137-d65b-4ca7" value="6"/>
-        <characteristic name="Abilities" characteristicTypeId="837d-5e63-aeb7-1410" value="If an attack with this weapon slays an enemy &lt;b&gt;VEHICLE&lt;/b&gt; or &lt;b&gt;MONSTER&lt;/b&gt; unit in the Shooting phase, you may immediately make another attack against a separate target within range. This bonus attack does not generate further attacks."/>
+        <characteristic name="Abilities" characteristicTypeId="837d-5e63-aeb7-1410" value="If an attack with this weapon slays an enemy VEHICLE or MONSTER unit in the Shooting phase, you may immediately make another attack against a separate target within range. This bonus attack does not generate further attacks."/>
       </characteristics>
     </profile>
     <profile id="713f-5e30-2611-61f2" name="Atropos lascutter (melee)" hidden="false" profileTypeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" profileTypeName="Weapon">
@@ -3894,7 +4214,7 @@
         <characteristic name="S" characteristicTypeId="59b1-319e-ec13-d466" value="14"/>
         <characteristic name="AP" characteristicTypeId="75aa-a838-b675-6484" value="-4"/>
         <characteristic name="D" characteristicTypeId="ae8a-3137-d65b-4ca7" value="6"/>
-        <characteristic name="Abilities" characteristicTypeId="837d-5e63-aeb7-1410" value="You may re-roll failed hit rolls and wound rolls for this weapon against targets with the &lt;b&gt;MONSTER&lt;/b&gt;, &lt;b&gt;BUILDING&lt;/b&gt; or &lt;b&gt;VEHICLE&lt;/b&gt; keyword."/>
+        <characteristic name="Abilities" characteristicTypeId="837d-5e63-aeb7-1410" value="You may re-roll failed hit rolls and wound rolls for this weapon against targets with the MONSTER, BUILDING or VEHICLE keyword."/>
       </characteristics>
     </profile>
     <profile id="e983-fc05-bed3-805c" name="Graviton singularity cannon" hidden="false" profileTypeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" profileTypeName="Weapon">
@@ -3964,7 +4284,7 @@
         <characteristic name="S" characteristicTypeId="59b1-319e-ec13-d466" value="8"/>
         <characteristic name="AP" characteristicTypeId="75aa-a838-b675-6484" value="-2"/>
         <characteristic name="D" characteristicTypeId="ae8a-3137-d65b-4ca7" value="3"/>
-        <characteristic name="Abilities" characteristicTypeId="837d-5e63-aeb7-1410" value="Add 1 to all hit rolls made for this weapon against targets that can &lt;b&gt;FLY&lt;/b&gt;. Subtract 1 from the hit rolls made for this weapon against all other targets."/>
+        <characteristic name="Abilities" characteristicTypeId="837d-5e63-aeb7-1410" value="Add 1 to all hit rolls made for this weapon against targets that can FLY. Subtract 1 from the hit rolls made for this weapon against all other targets."/>
       </characteristics>
     </profile>
     <profile id="093e-5079-8ad8-372d" name="Lightning cannon" hidden="false" profileTypeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" profileTypeName="Weapon">
@@ -4034,7 +4354,7 @@
         <characteristic name="S" characteristicTypeId="59b1-319e-ec13-d466" value="*"/>
         <characteristic name="AP" characteristicTypeId="75aa-a838-b675-6484" value="0"/>
         <characteristic name="D" characteristicTypeId="ae8a-3137-d65b-4ca7" value="3"/>
-        <characteristic name="Abilities" characteristicTypeId="837d-5e63-aeb7-1410" value="This weapon hits automatically, and it always wounds on a 3+ except against &lt;b&gt;TITANIC&lt;/b&gt; and &lt;b&gt;VEHICLE&lt;/b&gt; units, against which it always wounds on a 6+."/>
+        <characteristic name="Abilities" characteristicTypeId="837d-5e63-aeb7-1410" value="This weapon hits automatically, and it always wounds on a 3+ except against TITANIC and VEHICLE units, against which it always wounds on a 6+."/>
       </characteristics>
     </profile>
     <profile id="92a5-d997-84ae-5e2b" name="Volkite chieorovile" hidden="false" profileTypeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" profileTypeName="Weapon">
@@ -4104,7 +4424,7 @@
         <characteristic name="S" characteristicTypeId="59b1-319e-ec13-d466" value="+6"/>
         <characteristic name="AP" characteristicTypeId="75aa-a838-b675-6484" value="-3"/>
         <characteristic name="D" characteristicTypeId="ae8a-3137-d65b-4ca7" value="5"/>
-        <characteristic name="Abilities" characteristicTypeId="837d-5e63-aeb7-1410" value="If any result of a 6 is rolled on any wound roll with this weapon against a &lt;b&gt;MONSTER&lt;/b&gt; or &lt;b&gt;VEHICLE&lt;/b&gt;, then an additional D3 mortal wounds are also inflicted on the enemy unit."/>
+        <characteristic name="Abilities" characteristicTypeId="837d-5e63-aeb7-1410" value="If any result of a 6 is rolled on any wound roll with this weapon against a MONSTER or VEHICLE, then an additional D3 mortal wounds are also inflicted on the enemy unit."/>
       </characteristics>
     </profile>
     <profile id="d8bd-fde5-02f4-3fea" name="Acastus Knight Porphyrion" hidden="false" profileTypeId="800f-21d0-4387-c943" profileTypeName="Unit">
@@ -4215,7 +4535,7 @@
       <infoLinks/>
       <modifiers/>
       <characteristics>
-        <characteristic name="Description" characteristicTypeId="21befb24-fc85-4f52-a745-64b2e48f8228" value="The model has a 5+ invulnerable save increasing to a 4+ invulnerable save in the Fight phase of any turn. In addition, enemy units with the &lt;b&gt;TITANIC&lt;/b&gt; keyword within 1&quot; must subtract 1 from their hit rolls when directing their attacks against this model (to a maximum of 6+ to hit)."/>
+        <characteristic name="Description" characteristicTypeId="21befb24-fc85-4f52-a745-64b2e48f8228" value="The model has a 5+ invulnerable save increasing to a 4+ invulnerable save in the Fight phase of any turn. In addition, enemy units with the TITANIC keyword within 1&quot; must subtract 1 from their hit rolls when directing their attacks against this model (to a maximum of 6+ to hit)."/>
       </characteristics>
     </profile>
     <profile id="3db7-ad30-051c-f1c6" name="Empyreal Preysight" hidden="false" profileTypeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" profileTypeName="Abilities">
@@ -4224,7 +4544,18 @@
       <infoLinks/>
       <modifiers/>
       <characteristics>
-        <characteristic name="Description" characteristicTypeId="21befb24-fc85-4f52-a745-64b2e48f8228" value="Units other than &lt;b&gt;VEHICLES&lt;/b&gt; cannot claim the bonus +1 to their save for being in cover against this model."/>
+        <characteristic name="Description" characteristicTypeId="21befb24-fc85-4f52-a745-64b2e48f8228" value="Units other than VEHICLES cannot claim the bonus +1 to their save for being in cover against this model."/>
+      </characteristics>
+    </profile>
+    <profile id="fa1d-76c9-a3fb-7adf" name="Explodes (Unstable Reactor) (Acastus Knight Porphyrion)" hidden="false" profileTypeId="6535-c5b9-7431-63ec" profileTypeName="Explosion">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <characteristics>
+        <characteristic name="Dice roll" characteristicTypeId="3684-f9d8-8984-a2bc" value="5+"/>
+        <characteristic name="Distance" characteristicTypeId="0cfb-ee72-50d6-0cfb" value="2D6&quot;"/>
+        <characteristic name="Mortal wounds" characteristicTypeId="a56d-fa6c-e1ee-bbe0" value="D6"/>
       </characteristics>
     </profile>
   </sharedProfiles>


### PR DESCRIPTION
Updated Questor Imperialis according to Codex: Adeptus Mechanicus (adding Questor Imperialis/Questor Mechanicus selector, which only changes keywords, to Knights Crusader, Errant, Gallant, Paladin and Warden).
Removed HTML sequences (which were not showing correctly) from Adeptus Titanicus, Blood Angels and Questor Imperialis.
Added keyword display to Adeptus Titanicus, Legion of the Damned and Questor Imperialis.