### PR TITLE
Chaos - Keyword Updates via Categories - HQ & Troops

### DIFF
--- a/Chaos - Death Guard.cat
+++ b/Chaos - Death Guard.cat
@@ -156,6 +156,34 @@
       <modifiers/>
       <constraints/>
     </categoryEntry>
+    <categoryEntry id="198b-9ec3-8ecd-121d" name="Malignant Plaguecaster" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints/>
+    </categoryEntry>
+    <categoryEntry id="cedd-5c01-92d2-32e5" name="Typhus" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints/>
+    </categoryEntry>
+    <categoryEntry id="be6b-26d4-4727-3683" name="Daemon Prince" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints/>
+    </categoryEntry>
+    <categoryEntry id="fa81-3af3-dfd0-208b" name="Sorcerer" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints/>
+    </categoryEntry>
   </categoryEntries>
   <forceEntries/>
   <selectionEntries/>
@@ -176,7 +204,7 @@
       <constraints/>
       <categoryLinks/>
     </entryLink>
-    <entryLink id="d65b-3bc2-bb33-a191" name="New EntryLink" hidden="false" targetId="8fbe-2b19-a2d3-8f50" type="selectionEntry">
+    <entryLink id="d65b-3bc2-bb33-a191" name="Lord of Contagion" hidden="false" targetId="8fbe-2b19-a2d3-8f50" type="selectionEntry">
       <profiles/>
       <rules/>
       <infoLinks/>
@@ -296,7 +324,7 @@
       <constraints/>
       <categoryLinks/>
     </entryLink>
-    <entryLink id="f31b-de7a-d5ee-1b5f" name="New EntryLink" hidden="false" targetId="299f-6b03-4963-d522" type="selectionEntry">
+    <entryLink id="f31b-de7a-d5ee-1b5f" name="Malignant Plaguecaster" hidden="false" targetId="299f-6b03-4963-d522" type="selectionEntry">
       <profiles/>
       <rules/>
       <infoLinks/>
@@ -304,7 +332,7 @@
       <constraints/>
       <categoryLinks/>
     </entryLink>
-    <entryLink id="649b-164f-b187-2632" name="New EntryLink" hidden="false" targetId="25f1-c2ff-203f-8173" type="selectionEntry">
+    <entryLink id="649b-164f-b187-2632" name="Typhus" hidden="false" targetId="25f1-c2ff-203f-8173" type="selectionEntry">
       <profiles/>
       <rules/>
       <infoLinks/>
@@ -1148,7 +1176,7 @@
           <modifiers/>
           <constraints/>
         </categoryLink>
-        <categoryLink id="727f-a091-0bf4-1bac" name="New CategoryLink" hidden="false" targetId="e691-aad7-d21c-1023" primary="false">
+        <categoryLink id="c4e3-8a99-42b0-353c" name="New CategoryLink" hidden="false" targetId="be6b-26d4-4727-3683" primary="false">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -1731,6 +1759,13 @@
           <constraints/>
         </categoryLink>
         <categoryLink id="c43b-1b90-00cb-c383" name="New CategoryLink" hidden="false" targetId="e691-aad7-d21c-1023" primary="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
+        <categoryLink id="14ca-aa26-cf57-7873" name="New CategoryLink" hidden="false" targetId="fa81-3af3-dfd0-208b" primary="false">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -2723,6 +2758,13 @@
           <modifiers/>
           <constraints/>
         </categoryLink>
+        <categoryLink id="2d8d-7512-dfe9-50c0" name="New CategoryLink" hidden="false" targetId="ca10-a5dd-f54f-0ed5" primary="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
       </categoryLinks>
       <selectionEntries/>
       <selectionEntryGroups/>
@@ -3097,6 +3139,13 @@
           <modifiers/>
           <constraints/>
         </categoryLink>
+        <categoryLink id="bfb7-7073-2f74-6340" name="New CategoryLink" hidden="false" targetId="fa81-3af3-dfd0-208b" primary="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
       </categoryLinks>
       <selectionEntries/>
       <selectionEntryGroups/>
@@ -3252,6 +3301,13 @@
           <constraints/>
         </categoryLink>
         <categoryLink id="d9ee-4ee7-deda-726d" name="New CategoryLink" hidden="false" targetId="5cf1-acf2-ca3b-c2e5" primary="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
