### PR TITLE
Fixed FW Doom Siren to d6

### DIFF
--- a/Chaos - FW Heretic Astartes.cat
+++ b/Chaos - FW Heretic Astartes.cat
@@ -13564,7 +13564,7 @@
               <modifiers/>
               <characteristics>
                 <characteristic name="Range" characteristicTypeId="6fa97fa8-ea74-4a27-a0fb-bc4e5f367464" value="8&quot;"/>
-                <characteristic name="Type" characteristicTypeId="077c342f-d7b9-45c6-b8af-88e97cafd3a2" value="Assault D3"/>
+                <characteristic name="Type" characteristicTypeId="077c342f-d7b9-45c6-b8af-88e97cafd3a2" value="Assault D6"/>
                 <characteristic name="S" characteristicTypeId="59b1-319e-ec13-d466" value="5"/>
                 <characteristic name="AP" characteristicTypeId="75aa-a838-b675-6484" value="-2"/>
                 <characteristic name="D" characteristicTypeId="ae8a-3137-d65b-4ca7" value="1"/>


### PR DESCRIPTION
Fixes the profile of Doom Siren in the FW entry to Assault d6.