### PR TITLE
FWAA v14

### DIFF
--- a/Imperium - FW Adeptus Astartes.cat
+++ b/Imperium - FW Adeptus Astartes.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="dab7-e076-dd5e-d8aa" name="Imperium - FW Adeptus Astartes" book="Imperial Armour Index: Forces of the Adeptus Astartes" revision="13" battleScribeVersion="2.01" authorName="Crowbar90" authorContact="" gameSystemId="28ec-711c-d87f-3aeb" gameSystemRevision="3" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="dab7-e076-dd5e-d8aa" name="Imperium - FW Adeptus Astartes" book="Imperial Armour Index: Forces of the Adeptus Astartes" revision="14" battleScribeVersion="2.01" authorName="Crowbar90" authorContact="" gameSystemId="28ec-711c-d87f-3aeb" gameSystemRevision="3" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <profiles/>
   <rules/>
   <infoLinks/>
@@ -14360,7 +14360,18 @@
           </entryLinks>
         </selectionEntryGroup>
       </selectionEntryGroups>
-      <entryLinks/>
+      <entryLinks>
+        <entryLink id="b69d-a927-312d-08e6" name="Cyclone missile launcher" hidden="false" targetId="0c83-f5bb-fdb1-1cfd" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f8cc-5068-5676-2692" type="max"/>
+          </constraints>
+          <categoryLinks/>
+        </entryLink>
+      </entryLinks>
       <costs>
         <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="13.0"/>
         <cost name="pts" costTypeId="points" value="135.0"/>


### PR DESCRIPTION
Cyclone Missile Launcher is now available for Relic Contemptor Dreadnought, according to latest FAQ. Fixes #1575.