+        <categoryLink id="15d1-2cf7-4cad-061b" name="New CategoryLink" hidden="false" targetId="fa81-3af3-dfd0-208b" primary="false">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -4459,7 +4515,9 @@
         </infoLink>
       </infoLinks>
       <modifiers/>
-      <constraints/>
+      <constraints>
+        <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b863-652b-b563-e938" type="max"/>
+      </constraints>
       <categoryLinks>
         <categoryLink id="61eb-e78c-279e-a97a" hidden="false" targetId="848a6ff2-0def-4c72-8433-ff7da70e6bc7" primary="true">
           <profiles/>
@@ -4525,6 +4583,13 @@
           <constraints/>
         </categoryLink>
         <categoryLink id="047c-1d1e-e9d0-4b28" name="New CategoryLink" hidden="false" targetId="ce71-91a7-35a9-2d68" primary="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
+        <categoryLink id="2f89-5cea-bbce-7fa4" name="New CategoryLink" hidden="false" targetId="cedd-5c01-92d2-32e5" primary="false">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -4718,13 +4783,6 @@
           <modifiers/>
           <constraints/>
         </categoryLink>
-        <categoryLink id="4d53-2e2f-90fb-e7a5" name="New CategoryLink" hidden="false" targetId="e691-aad7-d21c-1023" primary="false">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints/>
-        </categoryLink>
         <categoryLink id="7b80-cf42-16e3-5f6a" name="New CategoryLink" hidden="false" targetId="36b8-cf23-7648-ece9" primary="false">
           <profiles/>
           <rules/>
@@ -4754,6 +4812,13 @@
           <constraints/>
         </categoryLink>
         <categoryLink id="7a47-6998-12dc-23d4" name="New CategoryLink" hidden="false" targetId="5cf1-acf2-ca3b-c2e5" primary="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
+        <categoryLink id="7229-f940-f3ac-f47d" name="New CategoryLink" hidden="false" targetId="ce71-91a7-35a9-2d68" primary="false">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -4967,6 +5032,13 @@
           <constraints/>
         </categoryLink>
         <categoryLink id="f77e-e5c1-4965-97c3" name="New CategoryLink" hidden="false" targetId="5cf1-acf2-ca3b-c2e5" primary="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
+        <categoryLink id="9bd2-bbe1-3230-d71d" name="New CategoryLink" hidden="false" targetId="198b-9ec3-8ecd-121d" primary="false">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -5974,14 +6046,21 @@
           <modifiers/>
           <constraints/>
         </categoryLink>
-        <categoryLink id="1335-34ec-7bd7-82f1" name="New CategoryLink" hidden="false" targetId="848a6ff2-0def-4c72-8433-ff7da70e6bc7" primary="true">
+        <categoryLink id="135d-45a6-2cab-a907" name="New CategoryLink" hidden="false" targetId="e691-aad7-d21c-1023" primary="false">
           <profiles/>
           <rules/>
           <infoLinks/>
           <modifiers/>
           <constraints/>
         </categoryLink>
-        <categoryLink id="135d-45a6-2cab-a907" name="New CategoryLink" hidden="false" targetId="e691-aad7-d21c-1023" primary="false">
+        <categoryLink id="749f-164b-7981-fdb5" name="New CategoryLink" hidden="false" targetId="848a6ff2-0def-4c72-8433-ff7da70e6bc7" primary="true">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
+        <categoryLink id="a0a5-dd94-3d96-84bf" name="New CategoryLink" hidden="false" targetId="fa81-3af3-dfd0-208b" primary="false">
           <profiles/>
           <rules/>
           <infoLinks/>

--- a/Chaos - Death Guard.cat
+++ b/Chaos - Death Guard.cat
@@ -184,6 +184,27 @@
       <modifiers/>
       <constraints/>
     </categoryEntry>
+    <categoryEntry id="a50f-7a19-7624-5793" name="Plague Marines" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints/>
+    </categoryEntry>
+    <categoryEntry id="7c95-4704-2fe5-93bc" name="Chaos Cultists" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints/>
+    </categoryEntry>
+    <categoryEntry id="6676-37bc-5ed8-c56d" name="Poxwalkers" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints/>
+    </categoryEntry>
   </categoryEntries>
   <forceEntries/>
   <selectionEntries/>
