### PR TITLE
Fix points cost of Doom Siren for Noise Champion to Chapter Approved cost (10 points)

### DIFF
--- a/Chaos - Chaos Space Marines.cat
+++ b/Chaos - Chaos Space Marines.cat
@@ -16728,7 +16728,7 @@
       <selectionEntryGroups/>
       <entryLinks/>
       <costs>
-        <cost name="pts" costTypeId="points" value="22.0"/>
+        <cost name="pts" costTypeId="points" value="10.0"/>
         <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="0.0"/>
       </costs>
     </selectionEntry>


### PR DESCRIPTION
Fixes the cost of Doom Siren to it's Chapter Approved 2017 value.