@@ -1907,6 +1928,20 @@
           <constraints/>
         </categoryLink>
         <categoryLink id="4ebb-9605-ed47-488c" name="New CategoryLink" hidden="false" targetId="5cf1-acf2-ca3b-c2e5" primary="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
+        <categoryLink id="714e-a98b-83c9-f67d" name="New CategoryLink" hidden="false" targetId="ca10-a5dd-f54f-0ed5" primary="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
+        <categoryLink id="643b-5052-b1e6-8b16" name="New CategoryLink" hidden="false" targetId="6676-37bc-5ed8-c56d" primary="false">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -5216,6 +5251,13 @@
           <modifiers/>
           <constraints/>
         </categoryLink>
+        <categoryLink id="e07c-8cca-019d-438c" name="New CategoryLink" hidden="false" targetId="7c95-4704-2fe5-93bc" primary="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="563c-410b-0b71-71f9" name="Cultist Champion" hidden="false" collective="false" type="model">
@@ -7335,6 +7377,13 @@
           <constraints/>
         </categoryLink>
         <categoryLink id="8d79-a420-b5e8-3a01" name="New CategoryLink" hidden="false" targetId="5d76b6f5-20ae-4d70-8f59-ade72a2add3a" primary="true">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
+        <categoryLink id="0f50-d1a4-4741-1bd9" name="New CategoryLink" hidden="false" targetId="a50f-7a19-7624-5793" primary="false">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -11310,6 +11359,13 @@
           <constraints/>
         </categoryLink>
         <categoryLink id="ca6d-f468-4723-4289" name="New CategoryLink" hidden="false" targetId="5d76b6f5-20ae-4d70-8f59-ade72a2add3a" primary="true">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
+        <categoryLink id="63ff-42d1-9fd9-9baf" name="New CategoryLink" hidden="false" targetId="a50f-7a19-7624-5793" primary="false">
           <profiles/>
           <rules/>
           <infoLinks/>


### PR DESCRIPTION
Addresses Issues #1995 & #2017

I went back and forth a couple times wondering if Daemon Prince and Sorcerer, since used in multiple codexes, should be in Warhammer 40,000 8th instead; but after noticing Daemon Engine and so on were not in base I moved them back to Death Guard.

Updated Categories (otherwise known as Keywords)

# -----------------
# HQ
# -----------------
# Category Entries
* ### Added
    * Daemon Prince
    * Malignant Plaguecaster
    * Sorcerer
    * Typhus

# 
# Selection Entries

- ### Chaos Lord with Jump Pack
  - **Categories**
    - Added - Heretic Astartes

- ### Daemon Prince of Nurgle
  - **Categories**
    - Added - Daemon Prince
    - Removed - Psyker   --- not listed in Keywords but could be required because of something else

- ### Lord of Contagion
  - **Categories**
    - Added - Lord Of Contagion
    - Removed - Psyker


- ### Malignant Plaguecaster
  - **Categories**
    - Added - Malignant Plaguecaster

- ### Sorcerer
  - **Categories**
    - Added - Sorcerer

- ### Sorcerer in Terminator Armour
  - **Categories**
    - Added - Sorcerer

- ### Sorcerer on Palanquin of Nurgle
  - **Categories**
    - Added - Sorcerer

- ### Sorcerer with Jump Pack
  - **Categories**
    - Added - Sorcerer

- ### Typhus
  - **Categories**
    - Added - Typhus
  - **Quick Contraints**
    - Added - Max 1 in Roster

# -----------------
# TROOPS
# -----------------
BattleScribe version: 2.01.07.95

# Category Entries
* ### Added
    * Plague Marines
    * Chaos Cultists
    * Poxwalkers

# 
# Shared Selection Entries

- ### Plague Marines
  - **Categories**
    - Added - Plague Marines

- ### Chaos Cultists
  - **Categories**
    - Added - Chaos Cultists

- ### Poxwalkers
  - **Categories**
    - Added - Heretic Astartes
    - Added - Poxwalkers

- ### The Plague Brethren
  - **Categories**
    - Added - Plague Marines
