### PR TITLE
BA v27 - Codex update

### DIFF
--- a/Imperium - Blood Angels.cat
+++ b/Imperium - Blood Angels.cat
@@ -1,10 +1,18 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="eb0f-c144-a282-8bdc" name="Imperium - Blood Angels" book="Index: Imperium 1" revision="26" battleScribeVersion="2.01" authorName="Crowbar90" gameSystemId="28ec-711c-d87f-3aeb" gameSystemRevision="1" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="eb0f-c144-a282-8bdc" name="Imperium - Blood Angels" book="Codex: Blood Angels" revision="27" battleScribeVersion="2.01" authorName="Crowbar90" gameSystemId="28ec-711c-d87f-3aeb" gameSystemRevision="1" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <profiles/>
   <rules/>
   <infoLinks/>
   <costTypes/>
-  <profileTypes/>
+  <profileTypes>
+    <profileType id="818c-0db1-36f0-462a" name="Explosion">
+      <characteristicTypes>
+        <characteristicType id="f21d-8f6d-180d-36ff" name="Dice roll"/>
+        <characteristicType id="d69e-be07-1682-ebcc" name="Distance"/>
+        <characteristicType id="29f1-65a1-2c5d-8c7d" name="Mortal wounds"/>
+      </characteristicTypes>
+    </profileType>
+  </profileTypes>
   <categoryEntries>
     <categoryEntry id="2c4a-3ec9-a1f6-a1ee" name="Faction: Imperium" hidden="false">
       <profiles/>
@@ -72,7 +80,14 @@
     <categoryEntry id="2378-fd9b-5213-6a6c" name="Terminator" hidden="false">
       <profiles/>
       <rules/>
-      <infoLinks/>
+      <infoLinks>
+        <infoLink id="561d-e468-fcd1-647a" name="Teleport Strike" hidden="false" targetId="4243-5016-c4d9-2b6b" type="profile">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
       <modifiers/>
       <constraints/>
     </categoryEntry>
@@ -485,6 +500,69 @@
       <constraints/>
     </categoryEntry>
     <categoryEntry id="f78b-3f42-00f0-7bd4" name="Repulsor" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints/>
+    </categoryEntry>
+    <categoryEntry id="2ddb-c542-6db7-d30f" name="Cataphractii Terminator Squad" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints/>
+    </categoryEntry>
+    <categoryEntry id="5730-2cee-102d-c71f" name="Tartaros Terminator Squad" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints/>
+    </categoryEntry>
+    <categoryEntry id="5b5a-6b60-b356-d2ec" name="Contemptor Dreadnought" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints/>
+    </categoryEntry>
+    <categoryEntry id="c450-41ad-d4a6-cd12" name="Hunter" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints/>
+    </categoryEntry>
+    <categoryEntry id="7b59-3865-4434-bd31" name="Stalker" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints/>
+    </categoryEntry>
+    <categoryEntry id="d63c-e896-8db9-39dc" name="Land Speeder Storm" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints/>
+    </categoryEntry>
+    <categoryEntry id="16f0-25ae-1d96-ffc4" name="Land Speeder" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints/>
+    </categoryEntry>
+    <categoryEntry id="782a-435b-d18d-09a2" name="Stormtalon Gunship" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints/>
+    </categoryEntry>
+    <categoryEntry id="8104-d542-d9d5-ae7f" name="Stormhawk Interceptor" hidden="false">
       <profiles/>
       <rules/>
       <infoLinks/>
@@ -1095,7 +1173,63 @@
       <constraints/>
       <categoryLinks/>
     </entryLink>
-    <entryLink id="f87c-0a01-4770-934e" name="Primaris Captain with Power Fist" hidden="false" targetId="472a-98ae-1344-5dc5" type="selectionEntry">
+    <entryLink id="abdc-fbdd-1d58-af19" name="Captain in Cataphractii Armour" hidden="false" targetId="e6a5-f069-14a3-b6a1" type="selectionEntry">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints/>
+      <categoryLinks/>
+    </entryLink>
+    <entryLink id="ff33-202c-969a-ba01" name="Lieutenants" hidden="false" targetId="5a04-c03d-3ac5-2c78" type="selectionEntry">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints/>
+      <categoryLinks/>
+    </entryLink>
+    <entryLink id="2f78-5e19-86b7-1953" name="Cataphractii Terminator Squad" hidden="false" targetId="eef8-6558-5bca-4db1" type="selectionEntry">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints/>
+      <categoryLinks/>
+    </entryLink>
+    <entryLink id="9c3b-e25d-9ba9-d5f4" name="Tartaros Terminator Squad" hidden="false" targetId="e044-89c5-b266-854b" type="selectionEntry">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints/>
+      <categoryLinks/>
+    </entryLink>
+    <entryLink id="369a-b5a4-0587-7b8e" name="Contemptor Dreadought" hidden="false" targetId="0fa8-7fd2-34bb-b556" type="selectionEntry">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints/>
+      <categoryLinks/>
+    </entryLink>
+    <entryLink id="a934-b326-81d6-37c6" name="Hunter" hidden="false" targetId="b92e-9a51-38e3-065d" type="selectionEntry">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints/>
+      <categoryLinks/>
+    </entryLink>
+    <entryLink id="d98b-878d-f1fb-4c95" name="Stalker" hidden="false" targetId="74b4-a8e2-14b0-452d" type="selectionEntry">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints/>
+      <categoryLinks/>
+    </entryLink>
+    <entryLink id="37cd-b5e8-79cb-5435" name="Land Speeder Storm" hidden="false" targetId="3ea3-34fc-f59c-9d17" type="selectionEntry">
       <profiles/>
       <rules/>
       <infoLinks/>
@@ -1127,28 +1261,6 @@
         <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="12fb-6600-667f-5922" name="Inferno pistol" hidden="false" collective="false" type="upgrade">
-      <profiles/>
-      <rules/>
-      <infoLinks>
-        <infoLink id="8d6e-b6b3-9993-f3ee" name="New InfoLink" hidden="false" targetId="ab54-e0b9-ec6d-0b42" type="profile">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </infoLink>
-      </infoLinks>
-      <modifiers/>
-      <constraints/>
-      <categoryLinks/>
-      <selectionEntries/>
-      <selectionEntryGroups/>
-      <entryLinks/>
-      <costs>
-        <cost name="pts" costTypeId="points" value="20.0"/>
-        <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="0.0"/>
-      </costs>
-    </selectionEntry>
     <selectionEntry id="3594-71ee-de15-4824" name="Cyclone missile launcher and storm bolter" hidden="false" collective="false" type="upgrade">
       <profiles/>
       <rules/>
@@ -1159,7 +1271,7 @@
       <selectionEntries/>
       <selectionEntryGroups/>
       <entryLinks>
-        <entryLink id="844e-882f-c3c4-b83c" name="New EntryLink" hidden="false" targetId="25ce-f4e3-f00d-5035" type="selectionEntry">
+        <entryLink id="844e-882f-c3c4-b83c" name="Cyclone missile launcher" hidden="false" targetId="25b3-79f7-73cd-9321" type="selectionEntry">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -1170,7 +1282,7 @@
           </constraints>
           <categoryLinks/>
         </entryLink>
-        <entryLink id="d107-123a-679f-989c" name="New EntryLink" hidden="false" targetId="d74a-2fee-abea-1b42" type="selectionEntry">
+        <entryLink id="d107-123a-679f-989c" name="Storm bolter" hidden="false" targetId="2b03-8d64-3711-f300" type="selectionEntry">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -1335,7 +1447,7 @@
                   <selectionEntries/>
                   <selectionEntryGroups/>
                   <entryLinks>
-                    <entryLink id="d1bb-be31-1e7c-30ab" name="Eviscerator" hidden="false" targetId="587a-cf0a-2336-3117" type="selectionEntry">
+                    <entryLink id="d1bb-be31-1e7c-30ab" name="Eviscerator" hidden="false" targetId="b993-57b7-93c6-9acb" type="selectionEntry">
                       <profiles/>
                       <rules/>
                       <infoLinks/>
@@ -1380,7 +1492,7 @@
                 </selectionEntryGroup>
               </selectionEntryGroups>
               <entryLinks>
-                <entryLink id="b8cc-856a-2543-aece" name="Combat shield" hidden="false" targetId="a052-e708-7e92-feb7" type="selectionEntry">
+                <entryLink id="b8cc-856a-2543-aece" name="Combat shield" hidden="false" targetId="2792-c0fb-d72e-cee4" type="selectionEntry">
                   <profiles/>
                   <rules/>
                   <infoLinks/>
@@ -1390,7 +1502,7 @@
                   </constraints>
                   <categoryLinks/>
                 </entryLink>
-                <entryLink id="c1fa-3a74-8547-bb48" name="Melta bombs" hidden="false" targetId="5f8b-b9f4-ec1c-3316" type="selectionEntry">
+                <entryLink id="c1fa-3a74-8547-bb48" name="Melta bombs" hidden="false" targetId="8ed2-3e2c-4d52-af79" type="selectionEntry">
                   <profiles/>
                   <rules/>
                   <infoLinks/>
@@ -1400,18 +1512,7 @@
                   </constraints>
                   <categoryLinks/>
                 </entryLink>
-                <entryLink id="8e0c-d9ad-0345-3893" name="New EntryLink" hidden="false" targetId="e897-c8fa-0976-e2d3" type="selectionEntry">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                  <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7503-c070-1e67-9e9a" type="max"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8322-cfd7-1450-b455" type="min"/>
-                  </constraints>
-                  <categoryLinks/>
-                </entryLink>
-                <entryLink id="00e3-248c-1bb2-127a" name="New EntryLink" hidden="false" targetId="073b-2de5-765f-a4f2" type="selectionEntry">
+                <entryLink id="00e3-248c-1bb2-127a" name="Frag &amp; Krak grenades" hidden="false" targetId="cddf-945e-1335-e681" type="selectionEntry">
                   <profiles/>
                   <rules/>
                   <infoLinks/>
@@ -1453,18 +1554,7 @@
               <selectionEntries/>
               <selectionEntryGroups/>
               <entryLinks>
-                <entryLink id="1674-6348-575d-ffd2" name="New EntryLink" hidden="false" targetId="e897-c8fa-0976-e2d3" type="selectionEntry">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                  <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b4f6-4105-9642-872d" type="max"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8a8f-6992-fb48-6353" type="min"/>
-                  </constraints>
-                  <categoryLinks/>
-                </entryLink>
-                <entryLink id="8b48-9984-c4af-8294" name="New EntryLink" hidden="false" targetId="073b-2de5-765f-a4f2" type="selectionEntry">
+                <entryLink id="8b48-9984-c4af-8294" name="Frag &amp; Krak grenades" hidden="false" targetId="cddf-945e-1335-e681" type="selectionEntry">
                   <profiles/>
                   <rules/>
                   <infoLinks/>
@@ -1475,7 +1565,7 @@
                   </constraints>
                   <categoryLinks/>
                 </entryLink>
-                <entryLink id="290e-ce4c-2564-f93a" name="New EntryLink" hidden="false" targetId="0367-b42c-b6b4-0a58" type="selectionEntry">
+                <entryLink id="290e-ce4c-2564-f93a" name="Bolt pistol" hidden="false" targetId="37d3-7098-d596-9948" type="selectionEntry">
                   <profiles/>
                   <rules/>
                   <infoLinks/>
@@ -1486,7 +1576,7 @@
                   </constraints>
                   <categoryLinks/>
                 </entryLink>
-                <entryLink id="3e6d-992b-c7d6-73d2" name="New EntryLink" hidden="false" targetId="5905-f299-f23c-f9c1" type="selectionEntry">
+                <entryLink id="3e6d-992b-c7d6-73d2" name="Chainsword" hidden="false" targetId="4334-d2da-32f5-dc53" type="selectionEntry">
                   <profiles/>
                   <rules/>
                   <infoLinks/>
@@ -1538,18 +1628,7 @@
               <selectionEntries/>
               <selectionEntryGroups/>
               <entryLinks>
-                <entryLink id="835d-53dd-78aa-8cc3" name="New EntryLink" hidden="false" targetId="e897-c8fa-0976-e2d3" type="selectionEntry">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                  <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9ac6-2592-6cda-a23c" type="max"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e2d4-e1fd-6808-9288" type="min"/>
-                  </constraints>
-                  <categoryLinks/>
-                </entryLink>
-                <entryLink id="0379-bf8f-0a6d-83d4" name="New EntryLink" hidden="false" targetId="073b-2de5-765f-a4f2" type="selectionEntry">
+                <entryLink id="0379-bf8f-0a6d-83d4" name="Frag &amp; Krak grenades" hidden="false" targetId="cddf-945e-1335-e681" type="selectionEntry">
                   <profiles/>
                   <rules/>
                   <infoLinks/>
@@ -1560,7 +1639,7 @@
                   </constraints>
                   <categoryLinks/>
                 </entryLink>
-                <entryLink id="65a7-f4dc-d1af-a623" name="New EntryLink" hidden="false" targetId="587a-cf0a-2336-3117" type="selectionEntry">
+                <entryLink id="65a7-f4dc-d1af-a623" name="Eviscerator" hidden="false" targetId="b993-57b7-93c6-9acb" type="selectionEntry">
                   <profiles/>
                   <rules/>
                   <infoLinks/>
@@ -1628,7 +1707,7 @@
                       <selectionEntries/>
                       <selectionEntryGroups/>
                       <entryLinks>
-                        <entryLink id="25c7-0c7d-f548-f32c" name="Plasma pistol" hidden="false" targetId="b333-4c80-2f72-6b45" type="selectionEntry">
+                        <entryLink id="25c7-0c7d-f548-f32c" name="Plasma pistol" hidden="false" targetId="83be-1ba9-c326-4760" type="selectionEntry">
                           <profiles/>
                           <rules/>
                           <infoLinks/>
@@ -1638,7 +1717,7 @@
                           </constraints>
                           <categoryLinks/>
                         </entryLink>
-                        <entryLink id="b504-759a-0d40-11e5" name="Inferno pistol" hidden="false" targetId="12fb-6600-667f-5922" type="selectionEntry">
+                        <entryLink id="b504-759a-0d40-11e5" name="Inferno pistol" hidden="false" targetId="83f0-56d1-b852-f21c" type="selectionEntry">
                           <profiles/>
                           <rules/>
                           <infoLinks/>
@@ -1662,18 +1741,7 @@
                     </selectionEntryGroup>
                   </selectionEntryGroups>
                   <entryLinks>
-                    <entryLink id="9d35-a706-893a-ca5f" name="New EntryLink" hidden="false" targetId="e897-c8fa-0976-e2d3" type="selectionEntry">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks/>
-                      <modifiers/>
-                      <constraints>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7860-56ea-1051-d0a1" type="max"/>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="76e6-11b3-5e2b-506e" type="min"/>
-                      </constraints>
-                      <categoryLinks/>
-                    </entryLink>
-                    <entryLink id="df82-15f8-29af-c234" name="New EntryLink" hidden="false" targetId="073b-2de5-765f-a4f2" type="selectionEntry">
+                    <entryLink id="df82-15f8-29af-c234" name="Frag &amp; Krak grenades" hidden="false" targetId="cddf-945e-1335-e681" type="selectionEntry">
                       <profiles/>
                       <rules/>
                       <infoLinks/>
@@ -1684,7 +1752,7 @@
                       </constraints>
                       <categoryLinks/>
                     </entryLink>
-                    <entryLink id="08f9-9d2f-f6cc-e6e7" name="New EntryLink" hidden="false" targetId="5905-f299-f23c-f9c1" type="selectionEntry">
+                    <entryLink id="08f9-9d2f-f6cc-e6e7" name="Chainsword" hidden="false" targetId="4334-d2da-32f5-dc53" type="selectionEntry">
                       <profiles/>
                       <rules/>
                       <infoLinks/>
@@ -1740,7 +1808,7 @@
                       <selectionEntries/>
                       <selectionEntryGroups/>
                       <entryLinks>
-                        <entryLink id="90bc-5bd6-955f-d400" name="Flamer" hidden="false" targetId="a255-3b4c-89e4-e6b3" type="selectionEntry">
+                        <entryLink id="90bc-5bd6-955f-d400" name="Flamer" hidden="false" targetId="fd22-6743-2d4c-dd62" type="selectionEntry">
                           <profiles/>
                           <rules/>
                           <infoLinks/>
@@ -1750,7 +1818,7 @@
                           </constraints>
                           <categoryLinks/>
                         </entryLink>
-                        <entryLink id="1b3d-5051-089c-b537" name="Meltagun" hidden="false" targetId="9ec1-5584-a623-fdda" type="selectionEntry">
+                        <entryLink id="1b3d-5051-089c-b537" name="Meltagun" hidden="false" targetId="efc8-c51d-5b02-a3a2" type="selectionEntry">
                           <profiles/>
                           <rules/>
                           <infoLinks/>
@@ -1760,7 +1828,7 @@
                           </constraints>
                           <categoryLinks/>
                         </entryLink>
-                        <entryLink id="786a-0a2e-e60c-3247" name="Plasma gun" hidden="false" targetId="be22-4d06-c69b-5310" type="selectionEntry">
+                        <entryLink id="786a-0a2e-e60c-3247" name="Plasma gun" hidden="false" targetId="8c14-22cc-93ce-b85a" type="selectionEntry">
                           <profiles/>
                           <rules/>
                           <infoLinks/>
@@ -1774,18 +1842,7 @@
                     </selectionEntryGroup>
                   </selectionEntryGroups>
                   <entryLinks>
-                    <entryLink id="77e4-4c0c-8cea-774e" name="Frag grenade" hidden="false" targetId="e897-c8fa-0976-e2d3" type="selectionEntry">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks/>
-                      <modifiers/>
-                      <constraints>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3e32-50a3-4eab-4b03" type="max"/>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b41e-e335-acb6-4177" type="min"/>
-                      </constraints>
-                      <categoryLinks/>
-                    </entryLink>
-                    <entryLink id="5b42-fcc3-0a70-ce46" name="New EntryLink" hidden="false" targetId="073b-2de5-765f-a4f2" type="selectionEntry">
+                    <entryLink id="5b42-fcc3-0a70-ce46" name="Frag &amp; Krak grenades" hidden="false" targetId="cddf-945e-1335-e681" type="selectionEntry">
                       <profiles/>
                       <rules/>
                       <infoLinks/>
@@ -1846,7 +1903,7 @@
       <profiles/>
       <rules/>
       <infoLinks>
-        <infoLink id="7298-cf72-9f22-1657" name="New InfoLink" hidden="false" targetId="b1f9-97c2-db25-7761" type="profile">
+        <infoLink id="7298-cf72-9f22-1657" name="Jump Pack Assault" hidden="false" targetId="b1f9-97c2-db25-7761" type="profile">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -1889,7 +1946,7 @@
           <infoLinks/>
           <modifiers/>
         </infoLink>
-        <infoLink id="2739-0c9f-9d37-2f02" name="New InfoLink" hidden="false" targetId="92b7-fdc2-cdd2-9217" type="profile">
+        <infoLink id="2739-0c9f-9d37-2f02" name="Turbo-boost" hidden="false" targetId="92b7-fdc2-cdd2-9217" type="profile">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -1984,7 +2041,7 @@
           <selectionEntries/>
           <selectionEntryGroups/>
           <entryLinks>
-            <entryLink id="1994-5939-c2e5-8962" name="Heavy bolter" hidden="false" targetId="290a-8ad2-2af9-5ebc" type="selectionEntry">
+            <entryLink id="1994-5939-c2e5-8962" name="Heavy bolter" hidden="false" targetId="05ab-e7cc-e856-c36f" type="selectionEntry">
               <profiles/>
               <rules/>
               <infoLinks/>
@@ -1994,7 +2051,7 @@
               </constraints>
               <categoryLinks/>
             </entryLink>
-            <entryLink id="1b87-65fd-3447-6644" name="Multi-melta" hidden="false" targetId="9523-8395-ca20-2849" type="selectionEntry">
+            <entryLink id="1b87-65fd-3447-6644" name="Multi-melta" hidden="false" targetId="2b37-65ee-9443-b4ef" type="selectionEntry">
               <profiles/>
               <rules/>
               <infoLinks/>
@@ -2008,7 +2065,7 @@
         </selectionEntryGroup>
       </selectionEntryGroups>
       <entryLinks>
-        <entryLink id="e65e-3ec8-ad06-8c84" name="Twin boltgun" hidden="false" targetId="311e-ae83-ed70-26e9" type="selectionEntry">
+        <entryLink id="e65e-3ec8-ad06-8c84" name="Twin boltgun" hidden="false" targetId="a11f-8f20-5d2c-079a" type="selectionEntry">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -2019,7 +2076,7 @@
           </constraints>
           <categoryLinks/>
         </entryLink>
-        <entryLink id="6658-e365-1918-23ae" name="Bolt pistol" hidden="false" targetId="0367-b42c-b6b4-0a58" type="selectionEntry">
+        <entryLink id="6658-e365-1918-23ae" name="Bolt pistol" hidden="false" targetId="37d3-7098-d596-9948" type="selectionEntry">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -2030,18 +2087,7 @@
           </constraints>
           <categoryLinks/>
         </entryLink>
-        <entryLink id="aad4-df41-9f71-372f" name="New EntryLink" hidden="false" targetId="e897-c8fa-0976-e2d3" type="selectionEntry">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints>
-            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="89b8-a785-a9d6-5094" type="min"/>
-            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="baa5-60d1-9727-9b88" type="max"/>
-          </constraints>
-          <categoryLinks/>
-        </entryLink>
-        <entryLink id="5999-c749-f19a-630e" name="New EntryLink" hidden="false" targetId="073b-2de5-765f-a4f2" type="selectionEntry">
+        <entryLink id="5999-c749-f19a-630e" name="Frag &amp; Krak grenades" hidden="false" targetId="cddf-945e-1335-e681" type="selectionEntry">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -2189,7 +2235,7 @@
                   <selectionEntries/>
                   <selectionEntryGroups/>
                   <entryLinks>
-                    <entryLink id="c64b-a690-3821-a9a1" name="" hidden="false" targetId="0367-b42c-b6b4-0a58" type="selectionEntry">
+                    <entryLink id="c64b-a690-3821-a9a1" name="Bolt pistol" hidden="false" targetId="37d3-7098-d596-9948" type="selectionEntry">
                       <profiles/>
                       <rules/>
                       <infoLinks/>
@@ -2213,7 +2259,7 @@
                 </selectionEntryGroup>
               </selectionEntryGroups>
               <entryLinks>
-                <entryLink id="5c9e-f64a-1a38-5b27" name="New EntryLink" hidden="false" targetId="311e-ae83-ed70-26e9" type="selectionEntry">
+                <entryLink id="5c9e-f64a-1a38-5b27" name="Twin boltgun" hidden="false" targetId="a11f-8f20-5d2c-079a" type="selectionEntry">
                   <profiles/>
                   <rules/>
                   <infoLinks/>
@@ -2224,18 +2270,7 @@
                   </constraints>
                   <categoryLinks/>
                 </entryLink>
-                <entryLink id="6925-ed5d-4d4e-8395" name="New EntryLink" hidden="false" targetId="e897-c8fa-0976-e2d3" type="selectionEntry">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                  <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="eb7a-3db7-da30-1fd1" type="min"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="70ff-ab3c-8933-ed7c" type="max"/>
-                  </constraints>
-                  <categoryLinks/>
-                </entryLink>
-                <entryLink id="bec0-dfa7-f552-6255" name="New EntryLink" hidden="false" targetId="073b-2de5-765f-a4f2" type="selectionEntry">
+                <entryLink id="bec0-dfa7-f552-6255" name="Frag &amp; Krak grenades" hidden="false" targetId="cddf-945e-1335-e681" type="selectionEntry">
                   <profiles/>
                   <rules/>
                   <infoLinks/>
@@ -2284,7 +2319,7 @@
                   <selectionEntries/>
                   <selectionEntryGroups/>
                   <entryLinks>
-                    <entryLink id="6765-1eaa-518e-26c0" name="Bolt pistol" hidden="false" targetId="bf86-1c1b-6871-da0b" type="selectionEntry">
+                    <entryLink id="6765-1eaa-518e-26c0" name="Bolt pistol" hidden="false" targetId="0334-f487-8229-0c1a" type="selectionEntry">
                       <profiles/>
                       <rules/>
                       <infoLinks/>
@@ -2294,7 +2329,7 @@
                       </constraints>
                       <categoryLinks/>
                     </entryLink>
-                    <entryLink id="448b-1dcb-9580-edd6" name="Chainsword" hidden="false" targetId="5f85-cddd-00b5-41f8" type="selectionEntry">
+                    <entryLink id="448b-1dcb-9580-edd6" name="Chainsword" hidden="false" targetId="0dd1-2e2b-7dd1-5495" type="selectionEntry">
                       <profiles/>
                       <rules/>
                       <infoLinks/>
@@ -2319,18 +2354,7 @@
                 </selectionEntryGroup>
               </selectionEntryGroups>
               <entryLinks>
-                <entryLink id="435d-5ecc-859c-8d34" name="Frag grenades" hidden="false" targetId="e897-c8fa-0976-e2d3" type="selectionEntry">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                  <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2c60-b4b5-3154-78bb" type="min"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bae5-0684-d0c9-5b1b" type="max"/>
-                  </constraints>
-                  <categoryLinks/>
-                </entryLink>
-                <entryLink id="a0b1-ab28-436d-5983" name="New EntryLink" hidden="false" targetId="073b-2de5-765f-a4f2" type="selectionEntry">
+                <entryLink id="a0b1-ab28-436d-5983" name="Frag &amp; Krak grenades" hidden="false" targetId="cddf-945e-1335-e681" type="selectionEntry">
                   <profiles/>
                   <rules/>
                   <infoLinks/>
@@ -2341,7 +2365,7 @@
                   </constraints>
                   <categoryLinks/>
                 </entryLink>
-                <entryLink id="c8e6-c76f-02f0-222a" name="New EntryLink" hidden="false" targetId="311e-ae83-ed70-26e9" type="selectionEntry">
+                <entryLink id="c8e6-c76f-02f0-222a" name="Twin boltgun" hidden="false" targetId="a11f-8f20-5d2c-079a" type="selectionEntry">
                   <profiles/>
                   <rules/>
                   <infoLinks/>
@@ -2485,7 +2509,7 @@
           <selectionEntries/>
           <selectionEntryGroups/>
           <entryLinks>
-            <entryLink id="1d3e-2b9e-7afe-b9dc" name="Master-crafted boltgun" hidden="false" targetId="ef67-7b07-f5c3-7d6c" type="selectionEntry">
+            <entryLink id="1d3e-2b9e-7afe-b9dc" name="Master-crafted boltgun" hidden="false" targetId="c215-aaf9-77ef-27fb" type="selectionEntry">
               <profiles/>
               <rules/>
               <infoLinks/>
@@ -2540,7 +2564,7 @@
           <selectionEntries/>
           <selectionEntryGroups/>
           <entryLinks>
-            <entryLink id="d734-56a2-32a1-1455" name="Chainsword" hidden="false" targetId="5f85-cddd-00b5-41f8" type="selectionEntry">
+            <entryLink id="d734-56a2-32a1-1455" name="Chainsword" hidden="false" targetId="0dd1-2e2b-7dd1-5495" type="selectionEntry">
               <profiles/>
               <rules/>
               <infoLinks/>
@@ -2550,7 +2574,7 @@
               </constraints>
               <categoryLinks/>
             </entryLink>
-            <entryLink id="8103-8c1c-509c-3cdf" name="Storm shield" hidden="false" targetId="4376-c122-ff61-5a1c" type="selectionEntry">
+            <entryLink id="8103-8c1c-509c-3cdf" name="Storm shield" hidden="false" targetId="38b5-ef30-f87f-5275" type="selectionEntry">
               <profiles/>
               <rules/>
               <infoLinks/>
@@ -2566,7 +2590,7 @@
               </constraints>
               <categoryLinks/>
             </entryLink>
-            <entryLink id="5d55-0bcf-3f1f-8935" name="Relic blade" hidden="false" targetId="dc83-fc73-b7ae-62b6" type="selectionEntry">
+            <entryLink id="5d55-0bcf-3f1f-8935" name="Relic blade" hidden="false" targetId="0140-c9f2-0524-34cc" type="selectionEntry">
               <profiles/>
               <rules/>
               <infoLinks/>
@@ -2606,18 +2630,7 @@
           </constraints>
           <categoryLinks/>
         </entryLink>
-        <entryLink id="a96a-d387-aebc-e917" name="Frag grenades" hidden="false" targetId="e897-c8fa-0976-e2d3" type="selectionEntry">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c87f-4f6c-2d93-5634" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9108-cc43-4e70-e9fc" type="max"/>
-          </constraints>
-          <categoryLinks/>
-        </entryLink>
-        <entryLink id="26db-3522-557c-48e4" name="New EntryLink" hidden="false" targetId="073b-2de5-765f-a4f2" type="selectionEntry">
+        <entryLink id="26db-3522-557c-48e4" name="Frag &amp; Krak grenades" hidden="false" targetId="cddf-945e-1335-e681" type="selectionEntry">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -2628,7 +2641,7 @@
           </constraints>
           <categoryLinks/>
         </entryLink>
-        <entryLink id="16e4-4c79-59c5-fe32" name="Bolt pistol" hidden="false" targetId="bf86-1c1b-6871-da0b" type="selectionEntry">
+        <entryLink id="16e4-4c79-59c5-fe32" name="Bolt pistol" hidden="false" targetId="0334-f487-8229-0c1a" type="selectionEntry">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -2637,6 +2650,32 @@
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8c70-7b75-9694-98cd" type="min"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5340-d08b-d8a1-8c7e" type="max"/>
           </constraints>
+          <categoryLinks/>
+        </entryLink>
+        <entryLink id="9f3b-493e-783e-fadd" name="Warlord" hidden="false" targetId="33f6-60da-7b70-5fee" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3be0-d1b0-442e-01ca" type="max"/>
+          </constraints>
+          <categoryLinks/>
+        </entryLink>
+        <entryLink id="c8db-8689-a9d7-d2bd" name="Warlord Traits" hidden="false" targetId="c25d-2fbc-47b3-9e39" type="selectionEntryGroup">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+          <categoryLinks/>
+        </entryLink>
+        <entryLink id="ea90-b132-e186-6e59" name="Relics of Baal" hidden="false" targetId="441f-1714-0777-c202" type="selectionEntryGroup">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
           <categoryLinks/>
         </entryLink>
       </entryLinks>
@@ -2744,7 +2783,7 @@
       <selectionEntries/>
       <selectionEntryGroups/>
       <entryLinks>
-        <entryLink id="950f-5e31-03a8-e7cf" name="Master-crafted power sword" hidden="false" targetId="7636-00cc-752b-c59b" type="selectionEntry">
+        <entryLink id="950f-5e31-03a8-e7cf" name="Master-crafted power sword" hidden="false" targetId="7d93-d63c-bfba-c879" type="selectionEntry">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -2755,7 +2794,7 @@
           </constraints>
           <categoryLinks/>
         </entryLink>
-        <entryLink id="ee39-adc8-380e-bd7c" name="New EntryLink" hidden="false" targetId="ac6d-335e-9f02-e4f1" type="selectionEntry">
+        <entryLink id="ee39-adc8-380e-bd7c" name="Boltstorm gauntlet" hidden="false" targetId="689a-17db-7527-5cf8" type="selectionEntry">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -2764,6 +2803,32 @@
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="69b0-4a03-6859-6cfc" type="min"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="100b-6630-2fff-cc60" type="max"/>
           </constraints>
+          <categoryLinks/>
+        </entryLink>
+        <entryLink id="5cd6-7787-98af-56e0" name="Warlord" hidden="false" targetId="33f6-60da-7b70-5fee" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ae9e-a2be-46bb-a7ea" type="max"/>
+          </constraints>
+          <categoryLinks/>
+        </entryLink>
+        <entryLink id="aa53-35fa-1f80-b756" name="Warlord Traits" hidden="false" targetId="c25d-2fbc-47b3-9e39" type="selectionEntryGroup">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+          <categoryLinks/>
+        </entryLink>
+        <entryLink id="c5ea-119d-3bf5-81b1" name="Relics of Baal" hidden="false" targetId="441f-1714-0777-c202" type="selectionEntryGroup">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
           <categoryLinks/>
         </entryLink>
       </entryLinks>
@@ -2776,7 +2841,7 @@
       <profiles/>
       <rules/>
       <infoLinks>
-        <infoLink id="9e8c-1ceb-866e-4d25" name="New InfoLink" hidden="false" targetId="e1e2-ff52-023c-cf8d" type="profile">
+        <infoLink id="9e8c-1ceb-866e-4d25" name="Captain in Terminator Armour" hidden="false" targetId="e1e2-ff52-023c-cf8d" type="profile">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -2788,19 +2853,19 @@
           <infoLinks/>
           <modifiers/>
         </infoLink>
-        <infoLink id="8253-bb83-99f4-b029" name="New InfoLink" hidden="false" targetId="8742-48fe-7dfc-a1c0" type="profile">
+        <infoLink id="8253-bb83-99f4-b029" name="Iron Halo" hidden="false" targetId="8742-48fe-7dfc-a1c0" type="profile">
           <profiles/>
           <rules/>
           <infoLinks/>
           <modifiers/>
         </infoLink>
-        <infoLink id="c85c-146d-8339-b9bc" name="New InfoLink" hidden="false" targetId="cf04-2c83-f5e1-9fb4" type="profile">
+        <infoLink id="c85c-146d-8339-b9bc" name="Rites of Battle" hidden="false" targetId="cf04-2c83-f5e1-9fb4" type="profile">
           <profiles/>
           <rules/>
           <infoLinks/>
           <modifiers/>
         </infoLink>
-        <infoLink id="be8d-ac66-344e-1e46" name="New InfoLink" hidden="false" targetId="4243-5016-c4d9-2b6b" type="profile">
+        <infoLink id="be8d-ac66-344e-1e46" name="Teleport Strike" hidden="false" targetId="4243-5016-c4d9-2b6b" type="profile">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -2882,7 +2947,7 @@
           <selectionEntries/>
           <selectionEntryGroups/>
           <entryLinks>
-            <entryLink id="9e5f-4cd2-0ba9-4487" name="New EntryLink" hidden="false" targetId="d74a-2fee-abea-1b42" type="selectionEntry">
+            <entryLink id="9e5f-4cd2-0ba9-4487" name="Storm bolter" hidden="false" targetId="2b03-8d64-3711-f300" type="selectionEntry">
               <profiles/>
               <rules/>
               <infoLinks/>
@@ -2914,7 +2979,7 @@
             </entryLink>
           </entryLinks>
         </selectionEntryGroup>
-        <selectionEntryGroup id="5199-4d04-4904-9edd" name="Melee weapon" hidden="false" collective="false" defaultSelectionEntryId="c69a-7c46-6a70-cfd1">
+        <selectionEntryGroup id="5199-4d04-4904-9edd" name="Melee weapon" hidden="false" collective="false" defaultSelectionEntryId="f632-d498-5668-d8c3">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -2927,7 +2992,7 @@
           <selectionEntries/>
           <selectionEntryGroups/>
           <entryLinks>
-            <entryLink id="c69a-7c46-6a70-cfd1" name="Power sword" hidden="false" targetId="c3d0-2567-35c6-3f29" type="selectionEntry">
+            <entryLink id="c69a-7c46-6a70-cfd1" name="Power sword" hidden="false" targetId="bc9e-551d-9afb-78d5" type="selectionEntry">
               <profiles/>
               <rules/>
               <infoLinks/>
@@ -2937,7 +3002,7 @@
               </constraints>
               <categoryLinks/>
             </entryLink>
-            <entryLink id="f632-d498-5668-d8c3" name="Relic blade" hidden="false" targetId="dc83-fc73-b7ae-62b6" type="selectionEntry">
+            <entryLink id="f632-d498-5668-d8c3" name="Relic blade" hidden="false" targetId="0140-c9f2-0524-34cc" type="selectionEntry">
               <profiles/>
               <rules/>
               <infoLinks/>
@@ -2947,7 +3012,7 @@
               </constraints>
               <categoryLinks/>
             </entryLink>
-            <entryLink id="83af-fec2-4536-a149" name="Chainfist" hidden="false" targetId="fdc6-5770-1177-74f4" type="selectionEntry">
+            <entryLink id="83af-fec2-4536-a149" name="Chainfist" hidden="false" targetId="e464-77c1-12bb-e52f" type="selectionEntry">
               <profiles/>
               <rules/>
               <infoLinks/>
@@ -2957,7 +3022,7 @@
               </constraints>
               <categoryLinks/>
             </entryLink>
-            <entryLink id="b5f8-8870-d25a-c896" name="Storm shield" hidden="false" targetId="4376-c122-ff61-5a1c" type="selectionEntry">
+            <entryLink id="b5f8-8870-d25a-c896" name="Storm shield" hidden="false" targetId="38b5-ef30-f87f-5275" type="selectionEntry">
               <profiles/>
               <rules/>
               <infoLinks/>
@@ -2987,7 +3052,7 @@
         </selectionEntryGroup>
       </selectionEntryGroups>
       <entryLinks>
-        <entryLink id="5e82-35a9-7654-36a8" name="" hidden="false" targetId="e651-01ab-4ca9-0077" type="selectionEntry">
+        <entryLink id="5e82-35a9-7654-36a8" name="Wrist-mounted grenade launcher" hidden="false" targetId="f79f-74ef-e0a3-f967" type="selectionEntry">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -2995,7 +3060,7 @@
             <modifier type="set" field="hidden" value="true">
               <repeats/>
               <conditions>
-                <condition field="selections" scope="e647-bdc2-88ae-7c96" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3102-2dd8-4f31-3af7" type="equalTo"/>
+                <condition field="selections" scope="e647-bdc2-88ae-7c96" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f122-3720-fa32-4215" type="equalTo"/>
               </conditions>
               <conditionGroups/>
             </modifier>
@@ -3003,6 +3068,32 @@
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9f8f-9978-b997-7edd" type="max"/>
           </constraints>
+          <categoryLinks/>
+        </entryLink>
+        <entryLink id="7f8e-4a09-990f-63ff" name="Warlord" hidden="false" targetId="33f6-60da-7b70-5fee" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6bf5-575f-43e7-3029" type="max"/>
+          </constraints>
+          <categoryLinks/>
+        </entryLink>
+        <entryLink id="90e2-6e59-4147-4696" name="Warlord Traits" hidden="false" targetId="c25d-2fbc-47b3-9e39" type="selectionEntryGroup">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+          <categoryLinks/>
+        </entryLink>
+        <entryLink id="6558-6cae-9da4-b062" name="Relics of Baal" hidden="false" targetId="441f-1714-0777-c202" type="selectionEntryGroup">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
           <categoryLinks/>
         </entryLink>
       </entryLinks>
@@ -3114,7 +3205,7 @@
           <selectionEntries/>
           <selectionEntryGroups/>
           <entryLinks>
-            <entryLink id="0172-76af-d8e8-91e9" name="New EntryLink" hidden="false" targetId="ef67-7b07-f5c3-7d6c" type="selectionEntry">
+            <entryLink id="0172-76af-d8e8-91e9" name="Master-crafted boltgun" hidden="false" targetId="c215-aaf9-77ef-27fb" type="selectionEntry">
               <profiles/>
               <rules/>
               <infoLinks/>
@@ -3169,7 +3260,7 @@
           <selectionEntries/>
           <selectionEntryGroups/>
           <entryLinks>
-            <entryLink id="bea9-7f15-eda5-c8b4" name="Chainsword" hidden="false" targetId="5f85-cddd-00b5-41f8" type="selectionEntry">
+            <entryLink id="bea9-7f15-eda5-c8b4" name="Chainsword" hidden="false" targetId="0dd1-2e2b-7dd1-5495" type="selectionEntry">
               <profiles/>
               <rules/>
               <infoLinks/>
@@ -3179,7 +3270,7 @@
               </constraints>
               <categoryLinks/>
             </entryLink>
-            <entryLink id="75ba-9af4-3503-7555" name="Storm shield" hidden="false" targetId="4376-c122-ff61-5a1c" type="selectionEntry">
+            <entryLink id="75ba-9af4-3503-7555" name="Storm shield" hidden="false" targetId="38b5-ef30-f87f-5275" type="selectionEntry">
               <profiles/>
               <rules/>
               <infoLinks/>
@@ -3209,18 +3300,7 @@
         </selectionEntryGroup>
       </selectionEntryGroups>
       <entryLinks>
-        <entryLink id="af3d-5a3b-4dd5-bb92" name="New EntryLink" hidden="false" targetId="e897-c8fa-0976-e2d3" type="selectionEntry">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5f72-31f1-4bb1-1284" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5547-9562-0a61-d209" type="max"/>
-          </constraints>
-          <categoryLinks/>
-        </entryLink>
-        <entryLink id="8127-c19d-dd0d-289e" name="New EntryLink" hidden="false" targetId="073b-2de5-765f-a4f2" type="selectionEntry">
+        <entryLink id="8127-c19d-dd0d-289e" name="Frag &amp; Krak grenades" hidden="false" targetId="cddf-945e-1335-e681" type="selectionEntry">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -3231,7 +3311,7 @@
           </constraints>
           <categoryLinks/>
         </entryLink>
-        <entryLink id="ed52-4f79-a64f-f921" name="Twin boltgun" hidden="false" targetId="311e-ae83-ed70-26e9" type="selectionEntry">
+        <entryLink id="ed52-4f79-a64f-f921" name="Twin boltgun" hidden="false" targetId="a11f-8f20-5d2c-079a" type="selectionEntry">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -3242,7 +3322,7 @@
           </constraints>
           <categoryLinks/>
         </entryLink>
-        <entryLink id="4757-5371-64a9-2feb" name="Bolt pistol" hidden="false" targetId="bf86-1c1b-6871-da0b" type="selectionEntry">
+        <entryLink id="4757-5371-64a9-2feb" name="Bolt pistol" hidden="false" targetId="0334-f487-8229-0c1a" type="selectionEntry">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -3251,6 +3331,32 @@
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8a19-ba3f-98a2-dc5a" type="min"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="17ca-406f-918a-4c01" type="max"/>
           </constraints>
+          <categoryLinks/>
+        </entryLink>
+        <entryLink id="66e9-0335-73a0-8eb9" name="Warlord" hidden="false" targetId="33f6-60da-7b70-5fee" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6838-d6fd-c7b0-2ea9" type="max"/>
+          </constraints>
+          <categoryLinks/>
+        </entryLink>
+        <entryLink id="d766-b85d-a756-f2b9" name="Warlord Traits" hidden="false" targetId="c25d-2fbc-47b3-9e39" type="selectionEntryGroup">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+          <categoryLinks/>
+        </entryLink>
+        <entryLink id="7327-83fb-a5e6-0065" name="Relics of Baal" hidden="false" targetId="441f-1714-0777-c202" type="selectionEntryGroup">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
           <categoryLinks/>
         </entryLink>
       </entryLinks>
@@ -3370,7 +3476,7 @@
           <selectionEntries/>
           <selectionEntryGroups/>
           <entryLinks>
-            <entryLink id="4c16-341d-5cfd-709b" name="Boltgun" hidden="false" targetId="8e23-a2e7-23c4-cac7" type="selectionEntry">
+            <entryLink id="4c16-341d-5cfd-709b" name="Boltgun" hidden="false" targetId="b61f-a3c1-827d-c5b6" type="selectionEntry">
               <profiles/>
               <rules/>
               <infoLinks/>
@@ -3400,7 +3506,7 @@
               </constraints>
               <categoryLinks/>
             </entryLink>
-            <entryLink id="3030-375d-0ecd-4d47" name="New EntryLink" hidden="false" targetId="3102-2dd8-4f31-3af7" type="selectionEntry">
+            <entryLink id="3030-375d-0ecd-4d47" name="Power fist" hidden="false" targetId="f122-3720-fa32-4215" type="selectionEntry">
               <profiles/>
               <rules/>
               <infoLinks/>
@@ -3410,7 +3516,7 @@
               </constraints>
               <categoryLinks/>
             </entryLink>
-            <entryLink id="9750-51a1-2f2c-d284" name="Bolt pistol" hidden="false" targetId="bf86-1c1b-6871-da0b" type="selectionEntry">
+            <entryLink id="9750-51a1-2f2c-d284" name="Bolt pistol" hidden="false" targetId="0334-f487-8229-0c1a" type="selectionEntry">
               <profiles/>
               <rules/>
               <infoLinks/>
@@ -3440,18 +3546,7 @@
           </constraints>
           <categoryLinks/>
         </entryLink>
-        <entryLink id="0b04-70ee-830f-10be" name="New EntryLink" hidden="false" targetId="e897-c8fa-0976-e2d3" type="selectionEntry">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6873-c0a5-918c-adfa" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6157-5c38-4ea9-cd05" type="max"/>
-          </constraints>
-          <categoryLinks/>
-        </entryLink>
-        <entryLink id="9ea6-b3a7-6836-08a8" name="New EntryLink" hidden="false" targetId="073b-2de5-765f-a4f2" type="selectionEntry">
+        <entryLink id="9ea6-b3a7-6836-08a8" name="Frag &amp; Krak grenades" hidden="false" targetId="cddf-945e-1335-e681" type="selectionEntry">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -3462,7 +3557,7 @@
           </constraints>
           <categoryLinks/>
         </entryLink>
-        <entryLink id="6579-d1b5-bccf-f671" name="Crozius arcanum" hidden="false" targetId="5333-870f-3451-fcfa" type="selectionEntry">
+        <entryLink id="6579-d1b5-bccf-f671" name="Crozius arcanum" hidden="false" targetId="7543-5a4e-0f59-bacc" type="selectionEntry">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -3471,6 +3566,32 @@
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e86e-e3c5-2b97-3da5" type="min"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ec9d-2c85-2196-7aed" type="max"/>
           </constraints>
+          <categoryLinks/>
+        </entryLink>
+        <entryLink id="75d2-1b5c-8092-ea6a" name="Warlord" hidden="false" targetId="33f6-60da-7b70-5fee" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5147-a95d-d967-125c" type="max"/>
+          </constraints>
+          <categoryLinks/>
+        </entryLink>
+        <entryLink id="d0f4-8151-7d2a-63f6" name="Warlord Traits" hidden="false" targetId="c25d-2fbc-47b3-9e39" type="selectionEntryGroup">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+          <categoryLinks/>
+        </entryLink>
+        <entryLink id="1cd5-4c49-ccee-d9ea" name="Relics of Baal" hidden="false" targetId="441f-1714-0777-c202" type="selectionEntryGroup">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
           <categoryLinks/>
         </entryLink>
       </entryLinks>
@@ -3483,7 +3604,7 @@
       <profiles/>
       <rules/>
       <infoLinks>
-        <infoLink id="b65a-7163-ef05-8c8a" name="New InfoLink" hidden="false" targetId="7fd4-c500-a7fe-6966" type="profile">
+        <infoLink id="b65a-7163-ef05-8c8a" name="Chaplain in Terminator Armour" hidden="false" targetId="7fd4-c500-a7fe-6966" type="profile">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -3495,19 +3616,19 @@
           <infoLinks/>
           <modifiers/>
         </infoLink>
-        <infoLink id="a7b7-8203-6b3e-558c" name="New InfoLink" hidden="false" targetId="5aec-11fa-8ca0-f951" type="profile">
+        <infoLink id="a7b7-8203-6b3e-558c" name="Litanies of Hate" hidden="false" targetId="5aec-11fa-8ca0-f951" type="profile">
           <profiles/>
           <rules/>
           <infoLinks/>
           <modifiers/>
         </infoLink>
-        <infoLink id="26dc-a4de-b02f-326a" name="New InfoLink" hidden="false" targetId="b3b2-9c8e-c9bd-91b5" type="profile">
+        <infoLink id="26dc-a4de-b02f-326a" name="Spiritual Leaders" hidden="false" targetId="b3b2-9c8e-c9bd-91b5" type="profile">
           <profiles/>
           <rules/>
           <infoLinks/>
           <modifiers/>
         </infoLink>
-        <infoLink id="83e8-b6f2-f099-8599" name="New InfoLink" hidden="false" targetId="4243-5016-c4d9-2b6b" type="profile">
+        <infoLink id="83e8-b6f2-f099-8599" name="Teleport Strike" hidden="false" targetId="4243-5016-c4d9-2b6b" type="profile">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -3595,7 +3716,7 @@
           <selectionEntries/>
           <selectionEntryGroups/>
           <entryLinks>
-            <entryLink id="b053-de94-e3f1-1ab9" name="Storm bolter" hidden="false" targetId="d74a-2fee-abea-1b42" type="selectionEntry">
+            <entryLink id="b053-de94-e3f1-1ab9" name="Storm bolter" hidden="false" targetId="2b03-8d64-3711-f300" type="selectionEntry">
               <profiles/>
               <rules/>
               <infoLinks/>
@@ -3619,7 +3740,7 @@
         </selectionEntryGroup>
       </selectionEntryGroups>
       <entryLinks>
-        <entryLink id="36fa-9a86-c8c4-f2d1" name="Crozius arcanum" hidden="false" targetId="5333-870f-3451-fcfa" type="selectionEntry">
+        <entryLink id="36fa-9a86-c8c4-f2d1" name="Crozius arcanum" hidden="false" targetId="7543-5a4e-0f59-bacc" type="selectionEntry">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -3630,10 +3751,36 @@
           </constraints>
           <categoryLinks/>
         </entryLink>
+        <entryLink id="4673-c460-f59f-bfcf" name="Warlord" hidden="false" targetId="33f6-60da-7b70-5fee" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7d4f-a644-8cba-a07b" type="max"/>
+          </constraints>
+          <categoryLinks/>
+        </entryLink>
+        <entryLink id="2abf-4b05-9b96-7d03" name="Warlord Traits" hidden="false" targetId="c25d-2fbc-47b3-9e39" type="selectionEntryGroup">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+          <categoryLinks/>
+        </entryLink>
+        <entryLink id="15b4-ea5c-7a79-0da6" name="Relics of Baal" hidden="false" targetId="441f-1714-0777-c202" type="selectionEntryGroup">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+          <categoryLinks/>
+        </entryLink>
       </entryLinks>
       <costs>
         <cost name="pts" costTypeId="points" value="100.0"/>
-        <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="7.0"/>
+        <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="6.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="f8dd-6ce0-5e74-b52b" name="Chaplain on Bike" hidden="false" collective="false" type="model">
@@ -3745,7 +3892,7 @@
           <selectionEntries/>
           <selectionEntryGroups/>
           <entryLinks>
-            <entryLink id="b487-9682-1979-bc47" name="Boltgun" hidden="false" targetId="8e23-a2e7-23c4-cac7" type="selectionEntry">
+            <entryLink id="b487-9682-1979-bc47" name="Boltgun" hidden="false" targetId="b61f-a3c1-827d-c5b6" type="selectionEntry">
               <profiles/>
               <rules/>
               <infoLinks/>
@@ -3775,7 +3922,7 @@
               </constraints>
               <categoryLinks/>
             </entryLink>
-            <entryLink id="f0db-a93c-588c-bae9" name="New EntryLink" hidden="false" targetId="3102-2dd8-4f31-3af7" type="selectionEntry">
+            <entryLink id="f0db-a93c-588c-bae9" name="Power fist" hidden="false" targetId="f122-3720-fa32-4215" type="selectionEntry">
               <profiles/>
               <rules/>
               <infoLinks/>
@@ -3785,7 +3932,7 @@
               </constraints>
               <categoryLinks/>
             </entryLink>
-            <entryLink id="8339-744b-01cb-7788" name="Bolt pistol" hidden="false" targetId="bf86-1c1b-6871-da0b" type="selectionEntry">
+            <entryLink id="8339-744b-01cb-7788" name="Bolt pistol" hidden="false" targetId="0334-f487-8229-0c1a" type="selectionEntry">
               <profiles/>
               <rules/>
               <infoLinks/>
@@ -3799,18 +3946,7 @@
         </selectionEntryGroup>
       </selectionEntryGroups>
       <entryLinks>
-        <entryLink id="e3cc-cb19-2d68-06dd" name="New EntryLink" hidden="false" targetId="e897-c8fa-0976-e2d3" type="selectionEntry">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1f24-6f61-a96c-e727" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b319-9174-3361-1f33" type="max"/>
-          </constraints>
-          <categoryLinks/>
-        </entryLink>
-        <entryLink id="0091-710a-f010-149c" name="New EntryLink" hidden="false" targetId="073b-2de5-765f-a4f2" type="selectionEntry">
+        <entryLink id="0091-710a-f010-149c" name="Frag &amp; Krak grenades" hidden="false" targetId="cddf-945e-1335-e681" type="selectionEntry">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -3821,7 +3957,7 @@
           </constraints>
           <categoryLinks/>
         </entryLink>
-        <entryLink id="1eaa-8dc0-58d1-d415" name="New EntryLink" hidden="false" targetId="311e-ae83-ed70-26e9" type="selectionEntry">
+        <entryLink id="1eaa-8dc0-58d1-d415" name="Twin boltgun" hidden="false" targetId="a11f-8f20-5d2c-079a" type="selectionEntry">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -3830,6 +3966,32 @@
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4414-4ce5-55f8-4360" type="min"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="106b-3e8e-7b33-2308" type="max"/>
           </constraints>
+          <categoryLinks/>
+        </entryLink>
+        <entryLink id="7fc3-0d1c-298f-5401" name="Warlord" hidden="false" targetId="33f6-60da-7b70-5fee" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="16aa-c289-7efe-5b00" type="max"/>
+          </constraints>
+          <categoryLinks/>
+        </entryLink>
+        <entryLink id="2591-c452-7558-6c5d" name="Warlord Traits" hidden="false" targetId="c25d-2fbc-47b3-9e39" type="selectionEntryGroup">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+          <categoryLinks/>
+        </entryLink>
+        <entryLink id="44ea-2952-eb1f-b689" name="Relics of Baal" hidden="false" targetId="441f-1714-0777-c202" type="selectionEntryGroup">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
           <categoryLinks/>
         </entryLink>
       </entryLinks>
@@ -3937,7 +4099,7 @@
           <selectionEntries/>
           <selectionEntryGroups/>
           <entryLinks>
-            <entryLink id="152d-7dd3-4de3-939f" name="Boltgun" hidden="false" targetId="8e23-a2e7-23c4-cac7" type="selectionEntry">
+            <entryLink id="152d-7dd3-4de3-939f" name="Boltgun" hidden="false" targetId="b61f-a3c1-827d-c5b6" type="selectionEntry">
               <profiles/>
               <rules/>
               <infoLinks/>
@@ -3977,7 +4139,7 @@
               </constraints>
               <categoryLinks/>
             </entryLink>
-            <entryLink id="49a7-f354-33da-c8a6" name="Bolt pistol" hidden="false" targetId="bf86-1c1b-6871-da0b" type="selectionEntry">
+            <entryLink id="49a7-f354-33da-c8a6" name="Bolt pistol" hidden="false" targetId="0334-f487-8229-0c1a" type="selectionEntry">
               <profiles/>
               <rules/>
               <infoLinks/>
@@ -3991,18 +4153,7 @@
         </selectionEntryGroup>
       </selectionEntryGroups>
       <entryLinks>
-        <entryLink id="191c-e3bc-9906-f7c8" name="New EntryLink" hidden="false" targetId="e897-c8fa-0976-e2d3" type="selectionEntry">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b7bb-6edb-a1a1-6b82" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f719-437c-382f-25da" type="max"/>
-          </constraints>
-          <categoryLinks/>
-        </entryLink>
-        <entryLink id="f300-e18b-029f-c728" name="New EntryLink" hidden="false" targetId="073b-2de5-765f-a4f2" type="selectionEntry">
+        <entryLink id="f300-e18b-029f-c728" name="Frag &amp; Krak grenades" hidden="false" targetId="cddf-945e-1335-e681" type="selectionEntry">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -4027,6 +4178,32 @@
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0e26-85cd-a670-8d94" type="max"/>
           </constraints>
+          <categoryLinks/>
+        </entryLink>
+        <entryLink id="a3f4-4117-e4dc-dcb3" name="Warlord" hidden="false" targetId="33f6-60da-7b70-5fee" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5133-c1c5-ee31-4933" type="max"/>
+          </constraints>
+          <categoryLinks/>
+        </entryLink>
+        <entryLink id="22aa-a253-d761-24fe" name="Warlord Traits" hidden="false" targetId="c25d-2fbc-47b3-9e39" type="selectionEntryGroup">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+          <categoryLinks/>
+        </entryLink>
+        <entryLink id="973f-7d9a-ebf9-3ddf" name="Relics of Baal" hidden="false" targetId="441f-1714-0777-c202" type="selectionEntryGroup">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
           <categoryLinks/>
         </entryLink>
       </entryLinks>
@@ -4059,7 +4236,7 @@
           <infoLinks/>
           <modifiers/>
         </infoLink>
-        <infoLink id="9cc3-b367-4ce3-9909" name="New InfoLink" hidden="false" targetId="5d04-8767-d93e-f7fd" type="profile">
+        <infoLink id="9cc3-b367-4ce3-9909" name="Honour or Death" hidden="false" targetId="5d04-8767-d93e-f7fd" type="profile">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -4122,7 +4299,7 @@
       <selectionEntries/>
       <selectionEntryGroups/>
       <entryLinks>
-        <entryLink id="7b31-db71-e366-b838" name="Combat shield" book="" hidden="false" targetId="a052-e708-7e92-feb7" type="selectionEntry">
+        <entryLink id="7b31-db71-e366-b838" name="Combat shield" book="" hidden="false" targetId="2792-c0fb-d72e-cee4" type="selectionEntry">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -4133,18 +4310,7 @@
           </constraints>
           <categoryLinks/>
         </entryLink>
-        <entryLink id="c702-6d7a-ad76-123c" name="New EntryLink" hidden="false" targetId="e897-c8fa-0976-e2d3" type="selectionEntry">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="89ec-0717-8553-4fd2" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b9fb-58bc-d045-29b9" type="max"/>
-          </constraints>
-          <categoryLinks/>
-        </entryLink>
-        <entryLink id="2983-f9e6-bd83-3b39" name="New EntryLink" hidden="false" targetId="073b-2de5-765f-a4f2" type="selectionEntry">
+        <entryLink id="2983-f9e6-bd83-3b39" name="Frag &amp; Krak grenades" hidden="false" targetId="cddf-945e-1335-e681" type="selectionEntry">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -4155,7 +4321,7 @@
           </constraints>
           <categoryLinks/>
         </entryLink>
-        <entryLink id="e6f9-6ee0-991b-6fb8" name="Bolt pistol" hidden="false" targetId="bf86-1c1b-6871-da0b" type="selectionEntry">
+        <entryLink id="e6f9-6ee0-991b-6fb8" name="Bolt pistol" hidden="false" targetId="0334-f487-8229-0c1a" type="selectionEntry">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -4166,7 +4332,7 @@
           </constraints>
           <categoryLinks/>
         </entryLink>
-        <entryLink id="3c81-c2e5-0dde-62b0" name="Master-crafted power sword" hidden="false" targetId="7636-00cc-752b-c59b" type="selectionEntry">
+        <entryLink id="3c81-c2e5-0dde-62b0" name="Master-crafted power sword" hidden="false" targetId="7d93-d63c-bfba-c879" type="selectionEntry">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -4193,6 +4359,32 @@
           </constraints>
           <categoryLinks/>
         </entryLink>
+        <entryLink id="aef6-98e0-9fc7-b113" name="Warlord" hidden="false" targetId="33f6-60da-7b70-5fee" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="575a-12d2-ab88-0f1e" type="max"/>
+          </constraints>
+          <categoryLinks/>
+        </entryLink>
+        <entryLink id="1202-cf24-3cdd-d487" name="Warlord Traits" hidden="false" targetId="c25d-2fbc-47b3-9e39" type="selectionEntryGroup">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+          <categoryLinks/>
+        </entryLink>
+        <entryLink id="2868-cef9-529f-71b4" name="Relics of Baal" hidden="false" targetId="441f-1714-0777-c202" type="selectionEntryGroup">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+          <categoryLinks/>
+        </entryLink>
       </entryLinks>
       <costs>
         <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="3.0"/>
@@ -4209,7 +4401,7 @@
           <infoLinks/>
           <modifiers/>
         </infoLink>
-        <infoLink id="ee98-9f10-a652-cf91" name="New InfoLink" hidden="false" targetId="bbbc-22c8-630e-2c99" type="profile">
+        <infoLink id="ee98-9f10-a652-cf91" name="Command Squad Bodyguard" hidden="false" targetId="bbbc-22c8-630e-2c99" type="profile">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -4311,7 +4503,7 @@
               <selectionEntries/>
               <selectionEntryGroups/>
               <entryLinks>
-                <entryLink id="12e8-069d-b84c-2e78" name="New EntryLink" hidden="false" targetId="0367-b42c-b6b4-0a58" type="selectionEntry">
+                <entryLink id="12e8-069d-b84c-2e78" name="Bolt pistol" hidden="false" targetId="37d3-7098-d596-9948" type="selectionEntry">
                   <profiles/>
                   <rules/>
                   <infoLinks/>
@@ -4366,7 +4558,7 @@
               <selectionEntries/>
               <selectionEntryGroups/>
               <entryLinks>
-                <entryLink id="1205-ac4e-09b6-7a11" name="New EntryLink" hidden="false" targetId="5905-f299-f23c-f9c1" type="selectionEntry">
+                <entryLink id="1205-ac4e-09b6-7a11" name="Chainsword" hidden="false" targetId="4334-d2da-32f5-dc53" type="selectionEntry">
                   <profiles/>
                   <rules/>
                   <infoLinks/>
@@ -4406,7 +4598,7 @@
                   </constraints>
                   <categoryLinks/>
                 </entryLink>
-                <entryLink id="0130-fffb-9f44-c3e1" name="New EntryLink" hidden="false" targetId="7b26-e6ac-dce0-6897" type="selectionEntry">
+                <entryLink id="0130-fffb-9f44-c3e1" name="Boltgun" hidden="false" targetId="ca06-ac13-d02f-6f9a" type="selectionEntry">
                   <profiles/>
                   <rules/>
                   <infoLinks/>
@@ -4440,18 +4632,7 @@
             </selectionEntryGroup>
           </selectionEntryGroups>
           <entryLinks>
-            <entryLink id="1dce-7c88-7cf3-a4dd" name="New EntryLink" hidden="false" targetId="e897-c8fa-0976-e2d3" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="026e-fd63-7243-389b" type="min"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2c80-4495-e0df-bd2a" type="max"/>
-              </constraints>
-              <categoryLinks/>
-            </entryLink>
-            <entryLink id="2b5d-6f4e-a8fc-305b" name="New EntryLink" hidden="false" targetId="073b-2de5-765f-a4f2" type="selectionEntry">
+            <entryLink id="2b5d-6f4e-a8fc-305b" name="Frag &amp; Krak grenades" hidden="false" targetId="cddf-945e-1335-e681" type="selectionEntry">
               <profiles/>
               <rules/>
               <infoLinks/>
@@ -4526,7 +4707,7 @@
                   <selectionEntries/>
                   <selectionEntryGroups/>
                   <entryLinks>
-                    <entryLink id="5469-6540-2b60-b253" name="New EntryLink" hidden="false" targetId="0367-b42c-b6b4-0a58" type="selectionEntry">
+                    <entryLink id="5469-6540-2b60-b253" name="Bolt pistol" hidden="false" targetId="37d3-7098-d596-9948" type="selectionEntry">
                       <profiles/>
                       <rules/>
                       <infoLinks/>
@@ -4537,7 +4718,7 @@
                       </constraints>
                       <categoryLinks/>
                     </entryLink>
-                    <entryLink id="5866-f5b9-c316-15b4" name="New EntryLink" hidden="false" targetId="5905-f299-f23c-f9c1" type="selectionEntry">
+                    <entryLink id="5866-f5b9-c316-15b4" name="Chainsword" hidden="false" targetId="4334-d2da-32f5-dc53" type="selectionEntry">
                       <profiles/>
                       <rules/>
                       <infoLinks/>
@@ -4599,18 +4780,7 @@
             </selectionEntryGroup>
           </selectionEntryGroups>
           <entryLinks>
-            <entryLink id="aac0-403f-1e6c-5514" name="New EntryLink" hidden="false" targetId="e897-c8fa-0976-e2d3" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ae5e-f391-2387-ff53" type="min"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="515d-8b02-3b54-34c5" type="max"/>
-              </constraints>
-              <categoryLinks/>
-            </entryLink>
-            <entryLink id="a22c-ebab-7009-ddff" name="New EntryLink" hidden="false" targetId="073b-2de5-765f-a4f2" type="selectionEntry">
+            <entryLink id="a22c-ebab-7009-ddff" name="Frag &amp; Krak grenades" hidden="false" targetId="cddf-945e-1335-e681" type="selectionEntry">
               <profiles/>
               <rules/>
               <infoLinks/>
@@ -4657,7 +4827,7 @@
     <selectionEntry id="32b5-8b56-0956-48d5" name="Devastator Squad" hidden="false" collective="false" type="unit">
       <profiles/>
       <rules>
-        <rule id="4abb-6f49-ffea-9bc6" name="Combat Squads" hidden="false">
+        <rule id="ddb8-e341-cd25-1b7c" name="Combat Squads" hidden="false">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -4672,7 +4842,7 @@
           <infoLinks/>
           <modifiers/>
         </infoLink>
-        <infoLink id="57ca-c3b8-27b1-1802" name="New InfoLink" hidden="false" targetId="19c3-bcee-c057-c0cd" type="profile">
+        <infoLink id="57ca-c3b8-27b1-1802" name="Signum" hidden="false" targetId="19c3-bcee-c057-c0cd" type="profile">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -4767,7 +4937,7 @@
               <selectionEntries/>
               <selectionEntryGroups/>
               <entryLinks>
-                <entryLink id="c7d9-db54-0415-5069" name="Boltgun" hidden="false" targetId="8e23-a2e7-23c4-cac7" type="selectionEntry">
+                <entryLink id="c7d9-db54-0415-5069" name="Boltgun" hidden="false" targetId="b61f-a3c1-827d-c5b6" type="selectionEntry">
                   <profiles/>
                   <rules/>
                   <infoLinks/>
@@ -4789,7 +4959,7 @@
             </selectionEntryGroup>
           </selectionEntryGroups>
           <entryLinks>
-            <entryLink id="606a-0cae-fc25-2469" name="Bolt pistol" hidden="false" targetId="0367-b42c-b6b4-0a58" type="selectionEntry">
+            <entryLink id="606a-0cae-fc25-2469" name="Bolt pistol" hidden="false" targetId="37d3-7098-d596-9948" type="selectionEntry">
               <profiles/>
               <rules/>
               <infoLinks/>
@@ -4800,18 +4970,7 @@
               </constraints>
               <categoryLinks/>
             </entryLink>
-            <entryLink id="6fed-4096-93bc-17b5" name="New EntryLink" hidden="false" targetId="e897-c8fa-0976-e2d3" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="aee0-1342-0cb5-8c53" type="min"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="583e-7ee9-4200-7439" type="max"/>
-              </constraints>
-              <categoryLinks/>
-            </entryLink>
-            <entryLink id="1ad4-d8bc-5b87-4a4e" name="Krak grenades" hidden="false" targetId="073b-2de5-765f-a4f2" type="selectionEntry">
+            <entryLink id="1ad4-d8bc-5b87-4a4e" name="Frag &amp; Krak grenades" hidden="false" targetId="cddf-945e-1335-e681" type="selectionEntry">
               <profiles/>
               <rules/>
               <infoLinks/>
@@ -4853,7 +5012,7 @@
               <selectionEntries/>
               <selectionEntryGroups/>
               <entryLinks>
-                <entryLink id="33c3-3457-6da7-029d" name="Boltgun" hidden="false" targetId="8e23-a2e7-23c4-cac7" type="selectionEntry">
+                <entryLink id="33c3-3457-6da7-029d" name="Boltgun" hidden="false" targetId="b61f-a3c1-827d-c5b6" type="selectionEntry">
                   <profiles/>
                   <rules/>
                   <infoLinks/>
@@ -4878,7 +5037,7 @@
             </selectionEntryGroup>
           </selectionEntryGroups>
           <entryLinks>
-            <entryLink id="47bf-0a36-8377-4ee3" name="New EntryLink" hidden="false" targetId="0367-b42c-b6b4-0a58" type="selectionEntry">
+            <entryLink id="47bf-0a36-8377-4ee3" name="Bolt pistol" hidden="false" targetId="37d3-7098-d596-9948" type="selectionEntry">
               <profiles/>
               <rules/>
               <infoLinks/>
@@ -4889,18 +5048,7 @@
               </constraints>
               <categoryLinks/>
             </entryLink>
-            <entryLink id="c8a1-e8ae-ed68-19f7" name="New EntryLink" hidden="false" targetId="e897-c8fa-0976-e2d3" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2764-2d82-690a-7968" type="min"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5d5e-ba4d-0ff3-c197" type="max"/>
-              </constraints>
-              <categoryLinks/>
-            </entryLink>
-            <entryLink id="6ed4-3602-deeb-884e" name="Krak grenades" hidden="false" targetId="073b-2de5-765f-a4f2" type="selectionEntry">
+            <entryLink id="6ed4-3602-deeb-884e" name="Frag &amp; Krak grenades" hidden="false" targetId="cddf-945e-1335-e681" type="selectionEntry">
               <profiles/>
               <rules/>
               <infoLinks/>
@@ -4919,17 +5067,15 @@
         </selectionEntry>
         <selectionEntry id="2821-843f-82fd-ab8f" name="Armorium Cherub" hidden="false" collective="false" type="upgrade">
           <profiles/>
-          <rules>
-            <rule id="4ed4-96ec-8344-abed" name="Armorium Cherub" book="" hidden="false">
+          <rules/>
+          <infoLinks>
+            <infoLink id="52cd-af27-1847-a4bb" name="Armorium Cherub" hidden="false" targetId="12e6-f7f2-9af4-bfd4" type="profile">
               <profiles/>
               <rules/>
               <infoLinks/>
               <modifiers/>
-              <description>Once per game, after a model in this unit has fired, an Armorium Cherub can reload that model&apos;s weapons. When it does so, remove the Armorium Cherub and that model can immediately shoot again. The removal of an Armorium Cherub (for any reason) is ignored for the purposes of morale.</description>
-            </rule>
-          </rules>
-          <infoLinks>
-            <infoLink id="52cd-af27-1847-a4bb" name="New InfoLink" hidden="false" targetId="12e6-f7f2-9af4-bfd4" type="profile">
+            </infoLink>
+            <infoLink id="485b-e398-51f5-a85f" name="Armorium Cherub" hidden="false" targetId="444f-1f1f-a9a6-f302" type="profile">
               <profiles/>
               <rules/>
               <infoLinks/>
@@ -4959,13 +5105,15 @@
     </selectionEntry>
     <selectionEntry id="5aef-7a01-5b7c-047f" name="Dreadnought" hidden="false" collective="false" type="model">
       <profiles>
-        <profile id="2331-574e-4226-46bc" name="Explodes" hidden="false" profileTypeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" profileTypeName="Abilities">
+        <profile id="2331-574e-4226-46bc" name="Explodes" hidden="false" profileTypeId="818c-0db1-36f0-462a" profileTypeName="Explosion">
           <profiles/>
           <rules/>
           <infoLinks/>
           <modifiers/>
           <characteristics>
-            <characteristic name="Description" characteristicTypeId="21befb24-fc85-4f52-a745-64b2e48f8228" value="If this model is reduced to 0 wounds, roll a D6 before removing the model from the battlefield; on a 6 it explodes, and each unit within 3&quot; suffers D3 mortal wounds."/>
+            <characteristic name="Dice roll" characteristicTypeId="f21d-8f6d-180d-36ff" value="6"/>
+            <characteristic name="Distance" characteristicTypeId="d69e-be07-1682-ebcc" value="3&quot;"/>
+            <characteristic name="Mortal wounds" characteristicTypeId="29f1-65a1-2c5d-8c7d" value="D3"/>
           </characteristics>
         </profile>
       </profiles>
@@ -5032,7 +5180,7 @@
       </categoryLinks>
       <selectionEntries/>
       <selectionEntryGroups>
-        <selectionEntryGroup id="a871-3879-e3a1-839f" name="Melee weapon" hidden="false" collective="false" defaultSelectionEntryId="0f49-c522-dbc3-2d07">
+        <selectionEntryGroup id="a871-3879-e3a1-839f" name="Melee weapon arm" hidden="false" collective="false" defaultSelectionEntryId="747c-eed4-4e9b-0c48">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -5042,20 +5190,86 @@
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1c08-08a2-2e9d-315f" type="max"/>
           </constraints>
           <categoryLinks/>
-          <selectionEntries/>
-          <selectionEntryGroups/>
-          <entryLinks>
-            <entryLink id="0f49-c522-dbc3-2d07" name="New EntryLink" hidden="false" targetId="3371-814b-4320-12b6" type="selectionEntry">
+          <selectionEntries>
+            <selectionEntry id="747c-eed4-4e9b-0c48" name="Dreadnought combat weapon with ranged weapon" hidden="false" collective="false" type="upgrade">
               <profiles/>
               <rules/>
               <infoLinks/>
               <modifiers/>
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3aa6-453e-ba5f-46c1" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7063-49ae-8718-9e94" type="max"/>
               </constraints>
               <categoryLinks/>
-            </entryLink>
-            <entryLink id="5ab7-defa-c586-fdb9" name="New EntryLink" hidden="false" targetId="96f3-141e-f073-d314" type="selectionEntry">
+              <selectionEntries/>
+              <selectionEntryGroups>
+                <selectionEntryGroup id="1441-45bc-2daa-35a8" name="Ranged weapon" hidden="false" collective="false">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4a54-a513-c720-84d5" type="min"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="de7d-b5cd-261e-0bbe" type="max"/>
+                  </constraints>
+                  <categoryLinks/>
+                  <selectionEntries/>
+                  <selectionEntryGroups/>
+                  <entryLinks>
+                    <entryLink id="f5bc-72a4-7e63-cf84" name="Storm bolter" hidden="false" targetId="2b03-8d64-3711-f300" type="selectionEntry">
+                      <profiles/>
+                      <rules/>
+                      <infoLinks/>
+                      <modifiers/>
+                      <constraints>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8423-3d73-082d-5c81" type="max"/>
+                      </constraints>
+                      <categoryLinks/>
+                    </entryLink>
+                    <entryLink id="49b6-47b0-ff16-f990" name="Heavy flamer" hidden="false" targetId="18bc-b335-29c2-2ae2" type="selectionEntry">
+                      <profiles/>
+                      <rules/>
+                      <infoLinks/>
+                      <modifiers/>
+                      <constraints>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0646-ffa5-861b-a19d" type="max"/>
+                      </constraints>
+                      <categoryLinks/>
+                    </entryLink>
+                    <entryLink id="75c0-f823-0746-296a" name="Meltagun" hidden="false" targetId="efc8-c51d-5b02-a3a2" type="selectionEntry">
+                      <profiles/>
+                      <rules/>
+                      <infoLinks/>
+                      <modifiers/>
+                      <constraints>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6c91-fb97-654f-a3e6" type="max"/>
+                      </constraints>
+                      <categoryLinks/>
+                    </entryLink>
+                  </entryLinks>
+                </selectionEntryGroup>
+              </selectionEntryGroups>
+              <entryLinks>
+                <entryLink id="f861-7d47-5ffa-9960" name="Dreadnought combat weapon" hidden="false" targetId="a869-5624-fe55-fe95" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="acec-d2da-fd34-2e73" type="min"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="da8a-d808-c5f4-ac53" type="max"/>
+                  </constraints>
+                  <categoryLinks/>
+                </entryLink>
+              </entryLinks>
+              <costs>
+                <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="0.0"/>
+                <cost name="pts" costTypeId="points" value="0.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="5ab7-defa-c586-fdb9" name="Missile launcher" hidden="false" targetId="1469-1964-7a91-94d4" type="selectionEntry">
               <profiles/>
               <rules/>
               <infoLinks/>
@@ -5065,23 +5279,13 @@
               </constraints>
               <categoryLinks/>
             </entryLink>
-            <entryLink id="77ae-2615-cbed-ea69" name="Twin autocannon" hidden="false" targetId="2837-2f42-e4d7-56c6" type="selectionEntry">
+            <entryLink id="77ae-2615-cbed-ea69" name="Twin autocannon" hidden="false" targetId="afe0-3771-1982-92b4" type="selectionEntry">
               <profiles/>
               <rules/>
               <infoLinks/>
               <modifiers/>
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="43dc-dd0a-a500-eb4b" type="max"/>
-              </constraints>
-              <categoryLinks/>
-            </entryLink>
-            <entryLink id="1469-3f15-a897-95c1" name="New EntryLink" hidden="false" targetId="1720-3d63-ee7e-b95e" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9b1d-7680-6c0f-6fbb" type="max"/>
               </constraints>
               <categoryLinks/>
             </entryLink>
@@ -5114,7 +5318,7 @@
           <infoLinks/>
           <modifiers/>
           <characteristics>
-            <characteristic name="Capacity" characteristicTypeId="15aa-1916-a38b-d223" value="This model can transport 10 &lt;CHAPTER&gt; INFANTRY models. It cannot transport JUMP PACK, TERMINATOR, PRIMARIS or CENTURION models."/>
+            <characteristic name="Capacity" characteristicTypeId="15aa-1916-a38b-d223" value="This model can transport 10 BLOOD ANGELS INFANTRY models. It cannot transport JUMP PACK, TERMINATOR or PRIMARIS models."/>
           </characteristics>
         </profile>
       </profiles>
@@ -5207,7 +5411,7 @@
           <selectionEntries/>
           <selectionEntryGroups/>
           <entryLinks>
-            <entryLink id="f9da-394e-415d-d40b" name="New EntryLink" hidden="false" targetId="d74a-2fee-abea-1b42" type="selectionEntry">
+            <entryLink id="f9da-394e-415d-d40b" name="Storm bolter" hidden="false" targetId="2b03-8d64-3711-f300" type="selectionEntry">
               <profiles/>
               <rules/>
               <infoLinks/>
@@ -5217,7 +5421,7 @@
               </constraints>
               <categoryLinks/>
             </entryLink>
-            <entryLink id="1b92-092e-bfbd-b119" name="New EntryLink" hidden="false" targetId="d5e7-c159-7d9a-f6eb" type="selectionEntry">
+            <entryLink id="1b92-092e-bfbd-b119" name="Deathwind launcher" hidden="false" targetId="5342-99c6-bc9f-770a" type="selectionEntry">
               <profiles/>
               <rules/>
               <infoLinks/>
@@ -5351,7 +5555,7 @@
               <selectionEntries/>
               <selectionEntryGroups/>
               <entryLinks>
-                <entryLink id="f2f4-1d69-2c8d-c16d" name="Bolt pistol" book="" hidden="false" targetId="bf86-1c1b-6871-da0b" type="selectionEntry">
+                <entryLink id="f2f4-1d69-2c8d-c16d" name="Bolt pistol" book="" hidden="false" targetId="0334-f487-8229-0c1a" type="selectionEntry">
                   <profiles/>
                   <rules/>
                   <infoLinks/>
@@ -5361,7 +5565,7 @@
                   </constraints>
                   <categoryLinks/>
                 </entryLink>
-                <entryLink id="4872-e193-c81a-120c" name="Plasma pistol" hidden="false" targetId="b333-4c80-2f72-6b45" type="selectionEntry">
+                <entryLink id="4872-e193-c81a-120c" name="Plasma pistol" hidden="false" targetId="83be-1ba9-c326-4760" type="selectionEntry">
                   <profiles/>
                   <rules/>
                   <infoLinks/>
@@ -5375,18 +5579,7 @@
             </selectionEntryGroup>
           </selectionEntryGroups>
           <entryLinks>
-            <entryLink id="95f4-c191-c0a9-b837" name="Frag grenades" hidden="false" targetId="e897-c8fa-0976-e2d3" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4270-718d-2c66-7a2d" type="min"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0f06-8aa3-a319-eada" type="max"/>
-              </constraints>
-              <categoryLinks/>
-            </entryLink>
-            <entryLink id="4eac-3d0d-0cc4-3f5e" name="New EntryLink" hidden="false" targetId="073b-2de5-765f-a4f2" type="selectionEntry">
+            <entryLink id="4eac-3d0d-0cc4-3f5e" name="Frag &amp; Krak grenades" hidden="false" targetId="cddf-945e-1335-e681" type="selectionEntry">
               <profiles/>
               <rules/>
               <infoLinks/>
@@ -5423,7 +5616,7 @@
           <selectionEntries/>
           <selectionEntryGroups/>
           <entryLinks>
-            <entryLink id="157c-96bc-350b-92c8" name="Bolt pistol" hidden="false" targetId="0367-b42c-b6b4-0a58" type="selectionEntry">
+            <entryLink id="157c-96bc-350b-92c8" name="Bolt pistol" hidden="false" targetId="37d3-7098-d596-9948" type="selectionEntry">
               <profiles/>
               <rules/>
               <infoLinks/>
@@ -5434,18 +5627,7 @@
               </constraints>
               <categoryLinks/>
             </entryLink>
-            <entryLink id="7bca-6b63-aa8b-48c8" name="Frag grenade" hidden="false" targetId="e897-c8fa-0976-e2d3" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5a45-973b-d3bc-11f0" type="min"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0cb4-0c9f-cf6e-96f0" type="max"/>
-              </constraints>
-              <categoryLinks/>
-            </entryLink>
-            <entryLink id="b66b-978d-bc99-f294" name="Krak grenade" hidden="false" targetId="073b-2de5-765f-a4f2" type="selectionEntry">
+            <entryLink id="b66b-978d-bc99-f294" name="Frag &amp; Krak grenades" hidden="false" targetId="cddf-945e-1335-e681" type="selectionEntry">
               <profiles/>
               <rules/>
               <infoLinks/>
@@ -5477,7 +5659,7 @@
           <selectionEntries/>
           <selectionEntryGroups/>
           <entryLinks>
-            <entryLink id="864b-1dfd-786e-46a9" name="Plasma incinerator" hidden="false" targetId="0919-4387-aaf7-b60c" type="selectionEntry">
+            <entryLink id="864b-1dfd-786e-46a9" name="Plasma incinerator" hidden="false" targetId="801b-d6b0-333f-bc49" type="selectionEntry">
               <profiles/>
               <rules/>
               <infoLinks/>
@@ -5630,7 +5812,7 @@
       <selectionEntries/>
       <selectionEntryGroups/>
       <entryLinks>
-        <entryLink id="0b87-79d1-e950-5e91" name="New EntryLink" hidden="false" targetId="7ac2-1efb-acb1-6277" type="selectionEntry">
+        <entryLink id="0b87-79d1-e950-5e91" name="Disintegration combi-gun" hidden="false" targetId="dc17-09cb-c84b-e837" type="selectionEntry">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -5641,7 +5823,7 @@
           </constraints>
           <categoryLinks/>
         </entryLink>
-        <entryLink id="9d84-ba15-30e9-731a" name="New EntryLink" hidden="false" targetId="5b44-7240-a6a2-459f" type="selectionEntry">
+        <entryLink id="9d84-ba15-30e9-731a" name="Disintegration pistol" hidden="false" targetId="9728-3bce-75d9-803a" type="selectionEntry">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -5652,18 +5834,7 @@
           </constraints>
           <categoryLinks/>
         </entryLink>
-        <entryLink id="d2b1-823b-5048-557d" name="New EntryLink" hidden="false" targetId="e897-c8fa-0976-e2d3" type="selectionEntry">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d510-cbed-e779-6caa" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5b46-a762-393b-8100" type="max"/>
-          </constraints>
-          <categoryLinks/>
-        </entryLink>
-        <entryLink id="be76-634e-1b08-4bfa" name="New EntryLink" hidden="false" targetId="073b-2de5-765f-a4f2" type="selectionEntry">
+        <entryLink id="be76-634e-1b08-4bfa" name="Frag &amp; Krak grenades" hidden="false" targetId="cddf-945e-1335-e681" type="selectionEntry">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -5672,6 +5843,32 @@
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5f7e-0396-2220-9eae" type="min"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5973-8b5e-eda6-13a5" type="max"/>
           </constraints>
+          <categoryLinks/>
+        </entryLink>
+        <entryLink id="d37d-7c1b-c8fb-1b66" name="Warlord" hidden="false" targetId="33f6-60da-7b70-5fee" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b89e-bec1-8d4d-be30" type="max"/>
+          </constraints>
+          <categoryLinks/>
+        </entryLink>
+        <entryLink id="333d-7f25-cb1d-d0db" name="Warlord Traits" hidden="false" targetId="c25d-2fbc-47b3-9e39" type="selectionEntryGroup">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+          <categoryLinks/>
+        </entryLink>
+        <entryLink id="66a3-a789-1390-3d55" name="Relics of Baal" hidden="false" targetId="441f-1714-0777-c202" type="selectionEntryGroup">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
           <categoryLinks/>
         </entryLink>
       </entryLinks>
@@ -5706,7 +5903,7 @@
           <infoLinks/>
           <modifiers/>
         </infoLink>
-        <infoLink id="be62-b739-2bb8-ac04" name="New InfoLink" hidden="false" targetId="fe65-ace1-31c7-51ba" type="profile">
+        <infoLink id="be62-b739-2bb8-ac04" name="Meteoric Descent" hidden="false" targetId="fe65-ace1-31c7-51ba" type="profile">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -5871,7 +6068,7 @@
               <selectionEntries/>
               <selectionEntryGroups/>
               <entryLinks>
-                <entryLink id="54cd-ac62-b129-d3e0" name="Assault bolter" hidden="false" targetId="e0b5-8115-e721-81f6" type="selectionEntry">
+                <entryLink id="54cd-ac62-b129-d3e0" name="Assault bolter" hidden="false" targetId="e6b0-ca4c-c256-cdb0" type="selectionEntry">
                   <profiles/>
                   <rules/>
                   <infoLinks/>
@@ -5975,7 +6172,15 @@
           <modifiers/>
         </infoLink>
       </infoLinks>
-      <modifiers/>
+      <modifiers>
+        <modifier type="increment" field="e356-c769-5920-6e14" value="5">
+          <repeats/>
+          <conditions>
+            <condition field="selections" scope="35f1-7e44-9fe6-645f" value="5.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="model" type="greaterThan"/>
+          </conditions>
+          <conditionGroups/>
+        </modifier>
+      </modifiers>
       <constraints/>
       <categoryLinks>
         <categoryLink id="dcc9-3d4b-32d8-2448" name="New CategoryLink" hidden="false" targetId="b44c-e966-5868-c970" primary="false">
@@ -6049,7 +6254,7 @@
           <selectionEntries/>
           <selectionEntryGroups/>
           <entryLinks>
-            <entryLink id="8d36-c480-735d-c6ae" name="New EntryLink" hidden="false" targetId="0367-b42c-b6b4-0a58" type="selectionEntry">
+            <entryLink id="8d36-c480-735d-c6ae" name="Bolt pistol" hidden="false" targetId="37d3-7098-d596-9948" type="selectionEntry">
               <profiles/>
               <rules/>
               <infoLinks/>
@@ -6060,18 +6265,7 @@
               </constraints>
               <categoryLinks/>
             </entryLink>
-            <entryLink id="6c28-be8d-c67c-573c" name="Frag grenades" hidden="false" targetId="e897-c8fa-0976-e2d3" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6ccd-47f0-b8d2-5f55" type="min"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2289-42c3-42ec-124d" type="max"/>
-              </constraints>
-              <categoryLinks/>
-            </entryLink>
-            <entryLink id="3341-4c87-6d11-b3c8" name="New EntryLink" hidden="false" targetId="073b-2de5-765f-a4f2" type="selectionEntry">
+            <entryLink id="3341-4c87-6d11-b3c8" name="Frag &amp; Krak grenades" hidden="false" targetId="cddf-945e-1335-e681" type="selectionEntry">
               <profiles/>
               <rules/>
               <infoLinks/>
@@ -6079,6 +6273,17 @@
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7f07-5e0e-d25f-5a42" type="min"/>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d909-3af6-8192-ebbb" type="max"/>
+              </constraints>
+              <categoryLinks/>
+            </entryLink>
+            <entryLink id="a85b-ccb1-2e8a-fce4" name="Intercessor bolt rifles" hidden="false" targetId="92a9-e94b-7190-1eb3" type="selectionEntryGroup">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3616-b593-94f8-3cad" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="387a-4a55-d077-f0d1" type="max"/>
               </constraints>
               <categoryLinks/>
             </entryLink>
@@ -6106,9 +6311,98 @@
           </constraints>
           <categoryLinks/>
           <selectionEntries/>
-          <selectionEntryGroups/>
+          <selectionEntryGroups>
+            <selectionEntryGroup id="0f55-1bcd-3706-02d5" name="Main weapon (same as the rest of unit, chainsword may replace bolt rifle only)" hidden="false" collective="false" defaultSelectionEntryId="ab05-d5b5-ddab-af4c">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b1ec-7c1a-bd52-62c9" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fdcf-6920-c115-5df6" type="max"/>
+              </constraints>
+              <categoryLinks/>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks>
+                <entryLink id="ab05-d5b5-ddab-af4c" name="Bolt rifle" hidden="false" targetId="5907-c64e-703e-5778" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers>
+                    <modifier type="set" field="9d34-5e7e-c1f4-08f8" value="1">
+                      <repeats/>
+                      <conditions>
+                        <condition field="selections" scope="35f1-7e44-9fe6-645f" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="5907-c64e-703e-5778" type="greaterThan"/>
+                      </conditions>
+                      <conditionGroups/>
+                    </modifier>
+                  </modifiers>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9d34-5e7e-c1f4-08f8" type="max"/>
+                  </constraints>
+                  <categoryLinks/>
+                </entryLink>
+                <entryLink id="8c3c-cfd0-cd33-2ff6" name="Chainsword" hidden="false" targetId="4334-d2da-32f5-dc53" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers>
+                    <modifier type="set" field="071f-b956-7f51-6900" value="1">
+                      <repeats/>
+                      <conditions>
+                        <condition field="selections" scope="35f1-7e44-9fe6-645f" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="5907-c64e-703e-5778" type="greaterThan"/>
+                      </conditions>
+                      <conditionGroups/>
+                    </modifier>
+                  </modifiers>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="071f-b956-7f51-6900" type="max"/>
+                    <constraint field="selections" scope="0c90-9cbf-864c-3d60" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="bf1d-f5d3-c5ce-b1d4" type="max"/>
+                  </constraints>
+                  <categoryLinks/>
+                </entryLink>
+                <entryLink id="d855-3b9f-484c-44b4" name="Auto bolt rifle" hidden="false" targetId="36fb-ccc7-03d1-93c9" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers>
+                    <modifier type="set" field="2d08-307c-7ea5-9f40" value="1">
+                      <repeats/>
+                      <conditions>
+                        <condition field="selections" scope="35f1-7e44-9fe6-645f" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="36fb-ccc7-03d1-93c9" type="greaterThan"/>
+                      </conditions>
+                      <conditionGroups/>
+                    </modifier>
+                  </modifiers>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2d08-307c-7ea5-9f40" type="max"/>
+                  </constraints>
+                  <categoryLinks/>
+                </entryLink>
+                <entryLink id="4f99-4a61-c5be-684e" name="Stalker bolt rifle" hidden="false" targetId="1840-b6e5-27f2-3436" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers>
+                    <modifier type="set" field="ab35-1e15-bf69-fb17" value="1">
+                      <repeats/>
+                      <conditions>
+                        <condition field="selections" scope="35f1-7e44-9fe6-645f" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1840-b6e5-27f2-3436" type="greaterThan"/>
+                      </conditions>
+                      <conditionGroups/>
+                    </modifier>
+                  </modifiers>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ab35-1e15-bf69-fb17" type="max"/>
+                  </constraints>
+                  <categoryLinks/>
+                </entryLink>
+              </entryLinks>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
           <entryLinks>
-            <entryLink id="52c9-7e62-2229-1109" name="New EntryLink" hidden="false" targetId="0367-b42c-b6b4-0a58" type="selectionEntry">
+            <entryLink id="52c9-7e62-2229-1109" name="Bolt pistol" hidden="false" targetId="37d3-7098-d596-9948" type="selectionEntry">
               <profiles/>
               <rules/>
               <infoLinks/>
@@ -6119,18 +6413,7 @@
               </constraints>
               <categoryLinks/>
             </entryLink>
-            <entryLink id="83cf-adf5-46ab-3e77" name="Frag grenades" hidden="false" targetId="e897-c8fa-0976-e2d3" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5a18-caa6-90f3-3ff6" type="min"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1f8c-50f1-b4e0-e445" type="max"/>
-              </constraints>
-              <categoryLinks/>
-            </entryLink>
-            <entryLink id="0af7-46fc-50f1-c260" name="New EntryLink" hidden="false" targetId="073b-2de5-765f-a4f2" type="selectionEntry">
+            <entryLink id="0af7-46fc-50f1-c260" name="Frag &amp; Krak grenades" hidden="false" targetId="cddf-945e-1335-e681" type="selectionEntry">
               <profiles/>
               <rules/>
               <infoLinks/>
@@ -6141,13 +6424,13 @@
               </constraints>
               <categoryLinks/>
             </entryLink>
-            <entryLink id="2642-3105-2546-b613" name="Chainsword" hidden="false" targetId="5905-f299-f23c-f9c1" type="selectionEntry">
+            <entryLink id="2642-3105-2546-b613" name="Chainsword" hidden="false" targetId="4334-d2da-32f5-dc53" type="selectionEntry">
               <profiles/>
               <rules/>
               <infoLinks/>
               <modifiers/>
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="699b-0d3a-00bc-f0a0" type="max"/>
+                <constraint field="selections" scope="0c90-9cbf-864c-3d60" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="699b-0d3a-00bc-f0a0" type="max"/>
               </constraints>
               <categoryLinks/>
             </entryLink>
@@ -6158,79 +6441,7 @@
           </costs>
         </selectionEntry>
       </selectionEntries>
-      <selectionEntryGroups>
-        <selectionEntryGroup id="64e4-c3a8-462b-1271" name="Weapons" hidden="false" collective="false" defaultSelectionEntryId="f7ea-7f8a-a04a-945c">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5574-8538-cb88-433f" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a0fe-d337-da42-8388" type="max"/>
-          </constraints>
-          <categoryLinks/>
-          <selectionEntries/>
-          <selectionEntryGroups/>
-          <entryLinks>
-            <entryLink id="f7ea-7f8a-a04a-945c" name="Bolt rifle" hidden="false" targetId="96be-57ab-99fc-4420" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f037-b718-9a50-89f5" type="max"/>
-              </constraints>
-              <categoryLinks/>
-            </entryLink>
-            <entryLink id="7a69-dbcd-7be4-acb1" name="Auto bolt rifle" hidden="false" targetId="36fb-ccc7-03d1-93c9" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers>
-                <modifier type="decrement" field="points" value="1">
-                  <repeats/>
-                  <conditions/>
-                  <conditionGroups/>
-                </modifier>
-                <modifier type="increment" field="points" value="1">
-                  <repeats>
-                    <repeat field="selections" scope="35f1-7e44-9fe6-645f" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="model" repeats="1" roundUp="false"/>
-                  </repeats>
-                  <conditions/>
-                  <conditionGroups/>
-                </modifier>
-              </modifiers>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="dba1-2cd8-b492-e790" type="max"/>
-              </constraints>
-              <categoryLinks/>
-            </entryLink>
-            <entryLink id="219b-dfe4-8f4c-fd30" name="Stalker bolt rifle" hidden="false" targetId="1840-b6e5-27f2-3436" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers>
-                <modifier type="decrement" field="points" value="2">
-                  <repeats/>
-                  <conditions/>
-                  <conditionGroups/>
-                </modifier>
-                <modifier type="increment" field="points" value="2">
-                  <repeats>
-                    <repeat field="selections" scope="35f1-7e44-9fe6-645f" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="model" repeats="1" roundUp="false"/>
-                  </repeats>
-                  <conditions/>
-                  <conditionGroups/>
-                </modifier>
-              </modifiers>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a3ee-d1c1-3bcd-1476" type="max"/>
-              </constraints>
-              <categoryLinks/>
-            </entryLink>
-          </entryLinks>
-        </selectionEntryGroup>
-      </selectionEntryGroups>
+      <selectionEntryGroups/>
       <entryLinks>
         <entryLink id="8b9c-0fe9-0ee6-03fc" name="Auxiliary grenade launcher" hidden="false" targetId="acfe-6890-a697-b534" type="selectionEntry">
           <profiles/>
@@ -6258,22 +6469,24 @@
     </selectionEntry>
     <selectionEntry id="2a4d-3d40-582b-7283" name="Land Raider" hidden="false" collective="false" type="model">
       <profiles>
-        <profile id="ebaa-c9ec-b23e-b724" name="Explodes" hidden="false" profileTypeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" profileTypeName="Abilities">
+        <profile id="ebaa-c9ec-b23e-b724" name="Explodes" hidden="false" profileTypeId="818c-0db1-36f0-462a" profileTypeName="Explosion">
           <profiles/>
           <rules/>
           <infoLinks/>
           <modifiers/>
           <characteristics>
-            <characteristic name="Description" characteristicTypeId="21befb24-fc85-4f52-a745-64b2e48f8228" value="If this model is reduced to 0 wounds, roll a D6 before removing the model from the battlefield and before any embarked models disembark. On a 6 it explodes, and each unit within 6&quot; suffers D6 mortal wounds."/>
+            <characteristic name="Dice roll" characteristicTypeId="f21d-8f6d-180d-36ff" value="6"/>
+            <characteristic name="Distance" characteristicTypeId="d69e-be07-1682-ebcc" value="6&quot;"/>
+            <characteristic name="Mortal wounds" characteristicTypeId="29f1-65a1-2c5d-8c7d" value="D6"/>
           </characteristics>
         </profile>
-        <profile id="d483-3474-9a2e-3c95" name="Land Raider" hidden="false" profileTypeId="b3a8-0452-7436-44d1" profileTypeName="Transport">
+        <profile id="d483-3474-9a2e-3c95" name="Transport" hidden="false" profileTypeId="b3a8-0452-7436-44d1" profileTypeName="Transport">
           <profiles/>
           <rules/>
           <infoLinks/>
           <modifiers/>
           <characteristics>
-            <characteristic name="Capacity" characteristicTypeId="15aa-1916-a38b-d223" value="This model can transport 10 BLOOD ANGELS INFANTRY models. Each JUMP PACK or TERMINATOR model takes the space of two other models and each CENTURION takes the space of three other models. It cannot transport PRIMARIS models."/>
+            <characteristic name="Capacity" characteristicTypeId="15aa-1916-a38b-d223" value="This model can transport 10 BLOOD ANGELS INFANTRY models. Each JUMP PACK or TERMINATOR model takes the space of two other models. It cannot transport PRIMARIS models."/>
           </characteristics>
         </profile>
         <profile id="7b36-f5f8-3546-26bc" name="Land Raider" hidden="false" profileTypeId="5f4f-ea74-0630-4afe" profileTypeName="Wound Track">
@@ -6402,7 +6615,7 @@
       <selectionEntries/>
       <selectionEntryGroups/>
       <entryLinks>
-        <entryLink id="5462-08e4-ccd1-4514" name="Twin heavy bolter" hidden="false" targetId="b310-1fca-9564-5812" type="selectionEntry">
+        <entryLink id="5462-08e4-ccd1-4514" name="Twin heavy bolter" hidden="false" targetId="09d8-7790-ed3f-4d6d" type="selectionEntry">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -6413,7 +6626,7 @@
           </constraints>
           <categoryLinks/>
         </entryLink>
-        <entryLink id="0210-652d-3e53-e3f5" name="Twin lascannon" hidden="false" targetId="de7a-7bba-e2c5-c37c" type="selectionEntry">
+        <entryLink id="0210-652d-3e53-e3f5" name="Twin lascannon" hidden="false" targetId="ee18-b1cd-6b60-464d" type="selectionEntry">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -6424,7 +6637,7 @@
           </constraints>
           <categoryLinks/>
         </entryLink>
-        <entryLink id="edee-45ae-2a5e-14aa" name="New EntryLink" hidden="false" targetId="4dda-f43f-5335-f49f" type="selectionEntry">
+        <entryLink id="edee-45ae-2a5e-14aa" name="Hunter-killer missile" hidden="false" targetId="32bf-b117-4ecf-5165" type="selectionEntry">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -6434,7 +6647,7 @@
           </constraints>
           <categoryLinks/>
         </entryLink>
-        <entryLink id="da79-4ce0-6c4f-f99b" name="New EntryLink" hidden="false" targetId="d74a-2fee-abea-1b42" type="selectionEntry">
+        <entryLink id="da79-4ce0-6c4f-f99b" name="Storm bolter" hidden="false" targetId="2b03-8d64-3711-f300" type="selectionEntry">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -6444,7 +6657,7 @@
           </constraints>
           <categoryLinks/>
         </entryLink>
-        <entryLink id="4031-9af1-0b8b-2701" name="New EntryLink" hidden="false" targetId="9523-8395-ca20-2849" type="selectionEntry">
+        <entryLink id="4031-9af1-0b8b-2701" name="Multi-melta" hidden="false" targetId="2b37-65ee-9443-b4ef" type="selectionEntry">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -6462,22 +6675,24 @@
     </selectionEntry>
     <selectionEntry id="33d9-d55e-af03-71da" name="Land Raider Crusader" hidden="false" collective="false" type="model">
       <profiles>
-        <profile id="6258-f088-c04e-1ec6" name="Explodes" hidden="false" profileTypeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" profileTypeName="Abilities">
+        <profile id="6258-f088-c04e-1ec6" name="Explodes" hidden="false" profileTypeId="818c-0db1-36f0-462a" profileTypeName="Explosion">
           <profiles/>
           <rules/>
           <infoLinks/>
           <modifiers/>
           <characteristics>
-            <characteristic name="Description" characteristicTypeId="21befb24-fc85-4f52-a745-64b2e48f8228" value="If this model is reduced to 0 wounds, roll a D6 before removing the model from the battlefield and before any embarked models disembark. On a 6 it explodes, and each unit within 6&quot; suffers D6 mortal wounds."/>
+            <characteristic name="Dice roll" characteristicTypeId="f21d-8f6d-180d-36ff" value="6"/>
+            <characteristic name="Distance" characteristicTypeId="d69e-be07-1682-ebcc" value="6&quot;"/>
+            <characteristic name="Mortal wounds" characteristicTypeId="29f1-65a1-2c5d-8c7d" value="D6"/>
           </characteristics>
         </profile>
-        <profile id="ad24-9e1d-e130-99ba" name="Land Raider Crusader" hidden="false" profileTypeId="b3a8-0452-7436-44d1" profileTypeName="Transport">
+        <profile id="ad24-9e1d-e130-99ba" name="Transport" hidden="false" profileTypeId="b3a8-0452-7436-44d1" profileTypeName="Transport">
           <profiles/>
           <rules/>
           <infoLinks/>
           <modifiers/>
           <characteristics>
-            <characteristic name="Capacity" characteristicTypeId="15aa-1916-a38b-d223" value="This model can transport 16 BLOOD ANGELS INFANTRY models. Each JUMP PACK or TERMINATOR model takes the space of two other models and each CENTURION takes the space of three other models. It cannot transport PRIMARIS models."/>
+            <characteristic name="Capacity" characteristicTypeId="15aa-1916-a38b-d223" value="This model can transport 16 BLOOD ANGELS INFANTRY models. Each JUMP PACK or TERMINATOR model takes the space of two other models. It cannot transport PRIMARIS models."/>
           </characteristics>
         </profile>
         <profile id="13c1-d82c-c8c0-2c95" name="Land Raider Crusader" hidden="false" profileTypeId="5f4f-ea74-0630-4afe" profileTypeName="Wound Track">
@@ -6619,7 +6834,7 @@
       <selectionEntries/>
       <selectionEntryGroups/>
       <entryLinks>
-        <entryLink id="4dd9-47b5-f589-22af" name="New EntryLink" hidden="false" targetId="2f94-6e2f-de15-4a6c" type="selectionEntry">
+        <entryLink id="4dd9-47b5-f589-22af" name="Twin assault cannon" hidden="false" targetId="f787-a3af-72b5-60d1" type="selectionEntry">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -6630,7 +6845,7 @@
           </constraints>
           <categoryLinks/>
         </entryLink>
-        <entryLink id="16bf-93cb-0dee-aac7" name="New EntryLink" hidden="false" targetId="96fa-18f1-3b9d-974c" type="selectionEntry">
+        <entryLink id="16bf-93cb-0dee-aac7" name="Hurricane bolter" hidden="false" targetId="b34a-b0c7-689d-d9a9" type="selectionEntry">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -6641,7 +6856,7 @@
           </constraints>
           <categoryLinks/>
         </entryLink>
-        <entryLink id="94e7-375a-dd90-b278" name="New EntryLink" hidden="false" targetId="4dda-f43f-5335-f49f" type="selectionEntry">
+        <entryLink id="94e7-375a-dd90-b278" name="Hunter-killer missile" hidden="false" targetId="32bf-b117-4ecf-5165" type="selectionEntry">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -6651,7 +6866,7 @@
           </constraints>
           <categoryLinks/>
         </entryLink>
-        <entryLink id="2884-5cbc-e276-1a64" name="New EntryLink" hidden="false" targetId="d74a-2fee-abea-1b42" type="selectionEntry">
+        <entryLink id="2884-5cbc-e276-1a64" name="Storm bolter" hidden="false" targetId="2b03-8d64-3711-f300" type="selectionEntry">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -6661,7 +6876,7 @@
           </constraints>
           <categoryLinks/>
         </entryLink>
-        <entryLink id="40d1-35f8-527a-e9f7" name="New EntryLink" hidden="false" targetId="9523-8395-ca20-2849" type="selectionEntry">
+        <entryLink id="40d1-35f8-527a-e9f7" name="Multi-melta" hidden="false" targetId="2b37-65ee-9443-b4ef" type="selectionEntry">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -6679,22 +6894,24 @@
     </selectionEntry>
     <selectionEntry id="6d30-5649-7c11-cf86" name="Land Raider Redeemer" hidden="false" collective="false" type="model">
       <profiles>
-        <profile id="e4de-4635-7e4b-2d0a" name="Explodes" hidden="false" profileTypeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" profileTypeName="Abilities">
+        <profile id="e4de-4635-7e4b-2d0a" name="Explodes" hidden="false" profileTypeId="818c-0db1-36f0-462a" profileTypeName="Explosion">
           <profiles/>
           <rules/>
           <infoLinks/>
           <modifiers/>
           <characteristics>
-            <characteristic name="Description" characteristicTypeId="21befb24-fc85-4f52-a745-64b2e48f8228" value="If this model is reduced to 0 wounds, roll a D6 before removing the model from the battlefield and before any embarked models disembark. On a 6 it explodes, and each unit within 6&quot; suffers D6 mortal wounds."/>
+            <characteristic name="Dice roll" characteristicTypeId="f21d-8f6d-180d-36ff" value="6"/>
+            <characteristic name="Distance" characteristicTypeId="d69e-be07-1682-ebcc" value="6&quot;"/>
+            <characteristic name="Mortal wounds" characteristicTypeId="29f1-65a1-2c5d-8c7d" value="D6"/>
           </characteristics>
         </profile>
-        <profile id="20c2-1dfa-14a8-7525" name="Land Raider Redeemer" hidden="false" profileTypeId="b3a8-0452-7436-44d1" profileTypeName="Transport">
+        <profile id="20c2-1dfa-14a8-7525" name="Transport" hidden="false" profileTypeId="b3a8-0452-7436-44d1" profileTypeName="Transport">
           <profiles/>
           <rules/>
           <infoLinks/>
           <modifiers/>
           <characteristics>
-            <characteristic name="Capacity" characteristicTypeId="15aa-1916-a38b-d223" value="This model can transport 12 &lt;CHAPTER&gt; INFANTRY models. Each JUMP PACK or TERMINATOR model takes the space of two other models and each CENTURION takes the space of three other models. It cannot transport PRIMARIS models."/>
+            <characteristic name="Capacity" characteristicTypeId="15aa-1916-a38b-d223" value="This model can transport 12 BLOOD ANGELS INFANTRY models. Each JUMP PACK or TERMINATOR model takes the space of two other models. It cannot transport PRIMARIS models."/>
           </characteristics>
         </profile>
         <profile id="e962-f90a-22a8-f304" name="Land Raider Redeemer" hidden="false" profileTypeId="5f4f-ea74-0630-4afe" profileTypeName="Wound Track">
@@ -6766,7 +6983,7 @@
           <infoLinks/>
           <modifiers/>
         </infoLink>
-        <infoLink id="1b67-5aee-d985-d19e" name="New InfoLink" hidden="false" targetId="632d-cf52-e909-fdde" type="profile">
+        <infoLink id="1b67-5aee-d985-d19e" name="Frag Assault Launchers" hidden="false" targetId="632d-cf52-e909-fdde" type="profile">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -6836,7 +7053,7 @@
       <selectionEntries/>
       <selectionEntryGroups/>
       <entryLinks>
-        <entryLink id="e91b-a44d-8b88-4ce5" name="New EntryLink" hidden="false" targetId="2f94-6e2f-de15-4a6c" type="selectionEntry">
+        <entryLink id="e91b-a44d-8b88-4ce5" name="Twin assault cannon" hidden="false" targetId="f787-a3af-72b5-60d1" type="selectionEntry">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -6847,7 +7064,7 @@
           </constraints>
           <categoryLinks/>
         </entryLink>
-        <entryLink id="edbd-977c-3ec5-e7e0" name="New EntryLink" hidden="false" targetId="baef-4ad5-c92f-ac19" type="selectionEntry">
+        <entryLink id="edbd-977c-3ec5-e7e0" name="Flamestorm cannon" hidden="false" targetId="f09b-e29b-c7e0-c9e1" type="selectionEntry">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -6858,7 +7075,7 @@
           </constraints>
           <categoryLinks/>
         </entryLink>
-        <entryLink id="e63c-e29b-5686-d8bd" name="New EntryLink" hidden="false" targetId="4dda-f43f-5335-f49f" type="selectionEntry">
+        <entryLink id="e63c-e29b-5686-d8bd" name="Hunter-killer missile" hidden="false" targetId="32bf-b117-4ecf-5165" type="selectionEntry">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -6868,7 +7085,7 @@
           </constraints>
           <categoryLinks/>
         </entryLink>
-        <entryLink id="d26d-3e20-3ca7-4c8c" name="New EntryLink" hidden="false" targetId="d74a-2fee-abea-1b42" type="selectionEntry">
+        <entryLink id="d26d-3e20-3ca7-4c8c" name="Storm bolter" hidden="false" targetId="2b03-8d64-3711-f300" type="selectionEntry">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -6878,7 +7095,7 @@
           </constraints>
           <categoryLinks/>
         </entryLink>
-        <entryLink id="edc3-75a7-0be8-10ee" name="New EntryLink" hidden="false" targetId="9523-8395-ca20-2849" type="selectionEntry">
+        <entryLink id="edc3-75a7-0be8-10ee" name="Multi-melta" hidden="false" targetId="2b37-65ee-9443-b4ef" type="selectionEntry">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -7078,7 +7295,7 @@
       <selectionEntries/>
       <selectionEntryGroups/>
       <entryLinks>
-        <entryLink id="a091-9266-ceff-3a63" name="New EntryLink" hidden="false" targetId="68f5-b30c-1556-e4ac" type="selectionEntry">
+        <entryLink id="a091-9266-ceff-3a63" name="Grav-cannon and grav-amp" hidden="false" targetId="2f3b-2b38-8060-efc7" type="selectionEntry">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -7089,7 +7306,7 @@
           </constraints>
           <categoryLinks/>
         </entryLink>
-        <entryLink id="60d4-ced6-fa15-8bfb" name="New EntryLink" hidden="false" targetId="de7a-7bba-e2c5-c37c" type="selectionEntry">
+        <entryLink id="60d4-ced6-fa15-8bfb" name="Twin lascannon" hidden="false" targetId="ee18-b1cd-6b60-464d" type="selectionEntry">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -7100,7 +7317,7 @@
           </constraints>
           <categoryLinks/>
         </entryLink>
-        <entryLink id="e9c6-b837-e9c0-11b9" name="New EntryLink" hidden="false" targetId="4dda-f43f-5335-f49f" type="selectionEntry">
+        <entryLink id="e9c6-b837-e9c0-11b9" name="Hunter-killer missile" hidden="false" targetId="32bf-b117-4ecf-5165" type="selectionEntry">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -7110,7 +7327,7 @@
           </constraints>
           <categoryLinks/>
         </entryLink>
-        <entryLink id="5df6-7653-9a99-18c8" name="New EntryLink" hidden="false" targetId="d74a-2fee-abea-1b42" type="selectionEntry">
+        <entryLink id="5df6-7653-9a99-18c8" name="Storm bolter" hidden="false" targetId="2b03-8d64-3711-f300" type="selectionEntry">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -7120,7 +7337,7 @@
           </constraints>
           <categoryLinks/>
         </entryLink>
-        <entryLink id="6390-1b86-3f24-2f4c" name="New EntryLink" hidden="false" targetId="9523-8395-ca20-2849" type="selectionEntry">
+        <entryLink id="6390-1b86-3f24-2f4c" name="Multi-melta" hidden="false" targetId="2b37-65ee-9443-b4ef" type="selectionEntry">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -7130,7 +7347,7 @@
           </constraints>
           <categoryLinks/>
         </entryLink>
-        <entryLink id="234d-5d6c-64ad-c7e5" name="New EntryLink" hidden="false" targetId="1e2d-40cf-18d3-db7f" type="selectionEntry">
+        <entryLink id="234d-5d6c-64ad-c7e5" name="Combi-plasma" hidden="false" targetId="fdce-cdf7-21a9-f9ac" type="selectionEntry">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -7262,7 +7479,7 @@
               <selectionEntries/>
               <selectionEntryGroups/>
               <entryLinks>
-                <entryLink id="30fa-00e0-2f48-c480" name="Heavy bolter" hidden="false" targetId="290a-8ad2-2af9-5ebc" type="selectionEntry">
+                <entryLink id="30fa-00e0-2f48-c480" name="Heavy bolter" hidden="false" targetId="05ab-e7cc-e856-c36f" type="selectionEntry">
                   <profiles/>
                   <rules/>
                   <infoLinks/>
@@ -7272,7 +7489,7 @@
                   </constraints>
                   <categoryLinks/>
                 </entryLink>
-                <entryLink id="ed75-b560-7838-1949" name="Multi-melta" hidden="false" targetId="9523-8395-ca20-2849" type="selectionEntry">
+                <entryLink id="ed75-b560-7838-1949" name="Multi-melta" hidden="false" targetId="2b37-65ee-9443-b4ef" type="selectionEntry">
                   <profiles/>
                   <rules/>
                   <infoLinks/>
@@ -7282,7 +7499,7 @@
                   </constraints>
                   <categoryLinks/>
                 </entryLink>
-                <entryLink id="7183-82a9-d0b4-9fa2" name="Heavy flamer" hidden="false" targetId="7eb4-1d78-9058-f71a" type="selectionEntry">
+                <entryLink id="7183-82a9-d0b4-9fa2" name="Heavy flamer" hidden="false" targetId="18bc-b335-29c2-2ae2" type="selectionEntry">
                   <profiles/>
                   <rules/>
                   <infoLinks/>
@@ -7306,7 +7523,7 @@
               <selectionEntries/>
               <selectionEntryGroups/>
               <entryLinks>
-                <entryLink id="25c3-7486-357a-9551" name="Heavy bolter" hidden="false" targetId="290a-8ad2-2af9-5ebc" type="selectionEntry">
+                <entryLink id="25c3-7486-357a-9551" name="Heavy bolter" hidden="false" targetId="05ab-e7cc-e856-c36f" type="selectionEntry">
                   <profiles/>
                   <rules/>
                   <infoLinks/>
@@ -7316,7 +7533,7 @@
                   </constraints>
                   <categoryLinks/>
                 </entryLink>
-                <entryLink id="d517-1cab-4f41-2365" name="Multi-melta" hidden="false" targetId="9523-8395-ca20-2849" type="selectionEntry">
+                <entryLink id="d517-1cab-4f41-2365" name="Multi-melta" hidden="false" targetId="2b37-65ee-9443-b4ef" type="selectionEntry">
                   <profiles/>
                   <rules/>
                   <infoLinks/>
@@ -7326,7 +7543,7 @@
                   </constraints>
                   <categoryLinks/>
                 </entryLink>
-                <entryLink id="5389-7dbd-07cb-3721" name="Heavy flamer" hidden="false" targetId="7eb4-1d78-9058-f71a" type="selectionEntry">
+                <entryLink id="5389-7dbd-07cb-3721" name="Heavy flamer" hidden="false" targetId="18bc-b335-29c2-2ae2" type="selectionEntry">
                   <profiles/>
                   <rules/>
                   <infoLinks/>
@@ -7336,7 +7553,7 @@
                   </constraints>
                   <categoryLinks/>
                 </entryLink>
-                <entryLink id="af5c-d7fc-c05d-15ad" name="New EntryLink" hidden="false" targetId="a44a-4a6a-4886-274c" type="selectionEntry">
+                <entryLink id="af5c-d7fc-c05d-15ad" name="Typhoon missile launcher" hidden="false" targetId="6027-7017-756a-600c" type="selectionEntry">
                   <profiles/>
                   <rules/>
                   <infoLinks/>
@@ -7346,7 +7563,7 @@
                   </constraints>
                   <categoryLinks/>
                 </entryLink>
-                <entryLink id="a411-0256-bf72-d10b" name="Assault cannon" hidden="false" targetId="640e-ce8b-bba2-ce5f" type="selectionEntry">
+                <entryLink id="a411-0256-bf72-d10b" name="Assault cannon" hidden="false" targetId="51b0-3d46-5af4-683e" type="selectionEntry">
                   <profiles/>
                   <rules/>
                   <infoLinks/>
@@ -7375,37 +7592,70 @@
     </selectionEntry>
     <selectionEntry id="3043-848f-e165-d00e" name="Sanguinary Discipline" hidden="false" collective="false" type="upgrade">
       <profiles>
-        <profile id="a25f-8f46-f4df-654d" name="Sanguinary 1 - Blood Boil" hidden="false" profileTypeId="ae70-4738-0161-bec0" profileTypeName="Psychic Power">
+        <profile id="a25f-8f46-f4df-654d" name="Sanguinary 4 - Blood Boil" hidden="false" profileTypeId="ae70-4738-0161-bec0" profileTypeName="Psychic Power">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Warp Charge" characteristicTypeId="5ffd-b800-c317-532a" value="6"/>
+            <characteristic name="Range" characteristicTypeId="fd64-cbc4-94de-24cc" value="6&quot;"/>
+            <characteristic name="Details" characteristicTypeId="ad96-dfa4-b4ed-656d" value="Select a visible enemy unit within 18&quot; of the psyker and roll 2D6. If the total exceeds the highest Toughness characteristic in the target unit, the unit suffers D3 mortal wounds; if the total rolled is more than double that of the highest Toughness characteristic, the unit suffers 3 mortal wounds instead."/>
+          </characteristics>
+        </profile>
+        <profile id="8076-2623-1ff0-badc" name="Sanguinary 3 - Shield of Sanguinius" hidden="false" profileTypeId="ae70-4738-0161-bec0" profileTypeName="Psychic Power">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Warp Charge" characteristicTypeId="5ffd-b800-c317-532a" value="6"/>
+            <characteristic name="Range" characteristicTypeId="fd64-cbc4-94de-24cc" value="12&quot;"/>
+            <characteristic name="Details" characteristicTypeId="ad96-dfa4-b4ed-656d" value="Select a friendly BLOOD ANGELS unit within 12&quot; of the psyker. Until the start of your next Psychic phase, that unit has a 5+ invulnerable save."/>
+          </characteristics>
+        </profile>
+        <profile id="970b-a55e-4672-3edc" name="Sanguinary 2 - Unleash Rage" hidden="false" profileTypeId="ae70-4738-0161-bec0" profileTypeName="Psychic Power">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Warp Charge" characteristicTypeId="5ffd-b800-c317-532a" value="6"/>
+            <characteristic name="Range" characteristicTypeId="fd64-cbc4-94de-24cc" value="12&quot;"/>
+            <characteristic name="Details" characteristicTypeId="ad96-dfa4-b4ed-656d" value="Select a friendly BLOOD ANGELS unit within 12&quot; of the psyker. Until the start of your next Psychic phase, add 1 to the Attacks characteristics of that unit."/>
+          </characteristics>
+        </profile>
+        <profile id="bc16-1818-35f1-54a5" name="Sanguinary 1 - Quickening" hidden="false" profileTypeId="ae70-4738-0161-bec0" profileTypeName="Psychic Power">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Warp Charge" characteristicTypeId="5ffd-b800-c317-532a" value="7"/>
+            <characteristic name="Range" characteristicTypeId="fd64-cbc4-94de-24cc" value="Self"/>
+            <characteristic name="Details" characteristicTypeId="ad96-dfa4-b4ed-656d" value="You can add 3 to Advance and charge rolls you make for the psyker, and make D3 additional attacks with them in the Fight phase, until the start of your next Psychic phase."/>
+          </characteristics>
+        </profile>
+        <profile id="bb46-0223-685a-e82f" name="Sanguinary 5 - The Blood Lance" hidden="false" profileTypeId="ae70-4738-0161-bec0" profileTypeName="Psychic Power">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Warp Charge" characteristicTypeId="5ffd-b800-c317-532a" value="6"/>
+            <characteristic name="Range" characteristicTypeId="fd64-cbc4-94de-24cc" value="12&quot;"/>
+            <characteristic name="Details" characteristicTypeId="ad96-dfa4-b4ed-656d" value="Select a visible enemy model within 12&quot; and draw a line between them and the psyker. Roll a D6 for each roll of 5+ that model&apos;s unit suffers a mortal wound."/>
+          </characteristics>
+        </profile>
+        <profile id="8fb9-f4bc-b6e3-f520" name="Sanguinary 6 - Wings of Sanguinius" hidden="false" profileTypeId="ae70-4738-0161-bec0" profileTypeName="Psychic Power">
           <profiles/>
           <rules/>
           <infoLinks/>
           <modifiers/>
           <characteristics>
             <characteristic name="Warp Charge" characteristicTypeId="5ffd-b800-c317-532a" value="5"/>
-            <characteristic name="Range" characteristicTypeId="fd64-cbc4-94de-24cc" value="18&quot;"/>
-            <characteristic name="Details" characteristicTypeId="ad96-dfa4-b4ed-656d" value="Select a visible enemy unit within 18&quot; of the psyker and roll three dice. The target suffers a mortal wound for each result that equals or exceeds its Toughness characteristic."/>
-          </characteristics>
-        </profile>
-        <profile id="8076-2623-1ff0-badc" name="Sanguinary 2 - Shield of Sanguinius" hidden="false" profileTypeId="ae70-4738-0161-bec0" profileTypeName="Psychic Power">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <characteristics>
-            <characteristic name="Warp Charge" characteristicTypeId="5ffd-b800-c317-532a" value="6"/>
-            <characteristic name="Range" characteristicTypeId="fd64-cbc4-94de-24cc" value="12&quot;"/>
-            <characteristic name="Details" characteristicTypeId="ad96-dfa4-b4ed-656d" value="Select a friendly &amp;lt;CHAPTER&amp;gt; unit within 12&quot; of the psyker. Until the start of your next Psychic phase, that unit has a 4+ invulnerable save."/>
-          </characteristics>
-        </profile>
-        <profile id="970b-a55e-4672-3edc" name="Sanguinary 3 - Unleash Rage" hidden="false" profileTypeId="ae70-4738-0161-bec0" profileTypeName="Psychic Power">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <characteristics>
-            <characteristic name="Warp Charge" characteristicTypeId="5ffd-b800-c317-532a" value="6"/>
-            <characteristic name="Range" characteristicTypeId="fd64-cbc4-94de-24cc" value="12&quot;"/>
-            <characteristic name="Details" characteristicTypeId="ad96-dfa4-b4ed-656d" value="Select a friendly &amp;lt;CHAPTER&amp;gt; unit within 12&quot; of the psyker. Until the start of your next Psychic phase, that unit has +1 Attack."/>
+            <characteristic name="Range" characteristicTypeId="fd64-cbc4-94de-24cc" value="Self"/>
+            <characteristic name="Details" characteristicTypeId="ad96-dfa4-b4ed-656d" value="The psyker can immediately move as if it were your Movement phase, but his Move characteristic is also increased to 12&quot; and he gains the FLY keyword until the start of your next Psychic phase (this means he can shoot if he Fell Back in his Movement phase). In addition, whilst this power is in effect, you can re-roll failed charge rolls for the psyker."/>
           </characteristics>
         </profile>
       </profiles>
@@ -7424,7 +7674,7 @@
     </selectionEntry>
     <selectionEntry id="c4f5-febb-7acd-bbd2" name="Librarian" hidden="false" collective="false" type="model">
       <profiles>
-        <profile id="c1da-de20-2958-c701" name="Librarian" hidden="false" profileTypeId="bc97-dea9-9e88-bb7d" profileTypeName="Psyker">
+        <profile id="c1da-de20-2958-c701" name="Psyker" hidden="false" profileTypeId="bc97-dea9-9e88-bb7d" profileTypeName="Psyker">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -7541,7 +7791,7 @@
           <selectionEntries/>
           <selectionEntryGroups/>
           <entryLinks>
-            <entryLink id="7add-2b34-35b4-2ad6" name="Boltgun" hidden="false" targetId="8e23-a2e7-23c4-cac7" type="selectionEntry">
+            <entryLink id="7add-2b34-35b4-2ad6" name="Boltgun" hidden="false" targetId="b61f-a3c1-827d-c5b6" type="selectionEntry">
               <profiles/>
               <rules/>
               <infoLinks/>
@@ -7571,7 +7821,7 @@
               </constraints>
               <categoryLinks/>
             </entryLink>
-            <entryLink id="d65a-b34b-50c6-6e36" name="Bolt pistol" hidden="false" targetId="bf86-1c1b-6871-da0b" type="selectionEntry">
+            <entryLink id="d65a-b34b-50c6-6e36" name="Bolt pistol" hidden="false" targetId="0334-f487-8229-0c1a" type="selectionEntry">
               <profiles/>
               <rules/>
               <infoLinks/>
@@ -7596,7 +7846,7 @@
           <selectionEntries/>
           <selectionEntryGroups/>
           <entryLinks>
-            <entryLink id="6517-3c83-c3c7-c81b" name="New EntryLink" hidden="false" targetId="759c-5bf6-02f6-e772" type="selectionEntry">
+            <entryLink id="6517-3c83-c3c7-c81b" name="Force axe" hidden="false" targetId="4a0e-0f13-63c2-9aae" type="selectionEntry">
               <profiles/>
               <rules/>
               <infoLinks/>
@@ -7606,7 +7856,7 @@
               </constraints>
               <categoryLinks/>
             </entryLink>
-            <entryLink id="7ec8-8c9a-4ff9-0353" name="New EntryLink" hidden="false" targetId="c7c7-c781-6eb6-a672" type="selectionEntry">
+            <entryLink id="7ec8-8c9a-4ff9-0353" name="Force stave" hidden="false" targetId="6f9a-c4fe-3132-d011" type="selectionEntry">
               <profiles/>
               <rules/>
               <infoLinks/>
@@ -7616,7 +7866,7 @@
               </constraints>
               <categoryLinks/>
             </entryLink>
-            <entryLink id="2435-1f3f-0beb-9bcb" name="New EntryLink" hidden="false" targetId="63d7-bf06-757d-3da2" type="selectionEntry">
+            <entryLink id="2435-1f3f-0beb-9bcb" name="Force sword" hidden="false" targetId="07e7-1f9b-4c1c-aad9" type="selectionEntry">
               <profiles/>
               <rules/>
               <infoLinks/>
@@ -7678,18 +7928,7 @@
           </constraints>
           <categoryLinks/>
         </entryLink>
-        <entryLink id="513c-ef0d-fafd-0fb4" name="New EntryLink" hidden="false" targetId="e897-c8fa-0976-e2d3" type="selectionEntry">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="17e6-f0fd-26f0-904a" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f9aa-672f-fb94-7239" type="max"/>
-          </constraints>
-          <categoryLinks/>
-        </entryLink>
-        <entryLink id="b386-7bba-aa61-749d" name="New EntryLink" hidden="false" targetId="073b-2de5-765f-a4f2" type="selectionEntry">
+        <entryLink id="b386-7bba-aa61-749d" name="Frag &amp; Krak grenades" hidden="false" targetId="cddf-945e-1335-e681" type="selectionEntry">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -7700,6 +7939,32 @@
           </constraints>
           <categoryLinks/>
         </entryLink>
+        <entryLink id="e21e-a870-2fa2-e2f9" name="Warlord" hidden="false" targetId="33f6-60da-7b70-5fee" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3071-8338-1de7-52e9" type="max"/>
+          </constraints>
+          <categoryLinks/>
+        </entryLink>
+        <entryLink id="1bab-97c6-1462-ab64" name="Warlord Traits" hidden="false" targetId="c25d-2fbc-47b3-9e39" type="selectionEntryGroup">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+          <categoryLinks/>
+        </entryLink>
+        <entryLink id="5fd3-8b28-71cc-d6bb" name="Relics of Baal" hidden="false" targetId="441f-1714-0777-c202" type="selectionEntryGroup">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+          <categoryLinks/>
+        </entryLink>
       </entryLinks>
       <costs>
         <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="6.0"/>
@@ -7708,7 +7973,7 @@
     </selectionEntry>
     <selectionEntry id="1f7e-fbb5-afed-1c64" name="Librarian in Terminator Armour" hidden="false" collective="false" type="model">
       <profiles>
-        <profile id="a6b7-4903-d2ae-fb25" name="Librarian in Terminator Armour" hidden="false" profileTypeId="bc97-dea9-9e88-bb7d" profileTypeName="Psyker">
+        <profile id="a6b7-4903-d2ae-fb25" name="Psyker" hidden="false" profileTypeId="bc97-dea9-9e88-bb7d" profileTypeName="Psyker">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -7735,7 +8000,7 @@
           <infoLinks/>
           <modifiers/>
         </infoLink>
-        <infoLink id="c6ab-e196-a8c1-1238" name="New InfoLink" hidden="false" targetId="1994-f6f7-58af-6fca" type="profile">
+        <infoLink id="c6ab-e196-a8c1-1238" name="Psychic Hood" hidden="false" targetId="1994-f6f7-58af-6fca" type="profile">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -7747,7 +8012,7 @@
           <infoLinks/>
           <modifiers/>
         </infoLink>
-        <infoLink id="89f6-718a-1460-d23e" name="New InfoLink" hidden="false" targetId="5263-7a0c-08ad-f754" type="profile">
+        <infoLink id="89f6-718a-1460-d23e" name="Crux Terminatus" hidden="false" targetId="5263-7a0c-08ad-f754" type="profile">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -7829,14 +8094,14 @@
           <infoLinks/>
           <modifiers/>
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="52db-9475-cec5-57f7" type="min"/>
+            <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="52db-9475-cec5-57f7" type="min"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="0b52-a981-bf34-1f87" type="max"/>
           </constraints>
           <categoryLinks/>
           <selectionEntries/>
           <selectionEntryGroups/>
           <entryLinks>
-            <entryLink id="8084-8250-93fd-c598" name="Storm shield" hidden="false" targetId="4376-c122-ff61-5a1c" type="selectionEntry">
+            <entryLink id="8084-8250-93fd-c598" name="Storm shield" hidden="false" targetId="38b5-ef30-f87f-5275" type="selectionEntry">
               <profiles/>
               <rules/>
               <infoLinks/>
@@ -7862,7 +8127,7 @@
               </constraints>
               <categoryLinks/>
             </entryLink>
-            <entryLink id="13d6-520a-c73f-60b0" name="Storm bolter" hidden="false" targetId="d74a-2fee-abea-1b42" type="selectionEntry">
+            <entryLink id="13d6-520a-c73f-60b0" name="Storm bolter" hidden="false" targetId="2b03-8d64-3711-f300" type="selectionEntry">
               <profiles/>
               <rules/>
               <infoLinks/>
@@ -7874,7 +8139,7 @@
             </entryLink>
           </entryLinks>
         </selectionEntryGroup>
-        <selectionEntryGroup id="6f5f-4f89-01fc-c496" name="Force weapon" hidden="false" collective="false" defaultSelectionEntryId="d520-a272-4a7a-37c7">
+        <selectionEntryGroup id="6f5f-4f89-01fc-c496" name="Force weapon" hidden="false" collective="false" defaultSelectionEntryId="1232-91f1-2d7c-b45e">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -7887,7 +8152,7 @@
           <selectionEntries/>
           <selectionEntryGroups/>
           <entryLinks>
-            <entryLink id="1232-91f1-2d7c-b45e" name="New EntryLink" hidden="false" targetId="759c-5bf6-02f6-e772" type="selectionEntry">
+            <entryLink id="1232-91f1-2d7c-b45e" name="Force axe" hidden="false" targetId="4a0e-0f13-63c2-9aae" type="selectionEntry">
               <profiles/>
               <rules/>
               <infoLinks/>
@@ -7897,7 +8162,7 @@
               </constraints>
               <categoryLinks/>
             </entryLink>
-            <entryLink id="d520-a272-4a7a-37c7" name="New EntryLink" hidden="false" targetId="c7c7-c781-6eb6-a672" type="selectionEntry">
+            <entryLink id="d520-a272-4a7a-37c7" name="Force stave" hidden="false" targetId="6f9a-c4fe-3132-d011" type="selectionEntry">
               <profiles/>
               <rules/>
               <infoLinks/>
@@ -7907,7 +8172,7 @@
               </constraints>
               <categoryLinks/>
             </entryLink>
-            <entryLink id="a437-ecaf-ad87-cc1a" name="New EntryLink" hidden="false" targetId="63d7-bf06-757d-3da2" type="selectionEntry">
+            <entryLink id="a437-ecaf-ad87-cc1a" name="Force sword" hidden="false" targetId="07e7-1f9b-4c1c-aad9" type="selectionEntry">
               <profiles/>
               <rules/>
               <infoLinks/>
@@ -7952,9 +8217,36 @@
           </entryLinks>
         </selectionEntryGroup>
       </selectionEntryGroups>
-      <entryLinks/>
+      <entryLinks>
+        <entryLink id="bf7f-f32b-9c11-cba4" name="Warlord" hidden="false" targetId="33f6-60da-7b70-5fee" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ecdd-469c-9efd-2769" type="max"/>
+          </constraints>
+          <categoryLinks/>
+        </entryLink>
+        <entryLink id="f33f-5286-2960-d8a4" name="Warlord Traits" hidden="false" targetId="c25d-2fbc-47b3-9e39" type="selectionEntryGroup">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+          <categoryLinks/>
+        </entryLink>
+        <entryLink id="1319-4f88-98f2-3ce1" name="Relics of Baal" hidden="false" targetId="441f-1714-0777-c202" type="selectionEntryGroup">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+          <categoryLinks/>
+        </entryLink>
+      </entryLinks>
       <costs>
-        <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="9.0"/>
+        <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="8.0"/>
         <cost name="pts" costTypeId="points" value="120.0"/>
       </costs>
     </selectionEntry>
@@ -7981,7 +8273,7 @@
           <infoLinks/>
           <modifiers/>
         </infoLink>
-        <infoLink id="d81b-b42c-ce4d-2f2c" name="New InfoLink" hidden="false" targetId="4ea8-94d3-ba39-042f" type="rule">
+        <infoLink id="d81b-b42c-ce4d-2f2c" name="And They Shall Know No Fear" hidden="false" targetId="4ea8-94d3-ba39-042f" type="rule">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -8075,7 +8367,7 @@
           <selectionEntries/>
           <selectionEntryGroups/>
           <entryLinks>
-            <entryLink id="1e34-3782-88a4-889b" name="New EntryLink" hidden="false" targetId="759c-5bf6-02f6-e772" type="selectionEntry">
+            <entryLink id="1e34-3782-88a4-889b" name="Force axe" hidden="false" targetId="4a0e-0f13-63c2-9aae" type="selectionEntry">
               <profiles/>
               <rules/>
               <infoLinks/>
@@ -8085,7 +8377,7 @@
               </constraints>
               <categoryLinks/>
             </entryLink>
-            <entryLink id="a8a7-228d-672a-0291" name="New EntryLink" hidden="false" targetId="c7c7-c781-6eb6-a672" type="selectionEntry">
+            <entryLink id="a8a7-228d-672a-0291" name="Force stave" hidden="false" targetId="6f9a-c4fe-3132-d011" type="selectionEntry">
               <profiles/>
               <rules/>
               <infoLinks/>
@@ -8095,7 +8387,7 @@
               </constraints>
               <categoryLinks/>
             </entryLink>
-            <entryLink id="c9d8-a193-d1b4-946d" name="New EntryLink" hidden="false" targetId="63d7-bf06-757d-3da2" type="selectionEntry">
+            <entryLink id="c9d8-a193-d1b4-946d" name="Force sword" hidden="false" targetId="07e7-1f9b-4c1c-aad9" type="selectionEntry">
               <profiles/>
               <rules/>
               <infoLinks/>
@@ -8152,7 +8444,7 @@
           <selectionEntries/>
           <selectionEntryGroups/>
           <entryLinks>
-            <entryLink id="0031-d6d1-5a97-821f" name="Boltgun" hidden="false" targetId="8e23-a2e7-23c4-cac7" type="selectionEntry">
+            <entryLink id="0031-d6d1-5a97-821f" name="Boltgun" hidden="false" targetId="b61f-a3c1-827d-c5b6" type="selectionEntry">
               <profiles/>
               <rules/>
               <infoLinks/>
@@ -8182,7 +8474,7 @@
               </constraints>
               <categoryLinks/>
             </entryLink>
-            <entryLink id="d4cf-7353-8e06-edb0" name="Bolt pistol" hidden="false" targetId="bf86-1c1b-6871-da0b" type="selectionEntry">
+            <entryLink id="d4cf-7353-8e06-edb0" name="Bolt pistol" hidden="false" targetId="0334-f487-8229-0c1a" type="selectionEntry">
               <profiles/>
               <rules/>
               <infoLinks/>
@@ -8195,7 +8487,34 @@
           </entryLinks>
         </selectionEntryGroup>
       </selectionEntryGroups>
-      <entryLinks/>
+      <entryLinks>
+        <entryLink id="a2f5-431f-caa2-1bbe" name="Warlord" hidden="false" targetId="33f6-60da-7b70-5fee" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="eead-ecf2-0f6b-2d4b" type="max"/>
+          </constraints>
+          <categoryLinks/>
+        </entryLink>
+        <entryLink id="d5f6-e482-609b-439d" name="Warlord Traits" hidden="false" targetId="c25d-2fbc-47b3-9e39" type="selectionEntryGroup">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+          <categoryLinks/>
+        </entryLink>
+        <entryLink id="6332-c06a-c78e-bcf4" name="Relics of Baal" hidden="false" targetId="441f-1714-0777-c202" type="selectionEntryGroup">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+          <categoryLinks/>
+        </entryLink>
+      </entryLinks>
       <costs>
         <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="8.0"/>
         <cost name="pts" costTypeId="points" value="119.0"/>
@@ -8203,13 +8522,15 @@
     </selectionEntry>
     <selectionEntry id="68cc-6db3-b109-6cfa" name="Predator" hidden="false" collective="false" type="model">
       <profiles>
-        <profile id="a627-8ff8-6add-b595" name="Explodes" hidden="false" profileTypeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" profileTypeName="Abilities">
+        <profile id="a627-8ff8-6add-b595" name="Explodes" hidden="false" profileTypeId="818c-0db1-36f0-462a" profileTypeName="Explosion">
           <profiles/>
           <rules/>
           <infoLinks/>
           <modifiers/>
           <characteristics>
-            <characteristic name="Description" characteristicTypeId="21befb24-fc85-4f52-a745-64b2e48f8228" value="If this model is reduced to 0 wounds, roll a D6 before removing the model from the battlefield; on a 6 it explodes, and each unit within 6&quot; suffers D3 mortal wounds."/>
+            <characteristic name="Dice roll" characteristicTypeId="f21d-8f6d-180d-36ff" value="6"/>
+            <characteristic name="Distance" characteristicTypeId="d69e-be07-1682-ebcc" value="6&quot;"/>
+            <characteristic name="Mortal wounds" characteristicTypeId="29f1-65a1-2c5d-8c7d" value="D3"/>
           </characteristics>
         </profile>
         <profile id="6db9-0662-3b65-7c40" name="Predator" hidden="false" profileTypeId="5f4f-ea74-0630-4afe" profileTypeName="Wound Track">
@@ -8337,7 +8658,7 @@
           <selectionEntries/>
           <selectionEntryGroups/>
           <entryLinks>
-            <entryLink id="06a9-5dd5-f1df-9427" name="" hidden="false" targetId="4b5e-82ac-65a7-7d9a" type="selectionEntry">
+            <entryLink id="06a9-5dd5-f1df-9427" name="Predator autocannon" hidden="false" targetId="974d-570e-66b3-e971" type="selectionEntry">
               <profiles/>
               <rules/>
               <infoLinks/>
@@ -8347,7 +8668,7 @@
               </constraints>
               <categoryLinks/>
             </entryLink>
-            <entryLink id="a285-a2ba-b63a-ef7c" name="New EntryLink" hidden="false" targetId="de7a-7bba-e2c5-c37c" type="selectionEntry">
+            <entryLink id="a285-a2ba-b63a-ef7c" name="Twin lascannon" hidden="false" targetId="ee18-b1cd-6b60-464d" type="selectionEntry">
               <profiles/>
               <rules/>
               <infoLinks/>
@@ -8381,7 +8702,7 @@
               <selectionEntries/>
               <selectionEntryGroups/>
               <entryLinks>
-                <entryLink id="e3a6-25ed-57d9-d320" name="New EntryLink" hidden="false" targetId="290a-8ad2-2af9-5ebc" type="selectionEntry">
+                <entryLink id="e3a6-25ed-57d9-d320" name="Heavy bolter" hidden="false" targetId="05ab-e7cc-e856-c36f" type="selectionEntry">
                   <profiles/>
                   <rules/>
                   <infoLinks/>
@@ -8410,7 +8731,7 @@
               <selectionEntries/>
               <selectionEntryGroups/>
               <entryLinks>
-                <entryLink id="1842-8619-7229-0055" name="New EntryLink" hidden="false" targetId="7c7d-abb2-d8b9-2d9c" type="selectionEntry">
+                <entryLink id="1842-8619-7229-0055" name="Lascannon" hidden="false" targetId="a908-4664-11cd-f8b2" type="selectionEntry">
                   <profiles/>
                   <rules/>
                   <infoLinks/>
@@ -8433,7 +8754,7 @@
         </selectionEntryGroup>
       </selectionEntryGroups>
       <entryLinks>
-        <entryLink id="cd08-e013-4e21-1a47" name="New EntryLink" hidden="false" targetId="4dda-f43f-5335-f49f" type="selectionEntry">
+        <entryLink id="cd08-e013-4e21-1a47" name="Hunter-killer missile" hidden="false" targetId="32bf-b117-4ecf-5165" type="selectionEntry">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -8443,7 +8764,7 @@
           </constraints>
           <categoryLinks/>
         </entryLink>
-        <entryLink id="54b8-4c50-835b-cc69" name="New EntryLink" hidden="false" targetId="d74a-2fee-abea-1b42" type="selectionEntry">
+        <entryLink id="54b8-4c50-835b-cc69" name="Storm bolter" hidden="false" targetId="2b03-8d64-3711-f300" type="selectionEntry">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -8456,7 +8777,7 @@
       </entryLinks>
       <costs>
         <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="9.0"/>
-        <cost name="pts" costTypeId="points" value="90.0"/>
+        <cost name="pts" costTypeId="points" value="102.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="6ceb-6e0f-60a3-50c4" name="Primaris Ancient" hidden="false" collective="false" type="model">
@@ -8545,7 +8866,7 @@
       <selectionEntries/>
       <selectionEntryGroups/>
       <entryLinks>
-        <entryLink id="9f6c-394c-6cc3-d0d5" name="New EntryLink" hidden="false" targetId="0367-b42c-b6b4-0a58" type="selectionEntry">
+        <entryLink id="9f6c-394c-6cc3-d0d5" name="Bolt pistol" hidden="false" targetId="37d3-7098-d596-9948" type="selectionEntry">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -8556,7 +8877,7 @@
           </constraints>
           <categoryLinks/>
         </entryLink>
-        <entryLink id="0993-7af8-1e6f-b2c1" name="New EntryLink" hidden="false" targetId="96be-57ab-99fc-4420" type="selectionEntry">
+        <entryLink id="0993-7af8-1e6f-b2c1" name="Bolt rifle" hidden="false" targetId="5907-c64e-703e-5778" type="selectionEntry">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -8567,18 +8888,7 @@
           </constraints>
           <categoryLinks/>
         </entryLink>
-        <entryLink id="78eb-5c81-3462-6cfc" name="New EntryLink" hidden="false" targetId="e897-c8fa-0976-e2d3" type="selectionEntry">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1339-ba65-0082-19b4" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a102-3450-7129-b3ec" type="max"/>
-          </constraints>
-          <categoryLinks/>
-        </entryLink>
-        <entryLink id="129d-34eb-8c1f-94c4" name="New EntryLink" hidden="false" targetId="073b-2de5-765f-a4f2" type="selectionEntry">
+        <entryLink id="129d-34eb-8c1f-94c4" name="Frag &amp; Krak grenades" hidden="false" targetId="cddf-945e-1335-e681" type="selectionEntry">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -8589,24 +8899,40 @@
           </constraints>
           <categoryLinks/>
         </entryLink>
-      </entryLinks>
-      <costs>
-        <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="4.0"/>
-        <cost name="pts" costTypeId="points" value="69.0"/>
-      </costs>
-    </selectionEntry>
-    <selectionEntry id="e5df-bc04-2b72-d546" name="Primaris Lieutenants" hidden="false" collective="false" type="unit">
-      <profiles>
-        <profile id="860b-d82b-3561-6d4d" name="Company Heroes" hidden="false" profileTypeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" profileTypeName="Abilities">
+        <entryLink id="79a2-332f-e7f7-59c2" name="Warlord" hidden="false" targetId="33f6-60da-7b70-5fee" type="selectionEntry">
           <profiles/>
           <rules/>
           <infoLinks/>
           <modifiers/>
-          <characteristics>
-            <characteristic name="Description" characteristicTypeId="21befb24-fc85-4f52-a745-64b2e48f8228" value="During deployment, all models in this unit must be set up in unit coherency. From that point onwards, each Primaris Lieutenant is treated as a separate unit."/>
-          </characteristics>
-        </profile>
-      </profiles>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a6ab-33cd-a189-08bc" type="max"/>
+          </constraints>
+          <categoryLinks/>
+        </entryLink>
+        <entryLink id="ac55-2794-a171-2ff1" name="Warlord Traits" hidden="false" targetId="c25d-2fbc-47b3-9e39" type="selectionEntryGroup">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+          <categoryLinks/>
+        </entryLink>
+        <entryLink id="e440-faba-fde2-6b4c" name="Relics of Baal" hidden="false" targetId="441f-1714-0777-c202" type="selectionEntryGroup">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+          <categoryLinks/>
+        </entryLink>
+      </entryLinks>
+      <costs>
+        <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="5.0"/>
+        <cost name="pts" costTypeId="points" value="69.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="e5df-bc04-2b72-d546" name="Primaris Lieutenants" hidden="false" collective="false" type="unit">
+      <profiles/>
       <rules/>
       <infoLinks>
         <infoLink id="f2af-3f48-c62e-578c" name="New InfoLink" hidden="false" targetId="4ea8-94d3-ba39-042f" type="rule">
@@ -8615,7 +8941,13 @@
           <infoLinks/>
           <modifiers/>
         </infoLink>
-        <infoLink id="37b1-2c4e-12f1-ddda" name="New InfoLink" hidden="false" targetId="a8e2-0267-b144-14fc" type="profile">
+        <infoLink id="37b1-2c4e-12f1-ddda" name="Tactical Precision" hidden="false" targetId="a8e2-0267-b144-14fc" type="profile">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="1b0b-8aaa-82d0-8e3e" name="Company Heroes" hidden="false" targetId="0ebd-45e5-3eb6-d9e0" type="profile">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -8715,7 +9047,7 @@
               <selectionEntries/>
               <selectionEntryGroups/>
               <entryLinks>
-                <entryLink id="91c1-00e9-55d0-c8ac" name="New EntryLink" hidden="false" targetId="aab9-369a-8f8d-1606" type="selectionEntry">
+                <entryLink id="91c1-00e9-55d0-c8ac" name="Master-crafted auto bolt rifle" hidden="false" targetId="f2f6-ed05-f2a9-f46f" type="selectionEntry">
                   <profiles/>
                   <rules/>
                   <infoLinks/>
@@ -8725,7 +9057,7 @@
                   </constraints>
                   <categoryLinks/>
                 </entryLink>
-                <entryLink id="65c4-8543-dcbd-468e" name="New EntryLink" hidden="false" targetId="c3d0-2567-35c6-3f29" type="selectionEntry">
+                <entryLink id="65c4-8543-dcbd-468e" name="Power sword" hidden="false" targetId="bc9e-551d-9afb-78d5" type="selectionEntry">
                   <profiles/>
                   <rules/>
                   <infoLinks/>
@@ -8735,11 +9067,21 @@
                   </constraints>
                   <categoryLinks/>
                 </entryLink>
+                <entryLink id="ba73-4271-f21d-4127" name="Master-crafted stalker bolt rifle" hidden="false" targetId="2949-638c-6eff-c3d8" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="83a4-b7b3-f356-f6d3" type="max"/>
+                  </constraints>
+                  <categoryLinks/>
+                </entryLink>
               </entryLinks>
             </selectionEntryGroup>
           </selectionEntryGroups>
           <entryLinks>
-            <entryLink id="67fe-16ec-05f5-dfc9" name="New EntryLink" hidden="false" targetId="0367-b42c-b6b4-0a58" type="selectionEntry">
+            <entryLink id="67fe-16ec-05f5-dfc9" name="Bolt pistol" hidden="false" targetId="37d3-7098-d596-9948" type="selectionEntry">
               <profiles/>
               <rules/>
               <infoLinks/>
@@ -8750,18 +9092,7 @@
               </constraints>
               <categoryLinks/>
             </entryLink>
-            <entryLink id="653b-51ff-09eb-d43c" name="New EntryLink" hidden="false" targetId="e897-c8fa-0976-e2d3" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bb75-0e6c-022b-4778" type="min"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f40b-4935-ca05-5e67" type="max"/>
-              </constraints>
-              <categoryLinks/>
-            </entryLink>
-            <entryLink id="c530-3118-bb40-aed3" name="New EntryLink" hidden="false" targetId="073b-2de5-765f-a4f2" type="selectionEntry">
+            <entryLink id="c530-3118-bb40-aed3" name="Frag &amp; Krak grenades" hidden="false" targetId="cddf-945e-1335-e681" type="selectionEntry">
               <profiles/>
               <rules/>
               <infoLinks/>
@@ -8772,9 +9103,35 @@
               </constraints>
               <categoryLinks/>
             </entryLink>
+            <entryLink id="ac31-45a8-91bf-5c72" name="Warlord" hidden="false" targetId="33f6-60da-7b70-5fee" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="af7d-c3f3-7ab2-4de0" type="max"/>
+              </constraints>
+              <categoryLinks/>
+            </entryLink>
+            <entryLink id="1e1d-e366-a823-75d2" name="Warlord Traits" hidden="false" targetId="c25d-2fbc-47b3-9e39" type="selectionEntryGroup">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+              <categoryLinks/>
+            </entryLink>
+            <entryLink id="43a8-3895-ac02-0d1e" name="Relics of Baal" hidden="false" targetId="441f-1714-0777-c202" type="selectionEntryGroup">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+              <categoryLinks/>
+            </entryLink>
           </entryLinks>
           <costs>
-            <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="4.0"/>
+            <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="5.0"/>
             <cost name="pts" costTypeId="points" value="70.0"/>
           </costs>
         </selectionEntry>
@@ -8788,13 +9145,15 @@
     </selectionEntry>
     <selectionEntry id="2ac6-ce4a-6789-b21a" name="Razorback" hidden="false" collective="false" type="model">
       <profiles>
-        <profile id="47b5-25d4-dda9-1680" name="Explodes" hidden="false" profileTypeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" profileTypeName="Abilities">
+        <profile id="47b5-25d4-dda9-1680" name="Explodes" hidden="false" profileTypeId="818c-0db1-36f0-462a" profileTypeName="Explosion">
           <profiles/>
           <rules/>
           <infoLinks/>
           <modifiers/>
           <characteristics>
-            <characteristic name="Description" characteristicTypeId="21befb24-fc85-4f52-a745-64b2e48f8228" value="If this model is reduced to 0 wounds, roll a D6 before removing the model from the battlefield and before any embarked models disembark. On a 6 it explodes, and each unit within 6&quot; suffers D3 mortal wounds."/>
+            <characteristic name="Dice roll" characteristicTypeId="f21d-8f6d-180d-36ff" value="6"/>
+            <characteristic name="Distance" characteristicTypeId="d69e-be07-1682-ebcc" value="6&quot;"/>
+            <characteristic name="Mortal wounds" characteristicTypeId="29f1-65a1-2c5d-8c7d" value="D3"/>
           </characteristics>
         </profile>
         <profile id="3009-35ef-bf80-8ef0" name="Razorback" hidden="false" profileTypeId="5f4f-ea74-0630-4afe" profileTypeName="Wound Track">
@@ -8851,7 +9210,7 @@
           <infoLinks/>
           <modifiers/>
           <characteristics>
-            <characteristic name="Capacity" characteristicTypeId="15aa-1916-a38b-d223" value="This model can transport 6 &lt;CHAPTER&gt; INFANTRY models. It cannot transport JUMP PACK, TERMINATOR, PRIMARIS or CENTURION models."/>
+            <characteristic name="Capacity" characteristicTypeId="15aa-1916-a38b-d223" value="This model can transport 6 BLOOD ANGELS INFANTRY models. It cannot transport JUMP PACK, TERMINATOR or PRIMARIS models."/>
           </characteristics>
         </profile>
       </profiles>
@@ -8955,7 +9314,7 @@
               <selectionEntries/>
               <selectionEntryGroups/>
               <entryLinks>
-                <entryLink id="a928-d87f-226a-ca9b" name="New EntryLink" hidden="false" targetId="7c7d-abb2-d8b9-2d9c" type="selectionEntry">
+                <entryLink id="a928-d87f-226a-ca9b" name="Lascannon" hidden="false" targetId="a908-4664-11cd-f8b2" type="selectionEntry">
                   <profiles/>
                   <rules/>
                   <infoLinks/>
@@ -8966,7 +9325,7 @@
                   </constraints>
                   <categoryLinks/>
                 </entryLink>
-                <entryLink id="50b8-a7cd-6e77-60a0" name="New EntryLink" hidden="false" targetId="abe0-0b05-cdd5-6f52" type="selectionEntry">
+                <entryLink id="50b8-a7cd-6e77-60a0" name="Twin plasma gun" hidden="false" targetId="3f51-b8fa-86ce-7388" type="selectionEntry">
                   <profiles/>
                   <rules/>
                   <infoLinks/>
@@ -8986,7 +9345,7 @@
           </selectionEntries>
           <selectionEntryGroups/>
           <entryLinks>
-            <entryLink id="4106-8129-2605-4e2b" name="" hidden="false" targetId="2f94-6e2f-de15-4a6c" type="selectionEntry">
+            <entryLink id="4106-8129-2605-4e2b" name="Twin assault cannon" hidden="false" targetId="f787-a3af-72b5-60d1" type="selectionEntry">
               <profiles/>
               <rules/>
               <infoLinks/>
@@ -8996,7 +9355,7 @@
               </constraints>
               <categoryLinks/>
             </entryLink>
-            <entryLink id="57e2-4693-3843-d547" name="New EntryLink" hidden="false" targetId="de7a-7bba-e2c5-c37c" type="selectionEntry">
+            <entryLink id="57e2-4693-3843-d547" name="Twin lascannon" hidden="false" targetId="ee18-b1cd-6b60-464d" type="selectionEntry">
               <profiles/>
               <rules/>
               <infoLinks/>
@@ -9006,7 +9365,7 @@
               </constraints>
               <categoryLinks/>
             </entryLink>
-            <entryLink id="99c3-4810-50b9-c65c" name="" hidden="false" targetId="b310-1fca-9564-5812" type="selectionEntry">
+            <entryLink id="99c3-4810-50b9-c65c" name="Twin heavy bolter" hidden="false" targetId="09d8-7790-ed3f-4d6d" type="selectionEntry">
               <profiles/>
               <rules/>
               <infoLinks/>
@@ -9016,7 +9375,7 @@
               </constraints>
               <categoryLinks/>
             </entryLink>
-            <entryLink id="dba0-9679-f373-6ecc" name="" hidden="false" targetId="256f-ce46-d4c9-02dc" type="selectionEntry">
+            <entryLink id="dba0-9679-f373-6ecc" name="Twin heavy flamer" hidden="false" targetId="8d70-a6af-cbad-f08c" type="selectionEntry">
               <profiles/>
               <rules/>
               <infoLinks/>
@@ -9030,7 +9389,7 @@
         </selectionEntryGroup>
       </selectionEntryGroups>
       <entryLinks>
-        <entryLink id="5ec9-e145-9971-9a38" name="New EntryLink" hidden="false" targetId="4dda-f43f-5335-f49f" type="selectionEntry">
+        <entryLink id="5ec9-e145-9971-9a38" name="Hunter-killer missile" hidden="false" targetId="32bf-b117-4ecf-5165" type="selectionEntry">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -9040,7 +9399,7 @@
           </constraints>
           <categoryLinks/>
         </entryLink>
-        <entryLink id="4573-0496-d3eb-5106" name="New EntryLink" hidden="false" targetId="d74a-2fee-abea-1b42" type="selectionEntry">
+        <entryLink id="4573-0496-d3eb-5106" name="Storm bolter" hidden="false" targetId="2b03-8d64-3711-f300" type="selectionEntry">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -9058,13 +9417,15 @@
     </selectionEntry>
     <selectionEntry id="c663-01df-6c43-0ef1" name="Rhino" hidden="false" collective="false" type="model">
       <profiles>
-        <profile id="7c6f-3ccb-ee58-91bb" name="Explodes" hidden="false" profileTypeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" profileTypeName="Abilities">
+        <profile id="7c6f-3ccb-ee58-91bb" name="Explodes" hidden="false" profileTypeId="818c-0db1-36f0-462a" profileTypeName="Explosion">
           <profiles/>
           <rules/>
           <infoLinks/>
           <modifiers/>
           <characteristics>
-            <characteristic name="Description" characteristicTypeId="21befb24-fc85-4f52-a745-64b2e48f8228" value="If this model is reduced to 0 wounds, roll a D6 before removing the model from the battlefield and before any embarked models disembark. On a 6 it explodes, and each unit within 6&quot; suffers D3 mortal wounds."/>
+            <characteristic name="Dice roll" characteristicTypeId="f21d-8f6d-180d-36ff" value="6"/>
+            <characteristic name="Distance" characteristicTypeId="d69e-be07-1682-ebcc" value="6&quot;"/>
+            <characteristic name="Mortal wounds" characteristicTypeId="29f1-65a1-2c5d-8c7d" value="D3"/>
           </characteristics>
         </profile>
         <profile id="d0c3-8923-0610-6add" name="Rhino" hidden="false" profileTypeId="5f4f-ea74-0630-4afe" profileTypeName="Wound Track">
@@ -9121,7 +9482,7 @@
           <infoLinks/>
           <modifiers/>
           <characteristics>
-            <characteristic name="Capacity" characteristicTypeId="15aa-1916-a38b-d223" value="This model can transport 10 &lt;CHAPTER&gt; INFANTRY models. It cannot transport JUMP PACK, TERMINATOR, PRIMARIS or CENTURION models."/>
+            <characteristic name="Capacity" characteristicTypeId="15aa-1916-a38b-d223" value="This model can transport 10 BLOOD ANGELS INFANTRY models. It cannot transport JUMP PACK, TERMINATOR or PRIMARIS models."/>
           </characteristics>
         </profile>
       </profiles>
@@ -9139,7 +9500,7 @@
           <infoLinks/>
           <modifiers/>
         </infoLink>
-        <infoLink id="cfef-0206-aed8-a348" name="New InfoLink" hidden="false" targetId="2bad-87b0-7710-b6d8" type="profile">
+        <infoLink id="cfef-0206-aed8-a348" name="Self-repair" hidden="false" targetId="2bad-87b0-7710-b6d8" type="profile">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -9209,7 +9570,7 @@
       <selectionEntries/>
       <selectionEntryGroups/>
       <entryLinks>
-        <entryLink id="a245-4ef1-799f-53bb" name="New EntryLink" hidden="false" targetId="4dda-f43f-5335-f49f" type="selectionEntry">
+        <entryLink id="a245-4ef1-799f-53bb" name="Hunter-killer missile" hidden="false" targetId="32bf-b117-4ecf-5165" type="selectionEntry">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -9219,7 +9580,7 @@
           </constraints>
           <categoryLinks/>
         </entryLink>
-        <entryLink id="5d7e-1036-8ad7-d34d" name="Storm bolter" hidden="false" targetId="d74a-2fee-abea-1b42" type="selectionEntry">
+        <entryLink id="5d7e-1036-8ad7-d34d" name="Storm bolter" hidden="false" targetId="2b03-8d64-3711-f300" type="selectionEntry">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -9398,7 +9759,7 @@
       <selectionEntries/>
       <selectionEntryGroups/>
       <entryLinks>
-        <entryLink id="1dbb-e238-68a3-0d52" name="New EntryLink" hidden="false" targetId="4dda-f43f-5335-f49f" type="selectionEntry">
+        <entryLink id="1dbb-e238-68a3-0d52" name="Hunter-killer missile" hidden="false" targetId="32bf-b117-4ecf-5165" type="selectionEntry">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -9408,7 +9769,7 @@
           </constraints>
           <categoryLinks/>
         </entryLink>
-        <entryLink id="12d2-990f-b6aa-9285" name="New EntryLink" hidden="false" targetId="abe0-0b05-cdd5-6f52" type="selectionEntry">
+        <entryLink id="12d2-990f-b6aa-9285" name="Twin plasma gun" hidden="false" targetId="3f51-b8fa-86ce-7388" type="selectionEntry">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -9419,7 +9780,7 @@
           </constraints>
           <categoryLinks/>
         </entryLink>
-        <entryLink id="9dd8-4370-f869-bd85" name="New EntryLink" hidden="false" targetId="a2b8-1ccb-c9d3-1141" type="selectionEntry">
+        <entryLink id="9dd8-4370-f869-bd85" name="Orbital array" hidden="false" targetId="6f0c-0f8c-1a73-4052" type="selectionEntry">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -9523,7 +9884,7 @@
       <selectionEntries/>
       <selectionEntryGroups/>
       <entryLinks>
-        <entryLink id="e33b-cf22-d2eb-e642" name="Bolt pistol" hidden="false" targetId="bf86-1c1b-6871-da0b" type="selectionEntry">
+        <entryLink id="e33b-cf22-d2eb-e642" name="Bolt pistol" hidden="false" targetId="0334-f487-8229-0c1a" type="selectionEntry">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -9534,7 +9895,7 @@
           </constraints>
           <categoryLinks/>
         </entryLink>
-        <entryLink id="ad65-aa23-46bc-86db" name="Chainsword" hidden="false" targetId="5f85-cddd-00b5-41f8" type="selectionEntry">
+        <entryLink id="ad65-aa23-46bc-86db" name="Chainsword" hidden="false" targetId="0dd1-2e2b-7dd1-5495" type="selectionEntry">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -9545,18 +9906,7 @@
           </constraints>
           <categoryLinks/>
         </entryLink>
-        <entryLink id="af78-07cc-bdef-5595" name="New EntryLink" hidden="false" targetId="e897-c8fa-0976-e2d3" type="selectionEntry">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c9c3-90f0-bf60-a948" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c757-60d5-0ccb-f369" type="max"/>
-          </constraints>
-          <categoryLinks/>
-        </entryLink>
-        <entryLink id="462c-680a-1e04-a12c" name="New EntryLink" hidden="false" targetId="073b-2de5-765f-a4f2" type="selectionEntry">
+        <entryLink id="462c-680a-1e04-a12c" name="Frag &amp; Krak grenades" hidden="false" targetId="cddf-945e-1335-e681" type="selectionEntry">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -9597,6 +9947,32 @@
               <constraints/>
             </categoryLink>
           </categoryLinks>
+        </entryLink>
+        <entryLink id="6580-b809-bcb6-98d3" name="Warlord" hidden="false" targetId="33f6-60da-7b70-5fee" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="eaaf-61ea-3f59-2616" type="max"/>
+          </constraints>
+          <categoryLinks/>
+        </entryLink>
+        <entryLink id="1304-1e9a-ef14-9fcf" name="Warlord Traits" hidden="false" targetId="c25d-2fbc-47b3-9e39" type="selectionEntryGroup">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+          <categoryLinks/>
+        </entryLink>
+        <entryLink id="ac4f-ae58-18ef-be44" name="Relics of Baal" hidden="false" targetId="441f-1714-0777-c202" type="selectionEntryGroup">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+          <categoryLinks/>
         </entryLink>
       </entryLinks>
       <costs>
@@ -9732,7 +10108,7 @@
               <selectionEntries/>
               <selectionEntryGroups/>
               <entryLinks>
-                <entryLink id="ff51-8731-07d1-987d" name="New EntryLink" hidden="false" targetId="311e-ae83-ed70-26e9" type="selectionEntry">
+                <entryLink id="ff51-8731-07d1-987d" name="Twin boltgun" hidden="false" targetId="a11f-8f20-5d2c-079a" type="selectionEntry">
                   <profiles/>
                   <rules/>
                   <infoLinks/>
@@ -9742,7 +10118,7 @@
                   </constraints>
                   <categoryLinks/>
                 </entryLink>
-                <entryLink id="fd71-8ce8-255b-968a" name="Astartes grenade launcher" hidden="false" targetId="22e0-2773-0a0f-ae62" type="selectionEntry">
+                <entryLink id="fd71-8ce8-255b-968a" name="Astartes grenade launcher" hidden="false" targetId="b4dd-2ff1-9f8e-ab00" type="selectionEntry">
                   <profiles/>
                   <rules/>
                   <infoLinks/>
@@ -9757,18 +10133,7 @@
             </selectionEntryGroup>
           </selectionEntryGroups>
           <entryLinks>
-            <entryLink id="314d-0dd4-1592-3024" name="New EntryLink" hidden="false" targetId="e897-c8fa-0976-e2d3" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7eba-51d2-1a3e-275b" type="min"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4a9d-7f26-37f4-ff3b" type="max"/>
-              </constraints>
-              <categoryLinks/>
-            </entryLink>
-            <entryLink id="9bb3-71b3-7945-70c1" name="New EntryLink" hidden="false" targetId="073b-2de5-765f-a4f2" type="selectionEntry">
+            <entryLink id="9bb3-71b3-7945-70c1" name="Frag &amp; Krak grenades" hidden="false" targetId="cddf-945e-1335-e681" type="selectionEntry">
               <profiles/>
               <rules/>
               <infoLinks/>
@@ -9779,7 +10144,7 @@
               </constraints>
               <categoryLinks/>
             </entryLink>
-            <entryLink id="b129-2f9c-5ac3-f205" name="New EntryLink" hidden="false" targetId="0367-b42c-b6b4-0a58" type="selectionEntry">
+            <entryLink id="b129-2f9c-5ac3-f205" name="Bolt pistol" hidden="false" targetId="37d3-7098-d596-9948" type="selectionEntry">
               <profiles/>
               <rules/>
               <infoLinks/>
@@ -9790,7 +10155,7 @@
               </constraints>
               <categoryLinks/>
             </entryLink>
-            <entryLink id="78ee-a58c-0e1e-d81d" name="New EntryLink" hidden="false" targetId="9ccd-823b-e317-5e31" type="selectionEntry">
+            <entryLink id="78ee-a58c-0e1e-d81d" name="Astartes shotgun" hidden="false" targetId="2b29-bc1f-cebc-3d95" type="selectionEntry">
               <profiles/>
               <rules/>
               <infoLinks/>
@@ -9801,7 +10166,7 @@
               </constraints>
               <categoryLinks/>
             </entryLink>
-            <entryLink id="f7a5-8928-3cf8-8cc8" name="New EntryLink" hidden="false" targetId="8250-8444-3124-6714" type="selectionEntry">
+            <entryLink id="f7a5-8928-3cf8-8cc8" name="Combat knife" hidden="false" targetId="bc0b-c19f-0b71-081e" type="selectionEntry">
               <profiles/>
               <rules/>
               <infoLinks/>
@@ -9850,7 +10215,7 @@
               <selectionEntries/>
               <selectionEntryGroups/>
               <entryLinks>
-                <entryLink id="458e-8d78-9c65-8e6e" name="New EntryLink" hidden="false" targetId="0367-b42c-b6b4-0a58" type="selectionEntry">
+                <entryLink id="458e-8d78-9c65-8e6e" name="Bolt pistol" hidden="false" targetId="37d3-7098-d596-9948" type="selectionEntry">
                   <profiles/>
                   <rules/>
                   <infoLinks/>
@@ -9884,18 +10249,7 @@
             </selectionEntryGroup>
           </selectionEntryGroups>
           <entryLinks>
-            <entryLink id="63c4-a4be-b2fd-ca5e" name="New EntryLink" hidden="false" targetId="e897-c8fa-0976-e2d3" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="00c2-f927-fc7f-5508" type="min"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="247d-7116-cded-2de0" type="max"/>
-              </constraints>
-              <categoryLinks/>
-            </entryLink>
-            <entryLink id="6fae-7feb-dee5-8318" name="New EntryLink" hidden="false" targetId="073b-2de5-765f-a4f2" type="selectionEntry">
+            <entryLink id="6fae-7feb-dee5-8318" name="Frag &amp; Krak grenades" hidden="false" targetId="cddf-945e-1335-e681" type="selectionEntry">
               <profiles/>
               <rules/>
               <infoLinks/>
@@ -9906,7 +10260,7 @@
               </constraints>
               <categoryLinks/>
             </entryLink>
-            <entryLink id="ef58-7d6f-dafa-2081" name="New EntryLink" hidden="false" targetId="9ccd-823b-e317-5e31" type="selectionEntry">
+            <entryLink id="ef58-7d6f-dafa-2081" name="Astartes shotgun" hidden="false" targetId="2b29-bc1f-cebc-3d95" type="selectionEntry">
               <profiles/>
               <rules/>
               <infoLinks/>
@@ -9917,7 +10271,7 @@
               </constraints>
               <categoryLinks/>
             </entryLink>
-            <entryLink id="c82d-2bd8-ee9a-5dfe" name="New EntryLink" hidden="false" targetId="8250-8444-3124-6714" type="selectionEntry">
+            <entryLink id="c82d-2bd8-ee9a-5dfe" name="Combat knife" hidden="false" targetId="bc0b-c19f-0b71-081e" type="selectionEntry">
               <profiles/>
               <rules/>
               <infoLinks/>
@@ -9928,7 +10282,7 @@
               </constraints>
               <categoryLinks/>
             </entryLink>
-            <entryLink id="a578-7b8f-3bcc-846b" name="New EntryLink" hidden="false" targetId="311e-ae83-ed70-26e9" type="selectionEntry">
+            <entryLink id="a578-7b8f-3bcc-846b" name="Twin boltgun" hidden="false" targetId="a11f-8f20-5d2c-079a" type="selectionEntry">
               <profiles/>
               <rules/>
               <infoLinks/>
@@ -9964,19 +10318,16 @@
             <characteristic name="Description" characteristicTypeId="21befb24-fc85-4f52-a745-64b2e48f8228" value="Before any models are deployed at the start of the game, a Scout Squad containing 10 models may be split into two units, each containing 5 models."/>
           </characteristics>
         </profile>
-        <profile id="e532-74d8-0f40-898c" name="Concealed Positions" hidden="false" profileTypeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" profileTypeName="Abilities">
+      </profiles>
+      <rules/>
+      <infoLinks>
+        <infoLink id="1570-469c-da1e-4cb2" name="And They Shall Know No Fear" hidden="false" targetId="4ea8-94d3-ba39-042f" type="rule">
           <profiles/>
           <rules/>
           <infoLinks/>
           <modifiers/>
-          <characteristics>
-            <characteristic name="Description" characteristicTypeId="21befb24-fc85-4f52-a745-64b2e48f8228" value="When you set up this unit during deployment, it can be set up anywhere on the battlefield that is more than 9&quot; from the enemy deployment zone and any enemy models."/>
-          </characteristics>
-        </profile>
-      </profiles>
-      <rules/>
-      <infoLinks>
-        <infoLink id="1570-469c-da1e-4cb2" name="New InfoLink" hidden="false" targetId="4ea8-94d3-ba39-042f" type="rule">
+        </infoLink>
+        <infoLink id="c1c5-f67c-f4b6-37c6" name="Concealed Positions" hidden="false" targetId="7d16-8f31-c8ac-339b" type="profile">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -10089,7 +10440,7 @@
                   <selectionEntries/>
                   <selectionEntryGroups/>
                   <entryLinks>
-                    <entryLink id="7e2e-fbd6-3524-7820" name="New EntryLink" hidden="false" targetId="290a-8ad2-2af9-5ebc" type="selectionEntry">
+                    <entryLink id="7e2e-fbd6-3524-7820" name="Heavy bolter" hidden="false" targetId="05ab-e7cc-e856-c36f" type="selectionEntry">
                       <profiles/>
                       <rules/>
                       <infoLinks/>
@@ -10099,7 +10450,7 @@
                       </constraints>
                       <categoryLinks/>
                     </entryLink>
-                    <entryLink id="c6ff-d804-34a7-3588" name="New EntryLink" hidden="false" targetId="96f3-141e-f073-d314" type="selectionEntry">
+                    <entryLink id="c6ff-d804-34a7-3588" name="Missile launcher" hidden="false" targetId="1469-1964-7a91-94d4" type="selectionEntry">
                       <profiles/>
                       <rules/>
                       <infoLinks/>
@@ -10113,7 +10464,7 @@
                 </selectionEntryGroup>
               </selectionEntryGroups>
               <entryLinks>
-                <entryLink id="f744-b6bf-2744-7a8f" name="New EntryLink" hidden="false" targetId="8e23-a2e7-23c4-cac7" type="selectionEntry">
+                <entryLink id="f744-b6bf-2744-7a8f" name="Boltgun" hidden="false" targetId="b61f-a3c1-827d-c5b6" type="selectionEntry">
                   <profiles/>
                   <rules/>
                   <infoLinks/>
@@ -10123,7 +10474,7 @@
                   </constraints>
                   <categoryLinks/>
                 </entryLink>
-                <entryLink id="f57b-2750-6979-b113" name="New EntryLink" hidden="false" targetId="012c-bc61-0ee5-aff4" type="selectionEntry">
+                <entryLink id="f57b-2750-6979-b113" name="Sniper rifle" hidden="false" targetId="ba62-f2c3-d7bb-4f5d" type="selectionEntry">
                   <profiles/>
                   <rules/>
                   <infoLinks/>
@@ -10133,7 +10484,7 @@
                   </constraints>
                   <categoryLinks/>
                 </entryLink>
-                <entryLink id="69f9-47e2-dfad-2943" name="New EntryLink" hidden="false" targetId="9ccd-823b-e317-5e31" type="selectionEntry">
+                <entryLink id="69f9-47e2-dfad-2943" name="Astartes shotgun" hidden="false" targetId="2b29-bc1f-cebc-3d95" type="selectionEntry">
                   <profiles/>
                   <rules/>
                   <infoLinks/>
@@ -10143,7 +10494,7 @@
                   </constraints>
                   <categoryLinks/>
                 </entryLink>
-                <entryLink id="df48-0e4b-45f0-8f0f" name="New EntryLink" hidden="false" targetId="8250-8444-3124-6714" type="selectionEntry">
+                <entryLink id="df48-0e4b-45f0-8f0f" name="Combat knife" hidden="false" targetId="bc0b-c19f-0b71-081e" type="selectionEntry">
                   <profiles/>
                   <rules/>
                   <infoLinks/>
@@ -10157,7 +10508,7 @@
             </selectionEntryGroup>
           </selectionEntryGroups>
           <entryLinks>
-            <entryLink id="40d8-bbb3-3594-0a41" name="Camo cloak" hidden="false" targetId="805b-66bf-45d2-fcd3" type="selectionEntry">
+            <entryLink id="40d8-bbb3-3594-0a41" name="Camo cloak" hidden="false" targetId="e0df-0e01-4e07-fdec" type="selectionEntry">
               <profiles/>
               <rules/>
               <infoLinks/>
@@ -10167,7 +10518,7 @@
               </constraints>
               <categoryLinks/>
             </entryLink>
-            <entryLink id="f46c-a176-9382-e9ef" name="New EntryLink" hidden="false" targetId="bf86-1c1b-6871-da0b" type="selectionEntry">
+            <entryLink id="f46c-a176-9382-e9ef" name="Bolt pistol" hidden="false" targetId="0334-f487-8229-0c1a" type="selectionEntry">
               <profiles/>
               <rules/>
               <infoLinks/>
@@ -10178,18 +10529,7 @@
               </constraints>
               <categoryLinks/>
             </entryLink>
-            <entryLink id="4a7c-ce3b-373d-4e03" name="New EntryLink" hidden="false" targetId="e897-c8fa-0976-e2d3" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="55d8-713d-6d52-4a08" type="min"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3d0c-eca0-550c-429c" type="max"/>
-              </constraints>
-              <categoryLinks/>
-            </entryLink>
-            <entryLink id="22b4-2ed3-8d64-b000" name="New EntryLink" hidden="false" targetId="073b-2de5-765f-a4f2" type="selectionEntry">
+            <entryLink id="22b4-2ed3-8d64-b000" name="Frag &amp; Krak grenades" hidden="false" targetId="cddf-945e-1335-e681" type="selectionEntry">
               <profiles/>
               <rules/>
               <infoLinks/>
@@ -10238,7 +10578,7 @@
               <selectionEntries/>
               <selectionEntryGroups/>
               <entryLinks>
-                <entryLink id="95a5-48b7-9422-e6a7" name="New EntryLink" hidden="false" targetId="8e23-a2e7-23c4-cac7" type="selectionEntry">
+                <entryLink id="95a5-48b7-9422-e6a7" name="Boltgun" hidden="false" targetId="b61f-a3c1-827d-c5b6" type="selectionEntry">
                   <profiles/>
                   <rules/>
                   <infoLinks/>
@@ -10248,7 +10588,7 @@
                   </constraints>
                   <categoryLinks/>
                 </entryLink>
-                <entryLink id="0634-11a5-d538-f122" name="New EntryLink" hidden="false" targetId="012c-bc61-0ee5-aff4" type="selectionEntry">
+                <entryLink id="0634-11a5-d538-f122" name="Sniper rifle" hidden="false" targetId="ba62-f2c3-d7bb-4f5d" type="selectionEntry">
                   <profiles/>
                   <rules/>
                   <infoLinks/>
@@ -10258,7 +10598,7 @@
                   </constraints>
                   <categoryLinks/>
                 </entryLink>
-                <entryLink id="ce15-fe41-7227-c024" name="Astartes shotgun" hidden="false" targetId="9ccd-823b-e317-5e31" type="selectionEntry">
+                <entryLink id="ce15-fe41-7227-c024" name="Astartes shotgun" hidden="false" targetId="2b29-bc1f-cebc-3d95" type="selectionEntry">
                   <profiles/>
                   <rules/>
                   <infoLinks/>
@@ -10268,7 +10608,7 @@
                   </constraints>
                   <categoryLinks/>
                 </entryLink>
-                <entryLink id="b500-aae1-b4bc-d691" name="New EntryLink" hidden="false" targetId="8250-8444-3124-6714" type="selectionEntry">
+                <entryLink id="b500-aae1-b4bc-d691" name="Combat knife" hidden="false" targetId="bc0b-c19f-0b71-081e" type="selectionEntry">
                   <profiles/>
                   <rules/>
                   <infoLinks/>
@@ -10303,7 +10643,7 @@
               <selectionEntries/>
               <selectionEntryGroups/>
               <entryLinks>
-                <entryLink id="a349-656b-1383-640a" name="New EntryLink" hidden="false" targetId="0367-b42c-b6b4-0a58" type="selectionEntry">
+                <entryLink id="a349-656b-1383-640a" name="Bolt pistol" hidden="false" targetId="37d3-7098-d596-9948" type="selectionEntry">
                   <profiles/>
                   <rules/>
                   <infoLinks/>
@@ -10327,7 +10667,7 @@
             </selectionEntryGroup>
           </selectionEntryGroups>
           <entryLinks>
-            <entryLink id="7283-3642-1e63-5831" name="New EntryLink" hidden="false" targetId="805b-66bf-45d2-fcd3" type="selectionEntry">
+            <entryLink id="7283-3642-1e63-5831" name="Camo cloak" hidden="false" targetId="e0df-0e01-4e07-fdec" type="selectionEntry">
               <profiles/>
               <rules/>
               <infoLinks/>
@@ -10337,18 +10677,7 @@
               </constraints>
               <categoryLinks/>
             </entryLink>
-            <entryLink id="237f-a077-17fc-682c" name="New EntryLink" hidden="false" targetId="e897-c8fa-0976-e2d3" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a35d-69a9-f533-03ff" type="min"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fc15-8cfd-0a38-4ab9" type="max"/>
-              </constraints>
-              <categoryLinks/>
-            </entryLink>
-            <entryLink id="fd45-4c81-5ba4-82ce" name="New EntryLink" hidden="false" targetId="073b-2de5-765f-a4f2" type="selectionEntry">
+            <entryLink id="fd45-4c81-5ba4-82ce" name="Frag &amp; Krak grenades" hidden="false" targetId="cddf-945e-1335-e681" type="selectionEntry">
               <profiles/>
               <rules/>
               <infoLinks/>
@@ -10369,24 +10698,21 @@
       <selectionEntryGroups/>
       <entryLinks/>
       <costs>
-        <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="6.0"/>
+        <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="4.0"/>
         <cost name="pts" costTypeId="points" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="9908-dedd-1373-5b4e" name="Servitors" hidden="false" collective="false" type="unit">
-      <profiles>
-        <profile id="aab2-56e8-499f-ad2a" name="Mindlock" hidden="false" profileTypeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" profileTypeName="Abilities">
+      <profiles/>
+      <rules/>
+      <infoLinks>
+        <infoLink id="f46f-00cf-4155-bd6c" name="Mindlock" hidden="false" targetId="2cb8-428d-9a50-6b53" type="profile">
           <profiles/>
           <rules/>
           <infoLinks/>
           <modifiers/>
-          <characteristics>
-            <characteristic name="Description" characteristicTypeId="21befb24-fc85-4f52-a745-64b2e48f8228" value="Servitors improve both their Weapon Skill and Ballistic Skill to 4+, and their Leadership to 9, whilst they are within 6&quot; of any friendly TECHMARINES."/>
-          </characteristics>
-        </profile>
-      </profiles>
-      <rules/>
-      <infoLinks/>
+        </infoLink>
+      </infoLinks>
       <modifiers/>
       <constraints/>
       <categoryLinks>
@@ -10478,7 +10804,7 @@
                   <selectionEntries/>
                   <selectionEntryGroups/>
                   <entryLinks>
-                    <entryLink id="5e0f-37cc-f86f-125b" name="New EntryLink" hidden="false" targetId="290a-8ad2-2af9-5ebc" type="selectionEntry">
+                    <entryLink id="5e0f-37cc-f86f-125b" name="Heavy bolter" hidden="false" targetId="05ab-e7cc-e856-c36f" type="selectionEntry">
                       <profiles/>
                       <rules/>
                       <infoLinks/>
@@ -10488,7 +10814,7 @@
                       </constraints>
                       <categoryLinks/>
                     </entryLink>
-                    <entryLink id="45e7-fb8b-7141-551c" name="New EntryLink" hidden="false" targetId="cc33-411c-60b0-fdec" type="selectionEntry">
+                    <entryLink id="45e7-fb8b-7141-551c" name="Plasma cannon" hidden="false" targetId="eb15-db61-5d4f-b65e" type="selectionEntry">
                       <profiles/>
                       <rules/>
                       <infoLinks/>
@@ -10498,7 +10824,7 @@
                       </constraints>
                       <categoryLinks/>
                     </entryLink>
-                    <entryLink id="f794-920f-ea7f-ea6d" name="New EntryLink" hidden="false" targetId="9523-8395-ca20-2849" type="selectionEntry">
+                    <entryLink id="f794-920f-ea7f-ea6d" name="Multi-melta" hidden="false" targetId="2b37-65ee-9443-b4ef" type="selectionEntry">
                       <profiles/>
                       <rules/>
                       <infoLinks/>
@@ -10512,7 +10838,7 @@
                 </selectionEntryGroup>
               </selectionEntryGroups>
               <entryLinks>
-                <entryLink id="a187-b3c6-794b-4c3b" name="New EntryLink" hidden="false" targetId="fb0f-7f69-e952-07dc" type="selectionEntry">
+                <entryLink id="a187-b3c6-794b-4c3b" name="Servo-arm" hidden="false" targetId="61ae-3901-0a79-4ec9" type="selectionEntry">
                   <profiles/>
                   <rules/>
                   <infoLinks/>
@@ -10683,7 +11009,7 @@
                 </selectionEntryGroup>
               </selectionEntryGroups>
               <entryLinks>
-                <entryLink id="0a36-da16-637d-8dd3" name="Special issue boltgun" hidden="false" targetId="ac47-fbfd-4381-3191" type="selectionEntry">
+                <entryLink id="0a36-da16-637d-8dd3" name="Special issue boltgun" hidden="false" targetId="cfc3-3735-a2e8-53cd" type="selectionEntry">
                   <profiles/>
                   <rules/>
                   <infoLinks/>
@@ -10707,18 +11033,7 @@
             </selectionEntryGroup>
           </selectionEntryGroups>
           <entryLinks>
-            <entryLink id="2ec1-6314-07d1-f8ef" name="New EntryLink" hidden="false" targetId="e897-c8fa-0976-e2d3" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c54d-5b2f-8d30-1a63" type="min"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0952-90e5-fd78-b8d8" type="max"/>
-              </constraints>
-              <categoryLinks/>
-            </entryLink>
-            <entryLink id="0cf4-50ee-0a2e-5ccf" name="New EntryLink" hidden="false" targetId="073b-2de5-765f-a4f2" type="selectionEntry">
+            <entryLink id="0cf4-50ee-0a2e-5ccf" name="Frag &amp; Krak grenades" hidden="false" targetId="cddf-945e-1335-e681" type="selectionEntry">
               <profiles/>
               <rules/>
               <infoLinks/>
@@ -10729,7 +11044,7 @@
               </constraints>
               <categoryLinks/>
             </entryLink>
-            <entryLink id="58cb-cb2f-f5f0-2a6c" name="New EntryLink" hidden="false" targetId="0367-b42c-b6b4-0a58" type="selectionEntry">
+            <entryLink id="58cb-cb2f-f5f0-2a6c" name="Bolt pistol" hidden="false" targetId="37d3-7098-d596-9948" type="selectionEntry">
               <profiles/>
               <rules/>
               <infoLinks/>
@@ -10800,7 +11115,7 @@
                       <selectionEntries/>
                       <selectionEntryGroups/>
                       <entryLinks>
-                        <entryLink id="60ac-44f6-d6b3-d7c0" name="Plasma pistol" hidden="false" targetId="b333-4c80-2f72-6b45" type="selectionEntry">
+                        <entryLink id="60ac-44f6-d6b3-d7c0" name="Plasma pistol" hidden="false" targetId="83be-1ba9-c326-4760" type="selectionEntry">
                           <profiles/>
                           <rules/>
                           <infoLinks/>
@@ -10820,7 +11135,7 @@
                           </constraints>
                           <categoryLinks/>
                         </entryLink>
-                        <entryLink id="c4db-99c0-6bd9-32b7" name="Inferno pistol" hidden="false" targetId="12fb-6600-667f-5922" type="selectionEntry">
+                        <entryLink id="c4db-99c0-6bd9-32b7" name="Inferno pistol" hidden="false" targetId="83f0-56d1-b852-f21c" type="selectionEntry">
                           <profiles/>
                           <rules/>
                           <infoLinks/>
@@ -10830,7 +11145,7 @@
                           </constraints>
                           <categoryLinks/>
                         </entryLink>
-                        <entryLink id="894f-c48f-7e1b-7a73" name="Power sword" hidden="false" targetId="c3d0-2567-35c6-3f29" type="selectionEntry">
+                        <entryLink id="894f-c48f-7e1b-7a73" name="Power sword" hidden="false" targetId="bc9e-551d-9afb-78d5" type="selectionEntry">
                           <profiles/>
                           <rules/>
                           <infoLinks/>
@@ -10840,7 +11155,7 @@
                           </constraints>
                           <categoryLinks/>
                         </entryLink>
-                        <entryLink id="b7c1-8229-f301-214d" name="Power axe" hidden="false" targetId="8d13-0f69-a808-e300" type="selectionEntry">
+                        <entryLink id="b7c1-8229-f301-214d" name="Power axe" hidden="false" targetId="3292-34e6-f679-d5b9" type="selectionEntry">
                           <profiles/>
                           <rules/>
                           <infoLinks/>
@@ -10850,7 +11165,7 @@
                           </constraints>
                           <categoryLinks/>
                         </entryLink>
-                        <entryLink id="fa8b-49d2-ac7d-1862" name="Power maul" hidden="false" targetId="b22c-5019-c613-fb74" type="selectionEntry">
+                        <entryLink id="fa8b-49d2-ac7d-1862" name="Power maul" hidden="false" targetId="6ea7-1195-7144-438e" type="selectionEntry">
                           <profiles/>
                           <rules/>
                           <infoLinks/>
@@ -10870,7 +11185,7 @@
                           </constraints>
                           <categoryLinks/>
                         </entryLink>
-                        <entryLink id="4d87-b7ed-8184-de38" name="Power fist" hidden="false" targetId="3102-2dd8-4f31-3af7" type="selectionEntry">
+                        <entryLink id="4d87-b7ed-8184-de38" name="Power fist" hidden="false" targetId="f122-3720-fa32-4215" type="selectionEntry">
                           <profiles/>
                           <rules/>
                           <infoLinks/>
@@ -10880,7 +11195,7 @@
                           </constraints>
                           <categoryLinks/>
                         </entryLink>
-                        <entryLink id="68b3-340d-d32f-c5c9" name="Grav-pistol" hidden="false" targetId="9f58-3b91-fa2e-32e2" type="selectionEntry">
+                        <entryLink id="68b3-340d-d32f-c5c9" name="Grav-pistol" hidden="false" targetId="7b66-cac7-e582-a518" type="selectionEntry">
                           <profiles/>
                           <rules/>
                           <infoLinks/>
@@ -10890,7 +11205,7 @@
                           </constraints>
                           <categoryLinks/>
                         </entryLink>
-                        <entryLink id="cea6-cccf-66b9-f02c" name="Chainsword" hidden="false" targetId="5f85-cddd-00b5-41f8" type="selectionEntry">
+                        <entryLink id="cea6-cccf-66b9-f02c" name="Chainsword" hidden="false" targetId="0dd1-2e2b-7dd1-5495" type="selectionEntry">
                           <profiles/>
                           <rules/>
                           <infoLinks/>
@@ -10914,7 +11229,7 @@
                       <selectionEntries/>
                       <selectionEntryGroups/>
                       <entryLinks>
-                        <entryLink id="e7cf-dfb0-1d20-b5a4" name="Boltgun" hidden="false" targetId="8e23-a2e7-23c4-cac7" type="selectionEntry">
+                        <entryLink id="e7cf-dfb0-1d20-b5a4" name="Boltgun" hidden="false" targetId="b61f-a3c1-827d-c5b6" type="selectionEntry">
                           <profiles/>
                           <rules/>
                           <infoLinks/>
@@ -10924,7 +11239,7 @@
                           </constraints>
                           <categoryLinks/>
                         </entryLink>
-                        <entryLink id="abaa-359d-2a72-cf22" name="Combi-flamer" hidden="false" targetId="a070-091c-f79c-7838" type="selectionEntry">
+                        <entryLink id="abaa-359d-2a72-cf22" name="Combi-flamer" hidden="false" targetId="c6a1-e0c4-c1b1-dce1" type="selectionEntry">
                           <profiles/>
                           <rules/>
                           <infoLinks/>
@@ -10934,7 +11249,7 @@
                           </constraints>
                           <categoryLinks/>
                         </entryLink>
-                        <entryLink id="affc-1024-b391-4868" name="New EntryLink" hidden="false" targetId="ce34-2e18-b818-b255" type="selectionEntry">
+                        <entryLink id="affc-1024-b391-4868" name="Combi-melta" hidden="false" targetId="c445-e211-f316-5d83" type="selectionEntry">
                           <profiles/>
                           <rules/>
                           <infoLinks/>
@@ -10944,7 +11259,7 @@
                           </constraints>
                           <categoryLinks/>
                         </entryLink>
-                        <entryLink id="b8ea-ea2c-3c85-e604" name="Combi-plasma" hidden="false" targetId="1e2d-40cf-18d3-db7f" type="selectionEntry">
+                        <entryLink id="b8ea-ea2c-3c85-e604" name="Combi-plasma" hidden="false" targetId="fdce-cdf7-21a9-f9ac" type="selectionEntry">
                           <profiles/>
                           <rules/>
                           <infoLinks/>
@@ -10954,7 +11269,7 @@
                           </constraints>
                           <categoryLinks/>
                         </entryLink>
-                        <entryLink id="9d9d-d11b-0cb1-33b2" name="Combi-grav" hidden="false" targetId="a80a-0476-1ef9-e1cc" type="selectionEntry">
+                        <entryLink id="9d9d-d11b-0cb1-33b2" name="Combi-grav" hidden="false" targetId="c027-24d6-7a3d-cf12" type="selectionEntry">
                           <profiles/>
                           <rules/>
                           <infoLinks/>
@@ -10964,7 +11279,7 @@
                           </constraints>
                           <categoryLinks/>
                         </entryLink>
-                        <entryLink id="2dd7-9a0e-233e-1aa2" name="Storm bolter" hidden="false" targetId="d74a-2fee-abea-1b42" type="selectionEntry">
+                        <entryLink id="2dd7-9a0e-233e-1aa2" name="Storm bolter" hidden="false" targetId="2b03-8d64-3711-f300" type="selectionEntry">
                           <profiles/>
                           <rules/>
                           <infoLinks/>
@@ -10981,7 +11296,7 @@
                 </selectionEntryGroup>
               </selectionEntryGroups>
               <entryLinks>
-                <entryLink id="f96e-1853-0324-b999" name="Bolt pistol" hidden="false" targetId="0367-b42c-b6b4-0a58" type="selectionEntry">
+                <entryLink id="f96e-1853-0324-b999" name="Bolt pistol" hidden="false" targetId="37d3-7098-d596-9948" type="selectionEntry">
                   <profiles/>
                   <rules/>
                   <infoLinks/>
@@ -11028,7 +11343,7 @@
                       <selectionEntries/>
                       <selectionEntryGroups/>
                       <entryLinks>
-                        <entryLink id="af5f-f76c-1619-b800" name="Bolt pistol" hidden="false" targetId="bf86-1c1b-6871-da0b" type="selectionEntry">
+                        <entryLink id="af5f-f76c-1619-b800" name="Bolt pistol" hidden="false" targetId="0334-f487-8229-0c1a" type="selectionEntry">
                           <profiles/>
                           <rules/>
                           <infoLinks/>
@@ -11038,7 +11353,7 @@
                           </constraints>
                           <categoryLinks/>
                         </entryLink>
-                        <entryLink id="1c0a-efa7-178a-d8f1" name="Plasma pistol" hidden="false" targetId="b333-4c80-2f72-6b45" type="selectionEntry">
+                        <entryLink id="1c0a-efa7-178a-d8f1" name="Plasma pistol" hidden="false" targetId="83be-1ba9-c326-4760" type="selectionEntry">
                           <profiles/>
                           <rules/>
                           <infoLinks/>
@@ -11058,7 +11373,7 @@
                           </constraints>
                           <categoryLinks/>
                         </entryLink>
-                        <entryLink id="4fd2-17b3-d1e9-755b" name="Inferno pistol" hidden="false" targetId="12fb-6600-667f-5922" type="selectionEntry">
+                        <entryLink id="4fd2-17b3-d1e9-755b" name="Inferno pistol" hidden="false" targetId="83f0-56d1-b852-f21c" type="selectionEntry">
                           <profiles/>
                           <rules/>
                           <infoLinks/>
@@ -11068,7 +11383,7 @@
                           </constraints>
                           <categoryLinks/>
                         </entryLink>
-                        <entryLink id="325f-cc46-3f26-e65b" name="Chainsword" hidden="false" targetId="5f85-cddd-00b5-41f8" type="selectionEntry">
+                        <entryLink id="325f-cc46-3f26-e65b" name="Chainsword" hidden="false" targetId="0dd1-2e2b-7dd1-5495" type="selectionEntry">
                           <profiles/>
                           <rules/>
                           <infoLinks/>
@@ -11078,7 +11393,7 @@
                           </constraints>
                           <categoryLinks/>
                         </entryLink>
-                        <entryLink id="bcbf-575d-8d47-ff1c" name="Power sword" hidden="false" targetId="c3d0-2567-35c6-3f29" type="selectionEntry">
+                        <entryLink id="bcbf-575d-8d47-ff1c" name="Power sword" hidden="false" targetId="bc9e-551d-9afb-78d5" type="selectionEntry">
                           <profiles/>
                           <rules/>
                           <infoLinks/>
@@ -11088,7 +11403,7 @@
                           </constraints>
                           <categoryLinks/>
                         </entryLink>
-                        <entryLink id="eee6-8336-d7cb-ffd7" name="Power axe" hidden="false" targetId="8d13-0f69-a808-e300" type="selectionEntry">
+                        <entryLink id="eee6-8336-d7cb-ffd7" name="Power axe" hidden="false" targetId="3292-34e6-f679-d5b9" type="selectionEntry">
                           <profiles/>
                           <rules/>
                           <infoLinks/>
@@ -11098,7 +11413,7 @@
                           </constraints>
                           <categoryLinks/>
                         </entryLink>
-                        <entryLink id="b424-8944-1d55-f14f" name="Power maul" hidden="false" targetId="b22c-5019-c613-fb74" type="selectionEntry">
+                        <entryLink id="b424-8944-1d55-f14f" name="Power maul" hidden="false" targetId="6ea7-1195-7144-438e" type="selectionEntry">
                           <profiles/>
                           <rules/>
                           <infoLinks/>
@@ -11118,7 +11433,7 @@
                           </constraints>
                           <categoryLinks/>
                         </entryLink>
-                        <entryLink id="943d-0074-a052-e4b8" name="Power fist" hidden="false" targetId="3102-2dd8-4f31-3af7" type="selectionEntry">
+                        <entryLink id="943d-0074-a052-e4b8" name="Power fist" hidden="false" targetId="f122-3720-fa32-4215" type="selectionEntry">
                           <profiles/>
                           <rules/>
                           <infoLinks/>
@@ -11128,7 +11443,7 @@
                           </constraints>
                           <categoryLinks/>
                         </entryLink>
-                        <entryLink id="6667-483d-3a75-e56d" name="Grav-pistol" hidden="false" targetId="9f58-3b91-fa2e-32e2" type="selectionEntry">
+                        <entryLink id="6667-483d-3a75-e56d" name="Grav-pistol" hidden="false" targetId="7b66-cac7-e582-a518" type="selectionEntry">
                           <profiles/>
                           <rules/>
                           <infoLinks/>
@@ -11152,7 +11467,7 @@
                       <selectionEntries/>
                       <selectionEntryGroups/>
                       <entryLinks>
-                        <entryLink id="7ab5-3e5c-3a47-ab0b" name="Boltgun" hidden="false" targetId="8e23-a2e7-23c4-cac7" type="selectionEntry">
+                        <entryLink id="7ab5-3e5c-3a47-ab0b" name="Boltgun" hidden="false" targetId="b61f-a3c1-827d-c5b6" type="selectionEntry">
                           <profiles/>
                           <rules/>
                           <infoLinks/>
@@ -11162,7 +11477,7 @@
                           </constraints>
                           <categoryLinks/>
                         </entryLink>
-                        <entryLink id="98da-2588-b6d4-adc9" name="Combi-flamer" hidden="false" targetId="a070-091c-f79c-7838" type="selectionEntry">
+                        <entryLink id="98da-2588-b6d4-adc9" name="Combi-flamer" hidden="false" targetId="c6a1-e0c4-c1b1-dce1" type="selectionEntry">
                           <profiles/>
                           <rules/>
                           <infoLinks/>
@@ -11172,7 +11487,7 @@
                           </constraints>
                           <categoryLinks/>
                         </entryLink>
-                        <entryLink id="7628-7ed1-ae46-fe50" name="Combi-melta" hidden="false" targetId="ce34-2e18-b818-b255" type="selectionEntry">
+                        <entryLink id="7628-7ed1-ae46-fe50" name="Combi-melta" hidden="false" targetId="c445-e211-f316-5d83" type="selectionEntry">
                           <profiles/>
                           <rules/>
                           <infoLinks/>
@@ -11182,7 +11497,7 @@
                           </constraints>
                           <categoryLinks/>
                         </entryLink>
-                        <entryLink id="0183-505a-0379-6e4f" name="Combi-plasma" hidden="false" targetId="1e2d-40cf-18d3-db7f" type="selectionEntry">
+                        <entryLink id="0183-505a-0379-6e4f" name="Combi-plasma" hidden="false" targetId="fdce-cdf7-21a9-f9ac" type="selectionEntry">
                           <profiles/>
                           <rules/>
                           <infoLinks/>
@@ -11192,7 +11507,7 @@
                           </constraints>
                           <categoryLinks/>
                         </entryLink>
-                        <entryLink id="40d6-a9ed-d1e9-2853" name="Combi-grav" hidden="false" targetId="a80a-0476-1ef9-e1cc" type="selectionEntry">
+                        <entryLink id="40d6-a9ed-d1e9-2853" name="Combi-grav" hidden="false" targetId="c027-24d6-7a3d-cf12" type="selectionEntry">
                           <profiles/>
                           <rules/>
                           <infoLinks/>
@@ -11202,7 +11517,7 @@
                           </constraints>
                           <categoryLinks/>
                         </entryLink>
-                        <entryLink id="09c3-16b8-81dd-fa98" name="Storm bolter" hidden="false" targetId="d74a-2fee-abea-1b42" type="selectionEntry">
+                        <entryLink id="09c3-16b8-81dd-fa98" name="Storm bolter" hidden="false" targetId="2b03-8d64-3711-f300" type="selectionEntry">
                           <profiles/>
                           <rules/>
                           <infoLinks/>
@@ -11219,7 +11534,7 @@
                 </selectionEntryGroup>
               </selectionEntryGroups>
               <entryLinks>
-                <entryLink id="680a-a253-efea-9880" name="Special issue boltgun" hidden="false" targetId="ac47-fbfd-4381-3191" type="selectionEntry">
+                <entryLink id="680a-a253-efea-9880" name="Special issue boltgun" hidden="false" targetId="cfc3-3735-a2e8-53cd" type="selectionEntry">
                   <profiles/>
                   <rules/>
                   <infoLinks/>
@@ -11233,18 +11548,7 @@
             </selectionEntryGroup>
           </selectionEntryGroups>
           <entryLinks>
-            <entryLink id="a4b8-b780-040f-e143" name="New EntryLink" hidden="false" targetId="e897-c8fa-0976-e2d3" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="74ac-273c-f126-0338" type="min"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4f02-9402-ef6a-4be9" type="max"/>
-              </constraints>
-              <categoryLinks/>
-            </entryLink>
-            <entryLink id="5863-77ec-8d49-d429" name="Krak grenade" hidden="false" targetId="073b-2de5-765f-a4f2" type="selectionEntry">
+            <entryLink id="5863-77ec-8d49-d429" name="Frag &amp; Krak grenades" hidden="false" targetId="cddf-945e-1335-e681" type="selectionEntry">
               <profiles/>
               <rules/>
               <infoLinks/>
@@ -11271,49 +11575,15 @@
     </selectionEntry>
     <selectionEntry id="52d2-481d-acf4-0787" name="Stormraven Gunship" hidden="false" collective="false" type="model">
       <profiles>
-        <profile id="7087-6f67-ac3e-7025" name="Airborne" hidden="false" profileTypeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" profileTypeName="Abilities">
+        <profile id="6019-69b5-1cb6-b828" name="Crash and Burn" hidden="false" profileTypeId="818c-0db1-36f0-462a" profileTypeName="Explosion">
           <profiles/>
           <rules/>
           <infoLinks/>
           <modifiers/>
           <characteristics>
-            <characteristic name="Description" characteristicTypeId="21befb24-fc85-4f52-a745-64b2e48f8228" value="This model cannot charge, can only be charged by units that can FLY, and can only attack or be attacked in the Fight phase by units that can FLY."/>
-          </characteristics>
-        </profile>
-        <profile id="0ef8-30e9-229b-09d7" name="Supersonic" hidden="false" profileTypeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" profileTypeName="Abilities">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <characteristics>
-            <characteristic name="Description" characteristicTypeId="21befb24-fc85-4f52-a745-64b2e48f8228" value="Each time this model moves, first pivot it on the spot up to 90° (this does not contribute to how far the model moves), and then move the model straight forwards. Note that it cannot pivot again after the initial pivot. When this model Advances, increase its Move characteristic by 20&quot; until the end of the phase - do not roll a dice."/>
-          </characteristics>
-        </profile>
-        <profile id="155b-d819-fbbe-d4ec" name="Hard to Hit" hidden="false" profileTypeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" profileTypeName="Abilities">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <characteristics>
-            <characteristic name="Description" characteristicTypeId="21befb24-fc85-4f52-a745-64b2e48f8228" value="Your opponent must subtract 1 from hit rolls for attacks that target this model in the Shooting phase."/>
-          </characteristics>
-        </profile>
-        <profile id="d6e1-2d96-2c4b-05b1" name="Hover Jet" hidden="false" profileTypeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" profileTypeName="Abilities">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <characteristics>
-            <characteristic name="Description" characteristicTypeId="21befb24-fc85-4f52-a745-64b2e48f8228" value="Before this model moves in your Movement phase, you can declare it will hover. Its Move characteristic becomes 20&quot; until the end of the phase, and it loses the Airborne, Hard to Hit and Supersonic abilities until the beginning of your next Movement phase."/>
-          </characteristics>
-        </profile>
-        <profile id="6019-69b5-1cb6-b828" name="Crash and Burn" hidden="false" profileTypeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" profileTypeName="Abilities">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <characteristics>
-            <characteristic name="Description" characteristicTypeId="21befb24-fc85-4f52-a745-64b2e48f8228" value="If this model is reduced to 0 wounds, roll a D6 before removing the model from the battlefield and before any embarked models disembark. On a 6 it crashes and explodes, and each unit within 6&quot; suffers D3 mortal wounds."/>
+            <characteristic name="Dice roll" characteristicTypeId="f21d-8f6d-180d-36ff" value="6"/>
+            <characteristic name="Distance" characteristicTypeId="d69e-be07-1682-ebcc" value="6&quot;"/>
+            <characteristic name="Mortal wounds" characteristicTypeId="29f1-65a1-2c5d-8c7d" value="D3"/>
           </characteristics>
         </profile>
         <profile id="0837-1d8a-4658-ddb7" name="Transport" hidden="false" profileTypeId="b3a8-0452-7436-44d1" profileTypeName="Transport">
@@ -11322,7 +11592,7 @@
           <infoLinks/>
           <modifiers/>
           <characteristics>
-            <characteristic name="Capacity" characteristicTypeId="15aa-1916-a38b-d223" value="This model can transport 12 &lt;CHAPTER&gt; INFANTRY models and 1 BLOOD ANGELS DREADNOUGHT. Each  JUMP PACK or TERMINATOR model takes the space of two other infantry models and each CENTURION takes the space of 3 other infantry models. It cannot transport PRIMARIS models."/>
+            <characteristic name="Capacity" characteristicTypeId="15aa-1916-a38b-d223" value="This model can transport 12 BLOOD ANGELS INFANTRY models and 1 BLOOD ANGELS DREADNOUGHT. Each  JUMP PACK or TERMINATOR model takes the space of two other models. It cannot transport PRIMARIS models or Redemptor Dreadnoughts."/>
           </characteristics>
         </profile>
         <profile id="21ad-c738-5c82-c22b" name="Stormraven Gunship" hidden="false" profileTypeId="5f4f-ea74-0630-4afe" profileTypeName="Wound Track">
@@ -11376,13 +11646,37 @@
       </profiles>
       <rules/>
       <infoLinks>
-        <infoLink id="1130-d477-713e-d31a" name="New InfoLink" hidden="false" targetId="4bfa-0006-220b-8949" type="profile">
+        <infoLink id="1130-d477-713e-d31a" name="Stormraven Gunship" hidden="false" targetId="4bfa-0006-220b-8949" type="profile">
           <profiles/>
           <rules/>
           <infoLinks/>
           <modifiers/>
         </infoLink>
         <infoLink id="ce39-9165-36e0-2d1e" name="New InfoLink" hidden="false" targetId="ea77-db2e-e94b-1dc8" type="profile">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="727b-f2d8-74c5-8888" name="Airborne" hidden="false" targetId="5612-a7b4-ed49-63e2" type="profile">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="eaf3-bc9d-4e0b-e55f" name="Hard to Hit" hidden="false" targetId="05fe-231e-bd86-86e4" type="profile">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="855d-bd33-c487-92d7" name="Hover Jet" page="" hidden="false" targetId="d061-4605-a6f7-0b4c" type="profile">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="ed29-1217-8a56-fe2b" name="Supersonic" hidden="false" targetId="c5ca-67fb-3f1a-5a0b" type="profile">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -11462,7 +11756,7 @@
           <selectionEntries/>
           <selectionEntryGroups/>
           <entryLinks>
-            <entryLink id="8414-4e68-c6d3-b1d4" name="New EntryLink" hidden="false" targetId="96fa-18f1-3b9d-974c" type="selectionEntry">
+            <entryLink id="8414-4e68-c6d3-b1d4" name="Hurricane bolter" hidden="false" targetId="b34a-b0c7-689d-d9a9" type="selectionEntry">
               <profiles/>
               <rules/>
               <infoLinks/>
@@ -11494,7 +11788,7 @@
           <selectionEntries/>
           <selectionEntryGroups/>
           <entryLinks>
-            <entryLink id="e8cd-86a8-d004-dd41" name="New EntryLink" hidden="false" targetId="2f94-6e2f-de15-4a6c" type="selectionEntry">
+            <entryLink id="e8cd-86a8-d004-dd41" name="Twin assault cannon" hidden="false" targetId="f787-a3af-72b5-60d1" type="selectionEntry">
               <profiles/>
               <rules/>
               <infoLinks/>
@@ -11504,7 +11798,7 @@
               </constraints>
               <categoryLinks/>
             </entryLink>
-            <entryLink id="e276-daae-4bf1-432c" name="New EntryLink" hidden="false" targetId="de7a-7bba-e2c5-c37c" type="selectionEntry">
+            <entryLink id="e276-daae-4bf1-432c" name="Twin lascannon" hidden="false" targetId="ee18-b1cd-6b60-464d" type="selectionEntry">
               <profiles/>
               <rules/>
               <infoLinks/>
@@ -11514,7 +11808,7 @@
               </constraints>
               <categoryLinks/>
             </entryLink>
-            <entryLink id="6439-30ac-e28c-0b73" name="New EntryLink" hidden="false" targetId="13b6-1003-db44-fdb0" type="selectionEntry">
+            <entryLink id="6439-30ac-e28c-0b73" name="Twin heavy plasma cannon" hidden="false" targetId="353e-3e4d-a6ed-d25c" type="selectionEntry">
               <profiles/>
               <rules/>
               <infoLinks/>
@@ -11539,7 +11833,7 @@
           <selectionEntries/>
           <selectionEntryGroups/>
           <entryLinks>
-            <entryLink id="1985-7e88-9720-59ff" name="New EntryLink" hidden="false" targetId="b310-1fca-9564-5812" type="selectionEntry">
+            <entryLink id="1985-7e88-9720-59ff" name="Twin heavy bolter" hidden="false" targetId="09d8-7790-ed3f-4d6d" type="selectionEntry">
               <profiles/>
               <rules/>
               <infoLinks/>
@@ -11549,7 +11843,7 @@
               </constraints>
               <categoryLinks/>
             </entryLink>
-            <entryLink id="3bd9-8516-f81e-b549" name="New EntryLink" hidden="false" targetId="a44a-4a6a-4886-274c" type="selectionEntry">
+            <entryLink id="3bd9-8516-f81e-b549" name="Typhoon missile launcher" hidden="false" targetId="6027-7017-756a-600c" type="selectionEntry">
               <profiles/>
               <rules/>
               <infoLinks/>
@@ -11559,7 +11853,7 @@
               </constraints>
               <categoryLinks/>
             </entryLink>
-            <entryLink id="b67c-80cd-2854-fcf6" name="New EntryLink" hidden="false" targetId="eeee-810f-767d-9e8f" type="selectionEntry">
+            <entryLink id="b67c-80cd-2854-fcf6" name="Twin multi-melta" hidden="false" targetId="d496-bdd5-426e-3e80" type="selectionEntry">
               <profiles/>
               <rules/>
               <infoLinks/>
@@ -11573,7 +11867,7 @@
         </selectionEntryGroup>
       </selectionEntryGroups>
       <entryLinks>
-        <entryLink id="065c-855a-f81f-aff8" name="Stormstrike missile launcher" hidden="false" targetId="e865-ee84-fe7d-9455" type="selectionEntry">
+        <entryLink id="065c-855a-f81f-aff8" name="Stormstrike missile launcher" hidden="false" targetId="38e3-37a8-42a3-e195" type="selectionEntry">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -11706,7 +12000,7 @@
                   </constraints>
                   <categoryLinks/>
                 </entryLink>
-                <entryLink id="3351-f10f-976c-6377" name="Bolt pistol" hidden="false" targetId="0367-b42c-b6b4-0a58" type="selectionEntry">
+                <entryLink id="3351-f10f-976c-6377" name="Bolt pistol" hidden="false" targetId="37d3-7098-d596-9948" type="selectionEntry">
                   <profiles/>
                   <rules/>
                   <infoLinks/>
@@ -11717,7 +12011,7 @@
                   </constraints>
                   <categoryLinks/>
                 </entryLink>
-                <entryLink id="2028-f41f-a3e4-b10a" name="New EntryLink" hidden="false" targetId="7b26-e6ac-dce0-6897" type="selectionEntry">
+                <entryLink id="2028-f41f-a3e4-b10a" name="Boltgun" hidden="false" targetId="ca06-ac13-d02f-6f9a" type="selectionEntry">
                   <profiles/>
                   <rules/>
                   <infoLinks/>
@@ -11784,7 +12078,7 @@
                       <selectionEntries/>
                       <selectionEntryGroups/>
                       <entryLinks>
-                        <entryLink id="4d68-6a29-198f-c44e" name="New EntryLink" hidden="false" targetId="0367-b42c-b6b4-0a58" type="selectionEntry">
+                        <entryLink id="4d68-6a29-198f-c44e" name="Bolt pistol" hidden="false" targetId="37d3-7098-d596-9948" type="selectionEntry">
                           <profiles/>
                           <rules/>
                           <infoLinks/>
@@ -11795,7 +12089,7 @@
                           </constraints>
                           <categoryLinks/>
                         </entryLink>
-                        <entryLink id="f2d8-ef68-a11f-2ac8" name="New EntryLink" hidden="false" targetId="7b26-e6ac-dce0-6897" type="selectionEntry">
+                        <entryLink id="f2d8-ef68-a11f-2ac8" name="Boltgun" hidden="false" targetId="ca06-ac13-d02f-6f9a" type="selectionEntry">
                           <profiles/>
                           <rules/>
                           <infoLinks/>
@@ -11827,18 +12121,7 @@
                 </selectionEntryGroup>
               </selectionEntryGroups>
               <entryLinks>
-                <entryLink id="51cd-e368-d83e-cd99" name="New EntryLink" hidden="false" targetId="e897-c8fa-0976-e2d3" type="selectionEntry">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                  <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="70a9-6e54-6a7b-9e7e" type="min"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d186-58e9-df29-6e8e" type="max"/>
-                  </constraints>
-                  <categoryLinks/>
-                </entryLink>
-                <entryLink id="bda4-eb42-6ff0-3784" name="New EntryLink" hidden="false" targetId="073b-2de5-765f-a4f2" type="selectionEntry">
+                <entryLink id="bda4-eb42-6ff0-3784" name="Frag &amp; Krak grenades" hidden="false" targetId="cddf-945e-1335-e681" type="selectionEntry">
                   <profiles/>
                   <rules/>
                   <infoLinks/>
@@ -11849,7 +12132,7 @@
                   </constraints>
                   <categoryLinks/>
                 </entryLink>
-                <entryLink id="4dc4-b7f5-c5cf-b190" name="Melta bombs" hidden="false" targetId="5f8b-b9f4-ec1c-3316" type="selectionEntry">
+                <entryLink id="4dc4-b7f5-c5cf-b190" name="Melta bombs" hidden="false" targetId="8ed2-3e2c-4d52-af79" type="selectionEntry">
                   <profiles/>
                   <rules/>
                   <infoLinks/>
@@ -11898,7 +12181,6 @@
                   </infoLinks>
                   <modifiers/>
                   <constraints>
-                    <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b163-146c-02b7-eeed" type="min"/>
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e86f-0b6c-00cf-847f" type="max"/>
                   </constraints>
                   <categoryLinks/>
@@ -11916,7 +12198,7 @@
                       </constraints>
                       <categoryLinks/>
                     </entryLink>
-                    <entryLink id="c513-1898-f177-fe68" name="New EntryLink" hidden="false" targetId="0367-b42c-b6b4-0a58" type="selectionEntry">
+                    <entryLink id="c513-1898-f177-fe68" name="Bolt pistol" hidden="false" targetId="37d3-7098-d596-9948" type="selectionEntry">
                       <profiles/>
                       <rules/>
                       <infoLinks/>
@@ -11957,7 +12239,6 @@
                   </infoLinks>
                   <modifiers/>
                   <constraints>
-                    <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="826d-1980-8527-2f0d" type="min"/>
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="85db-c2d1-e0dc-5f97" type="max"/>
                   </constraints>
                   <categoryLinks/>
@@ -11975,7 +12256,7 @@
                       </constraints>
                       <categoryLinks/>
                     </entryLink>
-                    <entryLink id="ef58-3c21-690c-b02d" name="New EntryLink" hidden="false" targetId="0367-b42c-b6b4-0a58" type="selectionEntry">
+                    <entryLink id="ef58-3c21-690c-b02d" name="Bolt pistol" hidden="false" targetId="37d3-7098-d596-9948" type="selectionEntry">
                       <profiles/>
                       <rules/>
                       <infoLinks/>
@@ -12035,7 +12316,7 @@
             </modifier>
           </modifiers>
         </infoLink>
-        <infoLink id="8002-8e3e-6a3c-be13" name="New InfoLink" hidden="false" targetId="314e-6c13-0097-da90" type="profile">
+        <infoLink id="8002-8e3e-6a3c-be13" name="Blessing of the Omnissiah" hidden="false" targetId="314e-6c13-0097-da90" type="profile">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -12116,7 +12397,7 @@
           <selectionEntries/>
           <selectionEntryGroups/>
           <entryLinks>
-            <entryLink id="56f8-df5b-ab9f-46dc" name="Bolt pistol" hidden="false" targetId="bf86-1c1b-6871-da0b" type="selectionEntry">
+            <entryLink id="56f8-df5b-ab9f-46dc" name="Bolt pistol" hidden="false" targetId="0334-f487-8229-0c1a" type="selectionEntry">
               <profiles/>
               <rules/>
               <infoLinks/>
@@ -12126,7 +12407,7 @@
               </constraints>
               <categoryLinks/>
             </entryLink>
-            <entryLink id="882d-63c8-23bf-5ad8" name="Boltgun" hidden="false" targetId="8e23-a2e7-23c4-cac7" type="selectionEntry">
+            <entryLink id="882d-63c8-23bf-5ad8" name="Boltgun" hidden="false" targetId="b61f-a3c1-827d-c5b6" type="selectionEntry">
               <profiles/>
               <rules/>
               <infoLinks/>
@@ -12171,7 +12452,7 @@
           <selectionEntries/>
           <selectionEntryGroups/>
           <entryLinks>
-            <entryLink id="e7f2-4dd0-0183-f833" name="Power axe" hidden="false" targetId="8d13-0f69-a808-e300" type="selectionEntry">
+            <entryLink id="e7f2-4dd0-0183-f833" name="Power axe" hidden="false" targetId="3292-34e6-f679-d5b9" type="selectionEntry">
               <profiles/>
               <rules/>
               <infoLinks/>
@@ -12206,7 +12487,7 @@
           <selectionEntries/>
           <selectionEntryGroups/>
           <entryLinks>
-            <entryLink id="f4ae-b4f4-91ec-149b" name="Servo-arm" hidden="false" targetId="fb0f-7f69-e952-07dc" type="selectionEntry">
+            <entryLink id="f4ae-b4f4-91ec-149b" name="Servo-arm" hidden="false" targetId="61ae-3901-0a79-4ec9" type="selectionEntry">
               <profiles/>
               <rules/>
               <infoLinks/>
@@ -12216,7 +12497,7 @@
               </constraints>
               <categoryLinks/>
             </entryLink>
-            <entryLink id="d60e-ae1c-bdf1-ed74" name="Conversion beamer" hidden="false" targetId="0fb1-018a-de93-8509" type="selectionEntry">
+            <entryLink id="d60e-ae1c-bdf1-ed74" name="Conversion beamer" hidden="false" targetId="fbb1-9dd6-aefc-eba2" type="selectionEntry">
               <profiles/>
               <rules/>
               <infoLinks/>
@@ -12256,18 +12537,7 @@
         </selectionEntryGroup>
       </selectionEntryGroups>
       <entryLinks>
-        <entryLink id="70bd-6958-d488-a8d9" name="New EntryLink" hidden="false" targetId="e897-c8fa-0976-e2d3" type="selectionEntry">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a00a-7c84-ed65-3b7b" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b694-a775-2688-ecec" type="max"/>
-          </constraints>
-          <categoryLinks/>
-        </entryLink>
-        <entryLink id="0fb0-1a09-76b8-79d4" name="Krak grenade" hidden="false" targetId="073b-2de5-765f-a4f2" type="selectionEntry">
+        <entryLink id="0fb0-1a09-76b8-79d4" name="Frag &amp; Krak grenades" hidden="false" targetId="cddf-945e-1335-e681" type="selectionEntry">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -12276,6 +12546,32 @@
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="22cd-3047-51bf-da65" type="min"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="69af-6d13-91f8-af7c" type="max"/>
           </constraints>
+          <categoryLinks/>
+        </entryLink>
+        <entryLink id="54e1-3104-8613-98df" name="Warlord" hidden="false" targetId="33f6-60da-7b70-5fee" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a050-d007-cff0-979a" type="max"/>
+          </constraints>
+          <categoryLinks/>
+        </entryLink>
+        <entryLink id="5a76-313c-e03c-8a6d" name="Warlord Traits" hidden="false" targetId="c25d-2fbc-47b3-9e39" type="selectionEntryGroup">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+          <categoryLinks/>
+        </entryLink>
+        <entryLink id="ba00-7fea-d251-897b" name="Relics of Baal" hidden="false" targetId="441f-1714-0777-c202" type="selectionEntryGroup">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
           <categoryLinks/>
         </entryLink>
       </entryLinks>
@@ -12373,7 +12669,7 @@
           <selectionEntries/>
           <selectionEntryGroups/>
           <entryLinks>
-            <entryLink id="043a-eb59-dced-147c" name="New EntryLink" hidden="false" targetId="fb0f-7f69-e952-07dc" type="selectionEntry">
+            <entryLink id="043a-eb59-dced-147c" name="Servo-arm" hidden="false" targetId="61ae-3901-0a79-4ec9" type="selectionEntry">
               <profiles/>
               <rules/>
               <infoLinks/>
@@ -12384,7 +12680,7 @@
               </constraints>
               <categoryLinks/>
             </entryLink>
-            <entryLink id="35a5-0c8b-5efe-954d" name="New EntryLink" hidden="false" targetId="c3f2-5ecb-a2ae-a92f" type="selectionEntry">
+            <entryLink id="35a5-0c8b-5efe-954d" name="Plasma cutter" hidden="false" targetId="d1e1-23e0-2777-dc7b" type="selectionEntry">
               <profiles/>
               <rules/>
               <infoLinks/>
@@ -12395,7 +12691,7 @@
               </constraints>
               <categoryLinks/>
             </entryLink>
-            <entryLink id="b70a-7911-19e7-a1e0" name="New EntryLink" hidden="false" targetId="a255-3b4c-89e4-e6b3" type="selectionEntry">
+            <entryLink id="b70a-7911-19e7-a1e0" name="Flamer" hidden="false" targetId="fd22-6743-2d4c-dd62" type="selectionEntry">
               <profiles/>
               <rules/>
               <infoLinks/>
@@ -12427,7 +12723,7 @@
           <selectionEntries/>
           <selectionEntryGroups/>
           <entryLinks>
-            <entryLink id="3539-2fab-293e-3857" name="Bolt pistol" hidden="false" targetId="bf86-1c1b-6871-da0b" type="selectionEntry">
+            <entryLink id="3539-2fab-293e-3857" name="Bolt pistol" hidden="false" targetId="0334-f487-8229-0c1a" type="selectionEntry">
               <profiles/>
               <rules/>
               <infoLinks/>
@@ -12437,7 +12733,7 @@
               </constraints>
               <categoryLinks/>
             </entryLink>
-            <entryLink id="fc99-1ea7-3333-235b" name="Boltgun" hidden="false" targetId="8e23-a2e7-23c4-cac7" type="selectionEntry">
+            <entryLink id="fc99-1ea7-3333-235b" name="Boltgun" hidden="false" targetId="b61f-a3c1-827d-c5b6" type="selectionEntry">
               <profiles/>
               <rules/>
               <infoLinks/>
@@ -12482,7 +12778,7 @@
           <selectionEntries/>
           <selectionEntryGroups/>
           <entryLinks>
-            <entryLink id="6c2d-2a52-5e4f-5f60" name="New EntryLink" hidden="false" targetId="8d13-0f69-a808-e300" type="selectionEntry">
+            <entryLink id="6c2d-2a52-5e4f-5f60" name="Power axe" hidden="false" targetId="3292-34e6-f679-d5b9" type="selectionEntry">
               <profiles/>
               <rules/>
               <infoLinks/>
@@ -12517,7 +12813,7 @@
           <selectionEntries/>
           <selectionEntryGroups/>
           <entryLinks>
-            <entryLink id="574d-7e1b-a2a6-e75e" name="New EntryLink" hidden="false" targetId="fb0f-7f69-e952-07dc" type="selectionEntry">
+            <entryLink id="574d-7e1b-a2a6-e75e" name="Servo-arm" hidden="false" targetId="61ae-3901-0a79-4ec9" type="selectionEntry">
               <profiles/>
               <rules/>
               <infoLinks/>
@@ -12527,7 +12823,7 @@
               </constraints>
               <categoryLinks/>
             </entryLink>
-            <entryLink id="4349-36e6-dbfe-a421" name="New EntryLink" hidden="false" targetId="0fb1-018a-de93-8509" type="selectionEntry">
+            <entryLink id="4349-36e6-dbfe-a421" name="Conversion beamer" hidden="false" targetId="fbb1-9dd6-aefc-eba2" type="selectionEntry">
               <profiles/>
               <rules/>
               <infoLinks/>
@@ -12549,18 +12845,7 @@
         </selectionEntryGroup>
       </selectionEntryGroups>
       <entryLinks>
-        <entryLink id="4df5-46b8-5112-8dd7" name="Frag grenade" hidden="false" targetId="e897-c8fa-0976-e2d3" type="selectionEntry">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b799-e6b2-504d-c4f9" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="868a-1227-e71a-6748" type="max"/>
-          </constraints>
-          <categoryLinks/>
-        </entryLink>
-        <entryLink id="1c69-3456-1cbf-27a5" name="New EntryLink" hidden="false" targetId="073b-2de5-765f-a4f2" type="selectionEntry">
+        <entryLink id="1c69-3456-1cbf-27a5" name="Frag &amp; Krak grenades" hidden="false" targetId="cddf-945e-1335-e681" type="selectionEntry">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -12571,7 +12856,7 @@
           </constraints>
           <categoryLinks/>
         </entryLink>
-        <entryLink id="056b-0a95-cf73-be0e" name="New EntryLink" hidden="false" targetId="311e-ae83-ed70-26e9" type="selectionEntry">
+        <entryLink id="056b-0a95-cf73-be0e" name="Twin boltgun" hidden="false" targetId="a11f-8f20-5d2c-079a" type="selectionEntry">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -12580,6 +12865,32 @@
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5ad6-658b-9888-9379" type="min"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5506-758c-be1d-1a58" type="max"/>
           </constraints>
+          <categoryLinks/>
+        </entryLink>
+        <entryLink id="f091-1ecb-0794-19d2" name="Warlord" hidden="false" targetId="33f6-60da-7b70-5fee" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ac95-3fb1-e995-2f52" type="max"/>
+          </constraints>
+          <categoryLinks/>
+        </entryLink>
+        <entryLink id="b259-f932-ce68-2049" name="Warlord Traits" hidden="false" targetId="c25d-2fbc-47b3-9e39" type="selectionEntryGroup">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+          <categoryLinks/>
+        </entryLink>
+        <entryLink id="3460-4cda-c9de-76fe" name="Relics of Baal" hidden="false" targetId="441f-1714-0777-c202" type="selectionEntryGroup">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
           <categoryLinks/>
         </entryLink>
       </entryLinks>
@@ -12644,7 +12955,7 @@
         </infoLink>
       </infoLinks>
       <modifiers>
-        <modifier type="increment" field="e356-c769-5920-6e14" value="12">
+        <modifier type="increment" field="e356-c769-5920-6e14" value="11">
           <repeats/>
           <conditions>
             <condition field="selections" scope="2922-dcff-ac2f-be78" value="4.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="eeef-44e5-7c91-607a" type="greaterThan"/>
@@ -12747,7 +13058,7 @@
                   <selectionEntries/>
                   <selectionEntryGroups/>
                   <entryLinks>
-                    <entryLink id="31e8-2004-8e88-1bd1" name="New EntryLink" hidden="false" targetId="7057-ee87-f5bf-5e42" type="selectionEntry">
+                    <entryLink id="31e8-2004-8e88-1bd1" name="Thunder hammer" hidden="false" targetId="0e57-eaf5-763f-9c45" type="selectionEntry">
                       <profiles/>
                       <rules/>
                       <infoLinks/>
@@ -12839,7 +13150,7 @@
                   <selectionEntries/>
                   <selectionEntryGroups/>
                   <entryLinks>
-                    <entryLink id="eb35-6aec-0e47-59ad" name="New EntryLink" hidden="false" targetId="7057-ee87-f5bf-5e42" type="selectionEntry">
+                    <entryLink id="eb35-6aec-0e47-59ad" name="Thunder hammer" hidden="false" targetId="0e57-eaf5-763f-9c45" type="selectionEntry">
                       <profiles/>
                       <rules/>
                       <infoLinks/>
@@ -12904,7 +13215,7 @@
         </entryLink>
       </entryLinks>
       <costs>
-        <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="12.0"/>
+        <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="11.0"/>
         <cost name="pts" costTypeId="points" value="0.0"/>
       </costs>
     </selectionEntry>
@@ -13023,7 +13334,7 @@
           <selectionEntries/>
           <selectionEntryGroups/>
           <entryLinks>
-            <entryLink id="d197-4947-34e0-409e" name="New EntryLink" hidden="false" targetId="d74a-2fee-abea-1b42" type="selectionEntry">
+            <entryLink id="d197-4947-34e0-409e" name="Storm bolter" hidden="false" targetId="2b03-8d64-3711-f300" type="selectionEntry">
               <profiles/>
               <rules/>
               <infoLinks/>
@@ -13034,7 +13345,7 @@
               </constraints>
               <categoryLinks/>
             </entryLink>
-            <entryLink id="bf6e-768d-71b0-44b6" name="New EntryLink" hidden="false" targetId="c3d0-2567-35c6-3f29" type="selectionEntry">
+            <entryLink id="bf6e-768d-71b0-44b6" name="Power sword" hidden="false" targetId="bc9e-551d-9afb-78d5" type="selectionEntry">
               <profiles/>
               <rules/>
               <infoLinks/>
@@ -13083,7 +13394,7 @@
               <selectionEntries/>
               <selectionEntryGroups/>
               <entryLinks>
-                <entryLink id="6686-c309-1d3c-df64" name="Power fist" hidden="false" targetId="3102-2dd8-4f31-3af7" type="selectionEntry">
+                <entryLink id="6686-c309-1d3c-df64" name="Power fist" hidden="false" targetId="f122-3720-fa32-4215" type="selectionEntry">
                   <profiles/>
                   <rules/>
                   <infoLinks/>
@@ -13093,7 +13404,7 @@
                   </constraints>
                   <categoryLinks/>
                 </entryLink>
-                <entryLink id="2a06-bbf2-4c4f-1f7b" name="Chainfist" hidden="false" targetId="fdc6-5770-1177-74f4" type="selectionEntry">
+                <entryLink id="2a06-bbf2-4c4f-1f7b" name="Chainfist" hidden="false" targetId="e464-77c1-12bb-e52f" type="selectionEntry">
                   <profiles/>
                   <rules/>
                   <infoLinks/>
@@ -13118,7 +13429,7 @@
               <selectionEntries/>
               <selectionEntryGroups/>
               <entryLinks>
-                <entryLink id="adf9-11fe-b467-28d6" name="Storm bolter" hidden="false" targetId="d74a-2fee-abea-1b42" type="selectionEntry">
+                <entryLink id="adf9-11fe-b467-28d6" name="Storm bolter" hidden="false" targetId="2b03-8d64-3711-f300" type="selectionEntry">
                   <profiles/>
                   <rules/>
                   <infoLinks/>
@@ -13316,7 +13627,7 @@
                   <selectionEntries/>
                   <selectionEntryGroups/>
                   <entryLinks>
-                    <entryLink id="8f31-f7df-2762-fc30" name="New EntryLink" hidden="false" targetId="0367-b42c-b6b4-0a58" type="selectionEntry">
+                    <entryLink id="8f31-f7df-2762-fc30" name="Bolt pistol" hidden="false" targetId="37d3-7098-d596-9948" type="selectionEntry">
                       <profiles/>
                       <rules/>
                       <infoLinks/>
@@ -13327,7 +13638,7 @@
                       </constraints>
                       <categoryLinks/>
                     </entryLink>
-                    <entryLink id="84ff-a85d-364f-ae41" name="New EntryLink" hidden="false" targetId="5905-f299-f23c-f9c1" type="selectionEntry">
+                    <entryLink id="84ff-a85d-364f-ae41" name="Chainsword" hidden="false" targetId="4334-d2da-32f5-dc53" type="selectionEntry">
                       <profiles/>
                       <rules/>
                       <infoLinks/>
@@ -13377,7 +13688,7 @@
                   </constraints>
                   <categoryLinks/>
                 </entryLink>
-                <entryLink id="1eca-4669-dd56-50f3" name="New EntryLink" hidden="false" targetId="dc83-fc73-b7ae-62b6" type="selectionEntry">
+                <entryLink id="1eca-4669-dd56-50f3" name="Relic blade" hidden="false" targetId="0140-c9f2-0524-34cc" type="selectionEntry">
                   <profiles/>
                   <rules/>
                   <infoLinks/>
@@ -13391,18 +13702,7 @@
             </selectionEntryGroup>
           </selectionEntryGroups>
           <entryLinks>
-            <entryLink id="8f39-8d0b-3261-ccf0" name="New EntryLink" hidden="false" targetId="e897-c8fa-0976-e2d3" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="49db-68bd-0cef-009f" type="min"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="48c8-e318-87c5-ee82" type="max"/>
-              </constraints>
-              <categoryLinks/>
-            </entryLink>
-            <entryLink id="a75d-a1f8-7996-5b35" name="New EntryLink" hidden="false" targetId="073b-2de5-765f-a4f2" type="selectionEntry">
+            <entryLink id="a75d-a1f8-7996-5b35" name="Frag &amp; Krak grenades" hidden="false" targetId="cddf-945e-1335-e681" type="selectionEntry">
               <profiles/>
               <rules/>
               <infoLinks/>
@@ -13413,7 +13713,7 @@
               </constraints>
               <categoryLinks/>
             </entryLink>
-            <entryLink id="7197-08e3-ceb6-fd57" name="New EntryLink" hidden="false" targetId="5f8b-b9f4-ec1c-3316" type="selectionEntry">
+            <entryLink id="7197-08e3-ceb6-fd57" name="Melta bombs" hidden="false" targetId="8ed2-3e2c-4d52-af79" type="selectionEntry">
               <profiles/>
               <rules/>
               <infoLinks/>
@@ -13495,7 +13795,7 @@
                   <selectionEntries/>
                   <selectionEntryGroups/>
                   <entryLinks>
-                    <entryLink id="7f12-925a-1cfe-f8dd" name="Bolt pistol" hidden="false" targetId="0367-b42c-b6b4-0a58" type="selectionEntry">
+                    <entryLink id="7f12-925a-1cfe-f8dd" name="Bolt pistol" hidden="false" targetId="37d3-7098-d596-9948" type="selectionEntry">
                       <profiles/>
                       <rules/>
                       <infoLinks/>
@@ -13506,7 +13806,7 @@
                       </constraints>
                       <categoryLinks/>
                     </entryLink>
-                    <entryLink id="cd04-b44e-46e9-b659" name="Chainsword" hidden="false" targetId="5905-f299-f23c-f9c1" type="selectionEntry">
+                    <entryLink id="cd04-b44e-46e9-b659" name="Chainsword" hidden="false" targetId="4334-d2da-32f5-dc53" type="selectionEntry">
                       <profiles/>
                       <rules/>
                       <infoLinks/>
@@ -13560,18 +13860,7 @@
             </selectionEntryGroup>
           </selectionEntryGroups>
           <entryLinks>
-            <entryLink id="2566-9d99-c4c5-b225" name="New EntryLink" hidden="false" targetId="e897-c8fa-0976-e2d3" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e0a8-4a90-2e03-7f37" type="min"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5f1d-1a18-7219-c460" type="max"/>
-              </constraints>
-              <categoryLinks/>
-            </entryLink>
-            <entryLink id="b4a4-b7ef-b116-416a" name="New EntryLink" hidden="false" targetId="073b-2de5-765f-a4f2" type="selectionEntry">
+            <entryLink id="b4a4-b7ef-b116-416a" name="Frag &amp; Krak grenades" hidden="false" targetId="cddf-945e-1335-e681" type="selectionEntry">
               <profiles/>
               <rules/>
               <infoLinks/>
@@ -13582,7 +13871,7 @@
               </constraints>
               <categoryLinks/>
             </entryLink>
-            <entryLink id="a62a-0e5d-c74d-4c30" name="New EntryLink" hidden="false" targetId="5f8b-b9f4-ec1c-3316" type="selectionEntry">
+            <entryLink id="a62a-0e5d-c74d-4c30" name="Melta bombs" hidden="false" targetId="8ed2-3e2c-4d52-af79" type="selectionEntry">
               <profiles/>
               <rules/>
               <infoLinks/>
@@ -13635,13 +13924,15 @@
     </selectionEntry>
     <selectionEntry id="be0e-f293-4692-d952" name="Whirlwind" hidden="false" collective="false" type="model">
       <profiles>
-        <profile id="0133-5f90-10ee-fc06" name="Explodes" hidden="false" profileTypeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" profileTypeName="Abilities">
+        <profile id="0133-5f90-10ee-fc06" name="Explodes" hidden="false" profileTypeId="818c-0db1-36f0-462a" profileTypeName="Explosion">
           <profiles/>
           <rules/>
           <infoLinks/>
           <modifiers/>
           <characteristics>
-            <characteristic name="Description" characteristicTypeId="21befb24-fc85-4f52-a745-64b2e48f8228" value="If this model is reduced to 0 wounds, roll a D6 before removing the model from the battlefield; on a 6 it explodes, and each unit within 6&quot; suffers D3 mortal wounds."/>
+            <characteristic name="Dice roll" characteristicTypeId="f21d-8f6d-180d-36ff" value="6"/>
+            <characteristic name="Distance" characteristicTypeId="d69e-be07-1682-ebcc" value="6&quot;"/>
+            <characteristic name="Mortal wounds" characteristicTypeId="29f1-65a1-2c5d-8c7d" value="D3"/>
           </characteristics>
         </profile>
         <profile id="289a-6223-b9b9-af61" name="Whirlwind" hidden="false" profileTypeId="5f4f-ea74-0630-4afe" profileTypeName="Wound Track">
@@ -13769,7 +14060,7 @@
           <selectionEntries/>
           <selectionEntryGroups/>
           <entryLinks>
-            <entryLink id="38c6-d173-e556-6040" name="" hidden="false" targetId="ca0d-b6b8-d8a5-2299" type="selectionEntry">
+            <entryLink id="38c6-d173-e556-6040" name="Whirlwind vengeance launcher" hidden="false" targetId="79a5-23f2-b542-a73f" type="selectionEntry">
               <profiles/>
               <rules/>
               <infoLinks/>
@@ -13779,7 +14070,7 @@
               </constraints>
               <categoryLinks/>
             </entryLink>
-            <entryLink id="82de-1166-baed-b43f" name="New EntryLink" hidden="false" targetId="fb0f-73a0-7ebe-6c86" type="selectionEntry">
+            <entryLink id="82de-1166-baed-b43f" name="Whirlwind castellan launcher" hidden="false" targetId="e640-c148-5944-6874" type="selectionEntry">
               <profiles/>
               <rules/>
               <infoLinks/>
@@ -13793,7 +14084,7 @@
         </selectionEntryGroup>
       </selectionEntryGroups>
       <entryLinks>
-        <entryLink id="fc1d-b83c-38b0-44c0" name="New EntryLink" hidden="false" targetId="4dda-f43f-5335-f49f" type="selectionEntry">
+        <entryLink id="fc1d-b83c-38b0-44c0" name="Hunter-killer missile" hidden="false" targetId="32bf-b117-4ecf-5165" type="selectionEntry">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -13803,7 +14094,7 @@
           </constraints>
           <categoryLinks/>
         </entryLink>
-        <entryLink id="9ce4-f0f1-93c0-1f11" name="New EntryLink" hidden="false" targetId="d74a-2fee-abea-1b42" type="selectionEntry">
+        <entryLink id="9ce4-f0f1-93c0-1f11" name="Storm bolter" hidden="false" targetId="2b03-8d64-3711-f300" type="selectionEntry">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -13821,13 +14112,15 @@
     </selectionEntry>
     <selectionEntry id="5a0f-867d-1d0f-4d3c" name="Vindicator" hidden="false" collective="false" type="model">
       <profiles>
-        <profile id="4623-b316-948c-0fa8" name="Explodes" hidden="false" profileTypeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" profileTypeName="Abilities">
+        <profile id="4623-b316-948c-0fa8" name="Explodes" hidden="false" profileTypeId="818c-0db1-36f0-462a" profileTypeName="Explosion">
           <profiles/>
           <rules/>
           <infoLinks/>
           <modifiers/>
           <characteristics>
-            <characteristic name="Description" characteristicTypeId="21befb24-fc85-4f52-a745-64b2e48f8228" value="If this model is reduced to 0 wounds, roll a D6 before removing the model from the battlefield; on a 6 it explodes, and each unit within 6&quot; suffers D3 mortal wounds."/>
+            <characteristic name="Dice roll" characteristicTypeId="f21d-8f6d-180d-36ff" value="6"/>
+            <characteristic name="Distance" characteristicTypeId="d69e-be07-1682-ebcc" value="6&quot;"/>
+            <characteristic name="Mortal wounds" characteristicTypeId="29f1-65a1-2c5d-8c7d" value="D3"/>
           </characteristics>
         </profile>
         <profile id="b6f1-a561-b2ac-8db9" name="Vindicator" hidden="false" profileTypeId="5f4f-ea74-0630-4afe" profileTypeName="Wound Track">
@@ -13943,7 +14236,7 @@
       <selectionEntries/>
       <selectionEntryGroups/>
       <entryLinks>
-        <entryLink id="2a8d-070e-989a-a6db" name="New EntryLink" hidden="false" targetId="4dda-f43f-5335-f49f" type="selectionEntry">
+        <entryLink id="2a8d-070e-989a-a6db" name="Hunter-killer missile" hidden="false" targetId="32bf-b117-4ecf-5165" type="selectionEntry">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -13953,7 +14246,7 @@
           </constraints>
           <categoryLinks/>
         </entryLink>
-        <entryLink id="7d3f-871e-8d11-0a90" name="New EntryLink" hidden="false" targetId="d74a-2fee-abea-1b42" type="selectionEntry">
+        <entryLink id="7d3f-871e-8d11-0a90" name="Storm bolter" hidden="false" targetId="2b03-8d64-3711-f300" type="selectionEntry">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -13963,7 +14256,7 @@
           </constraints>
           <categoryLinks/>
         </entryLink>
-        <entryLink id="4cc2-4956-790f-e500" name="Demolisher cannon" hidden="false" targetId="0e25-be06-59c9-4f34" type="selectionEntry">
+        <entryLink id="4cc2-4956-790f-e500" name="Demolisher cannon" hidden="false" targetId="1f7e-32c4-61af-510f" type="selectionEntry">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -13998,7 +14291,7 @@
       <selectionEntryGroups/>
       <entryLinks/>
       <costs>
-        <cost name="pts" costTypeId="points" value="9.0"/>
+        <cost name="pts" costTypeId="points" value="3.0"/>
         <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="0.0"/>
       </costs>
     </selectionEntry>
@@ -14160,7 +14453,7 @@
       <profiles/>
       <rules/>
       <infoLinks>
-        <infoLink id="1044-ab98-072a-2d00" name="New InfoLink" hidden="false" targetId="f88c-1ad6-af0b-db66" type="profile">
+        <infoLink id="1044-ab98-072a-2d00" name="Death Mask" hidden="false" targetId="f88c-1ad6-af0b-db66" type="profile">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -14201,17 +14494,7 @@
       </costs>
     </selectionEntry>
     <selectionEntry id="286d-d79d-7d73-8d72" name="Commander Dante" hidden="false" collective="false" type="model">
-      <profiles>
-        <profile id="ad3d-085e-7481-b2c8" name="Chapter Master" hidden="false" profileTypeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" profileTypeName="Abilities">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <characteristics>
-            <characteristic name="Description" characteristicTypeId="21befb24-fc85-4f52-a745-64b2e48f8228" value="You can re-roll failed hit rolls for friendly BLOOD ANGELS units within 6&quot; of Commander Dante."/>
-          </characteristics>
-        </profile>
-      </profiles>
+      <profiles/>
       <rules/>
       <infoLinks>
         <infoLink id="225e-28e0-6a49-a68c" name="Commander Dante" hidden="false" targetId="f82a-3b7e-febb-0d59" type="profile">
@@ -14227,6 +14510,12 @@
           <modifiers/>
         </infoLink>
         <infoLink id="40f9-a606-df34-46cc" name="Iron Halo" hidden="false" targetId="8742-48fe-7dfc-a1c0" type="profile">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="1b82-1d3a-4742-1863" name="Chapter Master (Blood Angels)" hidden="false" targetId="cb8d-e1e4-3ca6-9d20" type="profile">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -14308,34 +14597,15 @@
           <modifiers/>
           <constraints/>
         </categoryLink>
-      </categoryLinks>
-      <selectionEntries>
-        <selectionEntry id="8229-0664-0b43-a9c4" name="The Axe Mortalis" hidden="false" collective="false" type="upgrade">
+        <categoryLink id="0374-e72d-62ca-52c5" name="New CategoryLink" hidden="false" targetId="c7b7-edbc-bc14-6238" primary="false">
           <profiles/>
           <rules/>
-          <infoLinks>
-            <infoLink id="249e-86ab-046b-c1b1" name="New InfoLink" hidden="false" targetId="a662-325e-1bdf-351d" type="profile">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-            </infoLink>
-          </infoLinks>
+          <infoLinks/>
           <modifiers/>
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="23af-eaa9-4a04-413b" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="988f-c3c3-803d-f615" type="max"/>
-          </constraints>
-          <categoryLinks/>
-          <selectionEntries/>
-          <selectionEntryGroups/>
-          <entryLinks/>
-          <costs>
-            <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="0.0"/>
-            <cost name="pts" costTypeId="points" value="0.0"/>
-          </costs>
-        </selectionEntry>
-      </selectionEntries>
+          <constraints/>
+        </categoryLink>
+      </categoryLinks>
+      <selectionEntries/>
       <selectionEntryGroups/>
       <entryLinks>
         <entryLink id="54a1-726a-08bd-68ce" name="Death mask" hidden="false" targetId="2f38-7256-aeae-fc13" type="selectionEntry">
@@ -14355,7 +14625,7 @@
           </constraints>
           <categoryLinks/>
         </entryLink>
-        <entryLink id="b2f4-9cd1-1cd8-890a" name="Inferno pistol" hidden="false" targetId="12fb-6600-667f-5922" type="selectionEntry">
+        <entryLink id="b2f4-9cd1-1cd8-890a" name="Inferno pistol" hidden="false" targetId="83f0-56d1-b852-f21c" type="selectionEntry">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -14372,24 +14642,7 @@
           </constraints>
           <categoryLinks/>
         </entryLink>
-        <entryLink id="bf9f-5c81-66af-67a4" name="New EntryLink" hidden="false" targetId="e897-c8fa-0976-e2d3" type="selectionEntry">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers>
-            <modifier type="set" field="points" value="0">
-              <repeats/>
-              <conditions/>
-              <conditionGroups/>
-            </modifier>
-          </modifiers>
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="77b5-e076-8cec-6f6c" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a9d3-d518-31ea-4805" type="max"/>
-          </constraints>
-          <categoryLinks/>
-        </entryLink>
-        <entryLink id="3d47-2ca8-6772-e754" name="New EntryLink" hidden="false" targetId="073b-2de5-765f-a4f2" type="selectionEntry">
+        <entryLink id="3d47-2ca8-6772-e754" name="Frag &amp; Krak grenades" hidden="false" targetId="cddf-945e-1335-e681" type="selectionEntry">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -14406,7 +14659,7 @@
           </constraints>
           <categoryLinks/>
         </entryLink>
-        <entryLink id="0ae6-7855-3af3-aa69" name="" hidden="false" targetId="8eda-5cb2-0c31-56da" type="selectionEntry">
+        <entryLink id="0ae6-7855-3af3-aa69" name="Jump Pack" hidden="false" targetId="8eda-5cb2-0c31-56da" type="selectionEntry">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -14423,6 +14676,60 @@
           </constraints>
           <categoryLinks/>
         </entryLink>
+        <entryLink id="0c1d-0350-6213-1990" name="The Axe Mortalis" hidden="false" targetId="7f2b-f495-384a-6e65" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ef66-69bf-fbcc-2597" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3663-3dbb-a7de-289d" type="max"/>
+          </constraints>
+          <categoryLinks/>
+        </entryLink>
+        <entryLink id="73a7-036f-3eb2-1a20" name="Warlord" hidden="false" targetId="33f6-60da-7b70-5fee" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ef2b-8c96-3cb2-d010" type="max"/>
+          </constraints>
+          <categoryLinks/>
+        </entryLink>
+        <entryLink id="3b00-f354-21ce-ad55" name="4. Heroic Bearing" hidden="true" targetId="f000-3a97-306f-1264" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers>
+            <modifier type="set" field="6d7c-6185-34fa-32a2" value="1">
+              <repeats/>
+              <conditions>
+                <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="33f6-60da-7b70-5fee" type="equalTo"/>
+              </conditions>
+              <conditionGroups/>
+            </modifier>
+            <modifier type="set" field="6e04-c2a6-66cb-ad35" value="1">
+              <repeats/>
+              <conditions>
+                <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="33f6-60da-7b70-5fee" type="equalTo"/>
+              </conditions>
+              <conditionGroups/>
+            </modifier>
+            <modifier type="set" field="hidden" value="false">
+              <repeats/>
+              <conditions>
+                <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="33f6-60da-7b70-5fee" type="equalTo"/>
+              </conditions>
+              <conditionGroups/>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6e04-c2a6-66cb-ad35" type="min"/>
+            <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6d7c-6185-34fa-32a2" type="max"/>
+          </constraints>
+          <categoryLinks/>
+        </entryLink>
       </entryLinks>
       <costs>
         <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="11.0"/>
@@ -14430,20 +14737,10 @@
       </costs>
     </selectionEntry>
     <selectionEntry id="3f18-fc9e-d689-3131" name="Captain Tycho" hidden="false" collective="false" type="model">
-      <profiles>
-        <profile id="88f7-540f-e1a1-a55e" name="Abhor the Beast" hidden="false" profileTypeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" profileTypeName="Abilities">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <characteristics>
-            <characteristic name="Description" characteristicTypeId="21befb24-fc85-4f52-a745-64b2e48f8228" value="Captain Tycho may make D3 additional close combat attacks if he is within 1&quot; of any enemy ORKS after he has piled in during the Fight phase."/>
-          </characteristics>
-        </profile>
-      </profiles>
+      <profiles/>
       <rules/>
       <infoLinks>
-        <infoLink id="a97a-0db4-c530-36df" name="New InfoLink" hidden="false" targetId="8478-3bdd-ee82-fd76" type="profile">
+        <infoLink id="a97a-0db4-c530-36df" name="Captain Tycho" hidden="false" targetId="8478-3bdd-ee82-fd76" type="profile">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -14455,13 +14752,19 @@
           <infoLinks/>
           <modifiers/>
         </infoLink>
-        <infoLink id="2324-9a07-4b0e-39ce" name="Rites of Battle (Blood Angels)" hidden="false" targetId="8d29-f390-ff57-d858" type="profile">
+        <infoLink id="2324-9a07-4b0e-39ce" name="Rites of Battle" hidden="false" targetId="cf04-2c83-f5e1-9fb4" type="profile">
           <profiles/>
           <rules/>
           <infoLinks/>
           <modifiers/>
         </infoLink>
-        <infoLink id="bf75-3162-82fd-48a2" name="New InfoLink" hidden="false" targetId="8742-48fe-7dfc-a1c0" type="profile">
+        <infoLink id="bf75-3162-82fd-48a2" name="Iron Halo" hidden="false" targetId="8742-48fe-7dfc-a1c0" type="profile">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="16ee-024a-9918-826f" name="Abhor the Beast" hidden="false" targetId="7609-c5ba-3a3b-94ec" type="profile">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -14538,42 +14841,10 @@
           <constraints/>
         </categoryLink>
       </categoryLinks>
-      <selectionEntries>
-        <selectionEntry id="5877-417f-ce5b-b5a9" name="Blood Song" hidden="false" collective="false" type="upgrade">
-          <profiles/>
-          <rules/>
-          <infoLinks>
-            <infoLink id="9e54-2026-b878-6bd3" name="New InfoLink" hidden="false" targetId="d6e5-a8cf-4602-28e0" type="profile">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-            </infoLink>
-            <infoLink id="a6d6-cb0e-2428-f52d" name="New InfoLink" hidden="false" targetId="ec4c-1132-ddaf-db8e" type="profile">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-            </infoLink>
-          </infoLinks>
-          <modifiers/>
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="260f-2fde-23c6-5d45" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1c1e-9552-5ca1-aac1" type="max"/>
-          </constraints>
-          <categoryLinks/>
-          <selectionEntries/>
-          <selectionEntryGroups/>
-          <entryLinks/>
-          <costs>
-            <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="0.0"/>
-            <cost name="pts" costTypeId="points" value="0.0"/>
-          </costs>
-        </selectionEntry>
-      </selectionEntries>
+      <selectionEntries/>
       <selectionEntryGroups/>
       <entryLinks>
-        <entryLink id="411a-a078-9b43-ee4c" name="Bolt pistol" hidden="false" targetId="bf86-1c1b-6871-da0b" type="selectionEntry">
+        <entryLink id="411a-a078-9b43-ee4c" name="Bolt pistol" hidden="false" targetId="0334-f487-8229-0c1a" type="selectionEntry">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -14590,24 +14861,7 @@
           </constraints>
           <categoryLinks/>
         </entryLink>
-        <entryLink id="21cb-0edc-ed65-b052" name="New EntryLink" hidden="false" targetId="e897-c8fa-0976-e2d3" type="selectionEntry">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers>
-            <modifier type="set" field="points" value="0">
-              <repeats/>
-              <conditions/>
-              <conditionGroups/>
-            </modifier>
-          </modifiers>
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f7a6-b115-5577-1d5a" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9313-af3b-fce0-4007" type="max"/>
-          </constraints>
-          <categoryLinks/>
-        </entryLink>
-        <entryLink id="e1eb-d7c0-a3f8-fb0a" name="New EntryLink" hidden="false" targetId="073b-2de5-765f-a4f2" type="selectionEntry">
+        <entryLink id="e1eb-d7c0-a3f8-fb0a" name="Frag &amp; Krak grenades" hidden="false" targetId="cddf-945e-1335-e681" type="selectionEntry">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -14624,6 +14878,71 @@
           </constraints>
           <categoryLinks/>
         </entryLink>
+        <entryLink id="9acf-6efd-85c3-c04c" name="Blood Song" hidden="false" targetId="9637-a28b-ff2e-9950" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a907-1860-e58b-5e78" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6bf4-1e90-6d37-229e" type="max"/>
+          </constraints>
+          <categoryLinks/>
+        </entryLink>
+        <entryLink id="0caa-b180-51b0-ce0e" name="Dead Man&apos;s Hand" hidden="false" targetId="28f8-4358-519b-58d2" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a36b-ae8d-e2ea-f3f8" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="069c-83d6-ef81-10d5" type="max"/>
+          </constraints>
+          <categoryLinks/>
+        </entryLink>
+        <entryLink id="41ac-ae83-c6e2-d7f7" name="Warlord" hidden="false" targetId="33f6-60da-7b70-5fee" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ded6-caec-1fd1-5aa7" type="max"/>
+          </constraints>
+          <categoryLinks/>
+        </entryLink>
+        <entryLink id="ce65-f5d6-be1f-e62a" name="6. Selfless Valour" hidden="true" targetId="5aac-e94d-2bcf-c1d1" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers>
+            <modifier type="set" field="4d72-6e25-9c93-6917" value="1">
+              <repeats/>
+              <conditions>
+                <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="33f6-60da-7b70-5fee" type="equalTo"/>
+              </conditions>
+              <conditionGroups/>
+            </modifier>
+            <modifier type="set" field="fcab-ebc1-1923-3563" value="1">
+              <repeats/>
+              <conditions>
+                <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="33f6-60da-7b70-5fee" type="equalTo"/>
+              </conditions>
+              <conditionGroups/>
+            </modifier>
+            <modifier type="set" field="hidden" value="false">
+              <repeats/>
+              <conditions>
+                <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="33f6-60da-7b70-5fee" type="equalTo"/>
+              </conditions>
+              <conditionGroups/>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fcab-ebc1-1923-3563" type="min"/>
+            <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4d72-6e25-9c93-6917" type="max"/>
+          </constraints>
+          <categoryLinks/>
+        </entryLink>
       </entryLinks>
       <costs>
         <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="5.0"/>
@@ -14631,17 +14950,7 @@
       </costs>
     </selectionEntry>
     <selectionEntry id="7dcf-85dd-4c49-df66" name="Tycho the Lost" hidden="false" collective="false" type="model">
-      <profiles>
-        <profile id="caee-0bf7-f970-a744" name="Abhor the Beast" hidden="false" profileTypeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" profileTypeName="Abilities">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <characteristics>
-            <characteristic name="Description" characteristicTypeId="21befb24-fc85-4f52-a745-64b2e48f8228" value="Captain Tycho may make D3 additional close combat attacks if he is within 1&quot; of any enemy ORKS after he has piled in during the Fight phase."/>
-          </characteristics>
-        </profile>
-      </profiles>
+      <profiles/>
       <rules/>
       <infoLinks>
         <infoLink id="7197-34c6-dcb3-10e8" name="Tycho the Lost" hidden="false" targetId="d93a-3422-ab2f-b879" type="profile">
@@ -14663,6 +14972,12 @@
           <modifiers/>
         </infoLink>
         <infoLink id="76c7-5be7-f1ea-1915" name="Iron Halo" hidden="false" targetId="8742-48fe-7dfc-a1c0" type="profile">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="870a-0d69-40cf-d8e2" name="Abhor the Beast" hidden="false" targetId="7609-c5ba-3a3b-94ec" type="profile">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -14739,42 +15054,10 @@
           <constraints/>
         </categoryLink>
       </categoryLinks>
-      <selectionEntries>
-        <selectionEntry id="6b75-2793-cb6d-1338" name="Blood Song" hidden="false" collective="false" type="upgrade">
-          <profiles/>
-          <rules/>
-          <infoLinks>
-            <infoLink id="a01c-fbb3-68f8-a46a" name="New InfoLink" hidden="false" targetId="d6e5-a8cf-4602-28e0" type="profile">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-            </infoLink>
-            <infoLink id="b516-7ad1-1643-1704" name="New InfoLink" hidden="false" targetId="ec4c-1132-ddaf-db8e" type="profile">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-            </infoLink>
-          </infoLinks>
-          <modifiers/>
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="91eb-3cd3-b106-5635" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="043b-8ecc-3202-f7cf" type="max"/>
-          </constraints>
-          <categoryLinks/>
-          <selectionEntries/>
-          <selectionEntryGroups/>
-          <entryLinks/>
-          <costs>
-            <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="0.0"/>
-            <cost name="pts" costTypeId="points" value="0.0"/>
-          </costs>
-        </selectionEntry>
-      </selectionEntries>
+      <selectionEntries/>
       <selectionEntryGroups/>
       <entryLinks>
-        <entryLink id="c80f-e270-1f4b-34c2" name="New EntryLink" hidden="false" targetId="0367-b42c-b6b4-0a58" type="selectionEntry">
+        <entryLink id="c80f-e270-1f4b-34c2" name="Bolt pistol" hidden="false" targetId="37d3-7098-d596-9948" type="selectionEntry">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -14791,24 +15074,7 @@
           </constraints>
           <categoryLinks/>
         </entryLink>
-        <entryLink id="e33c-8bbf-235f-54d8" name="New EntryLink" hidden="false" targetId="e897-c8fa-0976-e2d3" type="selectionEntry">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers>
-            <modifier type="set" field="points" value="0">
-              <repeats/>
-              <conditions/>
-              <conditionGroups/>
-            </modifier>
-          </modifiers>
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b798-a3dd-7959-dae0" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6ba6-7957-cf7a-6953" type="max"/>
-          </constraints>
-          <categoryLinks/>
-        </entryLink>
-        <entryLink id="4443-337e-828e-c481" name="New EntryLink" hidden="false" targetId="073b-2de5-765f-a4f2" type="selectionEntry">
+        <entryLink id="4443-337e-828e-c481" name="Frag &amp; Krak grenades" hidden="false" targetId="cddf-945e-1335-e681" type="selectionEntry">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -14825,6 +15091,71 @@
           </constraints>
           <categoryLinks/>
         </entryLink>
+        <entryLink id="0bd3-ed0e-a588-152f" name="Blood Song" hidden="false" targetId="9637-a28b-ff2e-9950" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0d87-fcd6-1004-edff" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="09b6-41c6-6619-80df" type="max"/>
+          </constraints>
+          <categoryLinks/>
+        </entryLink>
+        <entryLink id="08bf-b619-4a5f-b12a" name="Dead Man&apos;s Hand" hidden="false" targetId="28f8-4358-519b-58d2" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="344b-6361-d487-0262" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2219-43a5-a96c-b9e0" type="max"/>
+          </constraints>
+          <categoryLinks/>
+        </entryLink>
+        <entryLink id="1817-85b1-5122-6423" name="Warlord" hidden="false" targetId="33f6-60da-7b70-5fee" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b350-b4bb-65ba-3023" type="max"/>
+          </constraints>
+          <categoryLinks/>
+        </entryLink>
+        <entryLink id="9ecc-09b1-8568-be31" name="6. Selfless Valour" hidden="true" targetId="5aac-e94d-2bcf-c1d1" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers>
+            <modifier type="set" field="cf61-1e0c-7029-4b1d" value="1">
+              <repeats/>
+              <conditions>
+                <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="33f6-60da-7b70-5fee" type="equalTo"/>
+              </conditions>
+              <conditionGroups/>
+            </modifier>
+            <modifier type="set" field="59b8-b5d7-6af2-f050" value="1">
+              <repeats/>
+              <conditions>
+                <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="33f6-60da-7b70-5fee" type="equalTo"/>
+              </conditions>
+              <conditionGroups/>
+            </modifier>
+            <modifier type="set" field="hidden" value="false">
+              <repeats/>
+              <conditions>
+                <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="33f6-60da-7b70-5fee" type="equalTo"/>
+              </conditions>
+              <conditionGroups/>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="cf61-1e0c-7029-4b1d" type="min"/>
+            <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="59b8-b5d7-6af2-f050" type="max"/>
+          </constraints>
+          <categoryLinks/>
+        </entryLink>
       </entryLinks>
       <costs>
         <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="4.0"/>
@@ -14833,7 +15164,7 @@
     </selectionEntry>
     <selectionEntry id="323b-4eb4-e725-1fdc" name="Librarian Dreadnought" hidden="false" collective="false" type="model">
       <profiles>
-        <profile id="91ec-0970-42b1-7fc4" name="Librarian Dreadnought" hidden="false" profileTypeId="bc97-dea9-9e88-bb7d" profileTypeName="Psyker">
+        <profile id="91ec-0970-42b1-7fc4" name="Psyker" hidden="false" profileTypeId="bc97-dea9-9e88-bb7d" profileTypeName="Psyker">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -14845,19 +15176,21 @@
             <characteristic name="Other" characteristicTypeId="c2e2-f115-0003-5d7b" value=""/>
           </characteristics>
         </profile>
-        <profile id="2f17-f189-0537-cc10" name="Explodes" hidden="false" profileTypeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" profileTypeName="Abilities">
+        <profile id="2f17-f189-0537-cc10" name="Explodes" hidden="false" profileTypeId="818c-0db1-36f0-462a" profileTypeName="Explosion">
           <profiles/>
           <rules/>
           <infoLinks/>
           <modifiers/>
           <characteristics>
-            <characteristic name="Description" characteristicTypeId="21befb24-fc85-4f52-a745-64b2e48f8228" value="If this model is reduced to 0 wounds, roll a D6 before removing the model from the battlefield; on a 6 it explodes, and each unit within 3&quot; suffers D3 mortal wounds."/>
+            <characteristic name="Dice roll" characteristicTypeId="f21d-8f6d-180d-36ff" value="6"/>
+            <characteristic name="Distance" characteristicTypeId="d69e-be07-1682-ebcc" value="3&quot;"/>
+            <characteristic name="Mortal wounds" characteristicTypeId="29f1-65a1-2c5d-8c7d" value="D3"/>
           </characteristics>
         </profile>
       </profiles>
       <rules/>
       <infoLinks>
-        <infoLink id="385d-3149-1090-f0ae" name="New InfoLink" hidden="false" targetId="953d-6184-eb9c-eef0" type="profile">
+        <infoLink id="385d-3149-1090-f0ae" name="Librarian Dreadnought" hidden="false" targetId="953d-6184-eb9c-eef0" type="profile">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -14875,7 +15208,7 @@
           <infoLinks/>
           <modifiers/>
         </infoLink>
-        <infoLink id="4388-fff2-bc1a-d38c" name="New InfoLink" hidden="false" targetId="c883-3078-1367-cc2c" type="profile">
+        <infoLink id="4388-fff2-bc1a-d38c" name="Smoke Launchers" hidden="false" targetId="c883-3078-1367-cc2c" type="profile">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -14971,7 +15304,7 @@
           <selectionEntries/>
           <selectionEntryGroups/>
           <entryLinks>
-            <entryLink id="73d9-fe85-966f-71f1" name="New EntryLink" hidden="false" targetId="7eb4-1d78-9058-f71a" type="selectionEntry">
+            <entryLink id="73d9-fe85-966f-71f1" name="Heavy flamer" hidden="false" targetId="18bc-b335-29c2-2ae2" type="selectionEntry">
               <profiles/>
               <rules/>
               <infoLinks/>
@@ -14981,7 +15314,7 @@
               </constraints>
               <categoryLinks/>
             </entryLink>
-            <entryLink id="3431-b2ed-1b87-66bb" name="New EntryLink" hidden="false" targetId="9ec1-5584-a623-fdda" type="selectionEntry">
+            <entryLink id="3431-b2ed-1b87-66bb" name="Meltagun" hidden="false" targetId="efc8-c51d-5b02-a3a2" type="selectionEntry">
               <profiles/>
               <rules/>
               <infoLinks/>
@@ -14991,7 +15324,7 @@
               </constraints>
               <categoryLinks/>
             </entryLink>
-            <entryLink id="7f14-6723-9cfa-6e77" name="New EntryLink" hidden="false" targetId="d74a-2fee-abea-1b42" type="selectionEntry">
+            <entryLink id="7f14-6723-9cfa-6e77" name="Storm bolter" hidden="false" targetId="2b03-8d64-3711-f300" type="selectionEntry">
               <profiles/>
               <rules/>
               <infoLinks/>
@@ -15059,15 +15392,41 @@
           </constraints>
           <categoryLinks/>
         </entryLink>
+        <entryLink id="d52c-d1f6-efd5-7132" name="Warlord" hidden="false" targetId="33f6-60da-7b70-5fee" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3278-860f-b266-e8d5" type="max"/>
+          </constraints>
+          <categoryLinks/>
+        </entryLink>
+        <entryLink id="b992-407a-9b58-dd36" name="Warlord Traits" hidden="false" targetId="c25d-2fbc-47b3-9e39" type="selectionEntryGroup">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+          <categoryLinks/>
+        </entryLink>
+        <entryLink id="f49b-6530-acfa-c5e3" name="Relics of Baal" hidden="false" targetId="441f-1714-0777-c202" type="selectionEntryGroup">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+          <categoryLinks/>
+        </entryLink>
       </entryLinks>
       <costs>
-        <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="10.0"/>
-        <cost name="pts" costTypeId="points" value="150.0"/>
+        <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="9.0"/>
+        <cost name="pts" costTypeId="points" value="130.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="4117-4646-9676-f09e" name="Chief Librarian Mephiston" hidden="false" collective="false" type="model">
       <profiles>
-        <profile id="d9b8-626d-3ccb-0105" name="Chief Librarian Mephiston" hidden="false" profileTypeId="bc97-dea9-9e88-bb7d" profileTypeName="Psyker">
+        <profile id="d9b8-626d-3ccb-0105" name="Psyker" hidden="false" profileTypeId="bc97-dea9-9e88-bb7d" profileTypeName="Psyker">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -15077,15 +15436,6 @@
             <characteristic name="Deny" characteristicTypeId="b5ac-9c20-5d5a-6f9b" value="2"/>
             <characteristic name="Powers Known" characteristicTypeId="69d7-b45e-00a2-7e46" value="Smite and three psychic powers from the Sanguinary discipline"/>
             <characteristic name="Other" characteristicTypeId="c2e2-f115-0003-5d7b" value=""/>
-          </characteristics>
-        </profile>
-        <profile id="b29b-d431-5d1e-0d7e" name="Lord of Death" hidden="false" profileTypeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" profileTypeName="Abilities">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <characteristics>
-            <characteristic name="Description" characteristicTypeId="21befb24-fc85-4f52-a745-64b2e48f8228" value="Each time Chief Librarian Mephiston suffers an unsaved wound or a mortal wound roll a D6. On a 5+ the damage is ignored."/>
           </characteristics>
         </profile>
       </profiles>
@@ -15179,33 +15529,7 @@
           <constraints/>
         </categoryLink>
       </categoryLinks>
-      <selectionEntries>
-        <selectionEntry id="069d-91d6-d7d7-c9bd" name="The Sanguine Sword" hidden="false" collective="false" type="upgrade">
-          <profiles/>
-          <rules/>
-          <infoLinks>
-            <infoLink id="c044-298f-cac9-169e" name="New InfoLink" hidden="false" targetId="d858-97ac-1795-e4a0" type="profile">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-            </infoLink>
-          </infoLinks>
-          <modifiers/>
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="704a-a932-e20f-cc7b" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8953-e7e7-01bc-d060" type="max"/>
-          </constraints>
-          <categoryLinks/>
-          <selectionEntries/>
-          <selectionEntryGroups/>
-          <entryLinks/>
-          <costs>
-            <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="0.0"/>
-            <cost name="pts" costTypeId="points" value="0.0"/>
-          </costs>
-        </selectionEntry>
-      </selectionEntries>
+      <selectionEntries/>
       <selectionEntryGroups>
         <selectionEntryGroup id="bea2-6487-c3c8-c599" name="Psychic powers summary" hidden="false" collective="false">
           <profiles/>
@@ -15217,7 +15541,7 @@
           <selectionEntries/>
           <selectionEntryGroups/>
           <entryLinks>
-            <entryLink id="5e56-2483-5313-c084" name="New EntryLink" hidden="false" targetId="3043-848f-e165-d00e" type="selectionEntry">
+            <entryLink id="5e56-2483-5313-c084" name="Sanguinary Discipline" hidden="false" targetId="3043-848f-e165-d00e" type="selectionEntry">
               <profiles/>
               <rules/>
               <infoLinks/>
@@ -15227,7 +15551,7 @@
               </constraints>
               <categoryLinks/>
             </entryLink>
-            <entryLink id="ea40-0322-7b10-0cf8" name="New EntryLink" hidden="false" targetId="03fd-db47-5333-1e1f" type="selectionEntry">
+            <entryLink id="ea40-0322-7b10-0cf8" name="Smite" hidden="false" targetId="03fd-db47-5333-1e1f" type="selectionEntry">
               <profiles/>
               <rules/>
               <infoLinks/>
@@ -15241,7 +15565,7 @@
         </selectionEntryGroup>
       </selectionEntryGroups>
       <entryLinks>
-        <entryLink id="c589-c0e1-f10a-5b3b" name="Plasma pistol" hidden="false" targetId="b333-4c80-2f72-6b45" type="selectionEntry">
+        <entryLink id="c589-c0e1-f10a-5b3b" name="Plasma pistol" hidden="false" targetId="83be-1ba9-c326-4760" type="selectionEntry">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -15258,24 +15582,7 @@
           </constraints>
           <categoryLinks/>
         </entryLink>
-        <entryLink id="489f-e776-beb4-35e5" name="" hidden="false" targetId="e897-c8fa-0976-e2d3" type="selectionEntry">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers>
-            <modifier type="set" field="points" value="0.0">
-              <repeats/>
-              <conditions/>
-              <conditionGroups/>
-            </modifier>
-          </modifiers>
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ffff-27b4-1981-dfbe" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="db1d-6695-3fdf-9bf7" type="max"/>
-          </constraints>
-          <categoryLinks/>
-        </entryLink>
-        <entryLink id="623d-b535-8afd-9d7c" name="" hidden="false" targetId="073b-2de5-765f-a4f2" type="selectionEntry">
+        <entryLink id="623d-b535-8afd-9d7c" name="Frag &amp; Krak grenades" hidden="false" targetId="cddf-945e-1335-e681" type="selectionEntry">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -15292,6 +15599,60 @@
           </constraints>
           <categoryLinks/>
         </entryLink>
+        <entryLink id="4445-5b0d-2102-8357" name="The Sanguine Sword" hidden="false" targetId="7800-6ae0-8f4e-4330" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="31e2-bff3-8349-3cd6" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="67e4-9a6a-ec78-8b3a" type="max"/>
+          </constraints>
+          <categoryLinks/>
+        </entryLink>
+        <entryLink id="0b84-795b-46d3-a2dd" name="Warlord" hidden="false" targetId="33f6-60da-7b70-5fee" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a31a-6cb3-793e-7551" type="max"/>
+          </constraints>
+          <categoryLinks/>
+        </entryLink>
+        <entryLink id="4d28-32d6-5240-abd4" name="1. Speed of the Primarch" hidden="true" targetId="2ec6-a5f9-9dc1-93e5" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers>
+            <modifier type="set" field="8f07-decf-f2c6-bc8e" value="1">
+              <repeats/>
+              <conditions>
+                <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="33f6-60da-7b70-5fee" type="equalTo"/>
+              </conditions>
+              <conditionGroups/>
+            </modifier>
+            <modifier type="set" field="e7e0-7779-bee6-c2d2" value="1">
+              <repeats/>
+              <conditions>
+                <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="33f6-60da-7b70-5fee" type="equalTo"/>
+              </conditions>
+              <conditionGroups/>
+            </modifier>
+            <modifier type="set" field="hidden" value="false">
+              <repeats/>
+              <conditions>
+                <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="33f6-60da-7b70-5fee" type="equalTo"/>
+              </conditions>
+              <conditionGroups/>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e7e0-7779-bee6-c2d2" type="min"/>
+            <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8f07-decf-f2c6-bc8e" type="max"/>
+          </constraints>
+          <categoryLinks/>
+        </entryLink>
       </entryLinks>
       <costs>
         <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="8.0"/>
@@ -15299,26 +15660,7 @@
       </costs>
     </selectionEntry>
     <selectionEntry id="b93b-c150-9a0d-804c" name="The Sanguinor" hidden="false" collective="false" type="model">
-      <profiles>
-        <profile id="f409-0e74-f45d-79e0" name="Aura of Fervour" hidden="false" profileTypeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" profileTypeName="Abilities">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <characteristics>
-            <characteristic name="Description" characteristicTypeId="21befb24-fc85-4f52-a745-64b2e48f8228" value="You can add 1 to the Attacks characteristic of friendly BLOOD ANGELS INFANTRY units within 6&quot; of the Sanguinor."/>
-          </characteristics>
-        </profile>
-        <profile id="978b-d6c8-6386-036e" name="Avenging Angel" hidden="false" profileTypeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" profileTypeName="Abilities">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <characteristics>
-            <characteristic name="Description" characteristicTypeId="21befb24-fc85-4f52-a745-64b2e48f8228" value="The Sanguinor can charge even if he Fell Back in the preceding Movement phase."/>
-          </characteristics>
-        </profile>
-      </profiles>
+      <profiles/>
       <rules/>
       <infoLinks>
         <infoLink id="a851-4dcb-c24f-ce80" name="The Sanguinor" hidden="false" targetId="6de9-4f8a-8273-e63d" type="profile">
@@ -15334,6 +15676,18 @@
           <modifiers/>
         </infoLink>
         <infoLink id="ecb3-8b43-da7f-ac1a" name="Iron Halo" hidden="false" targetId="8742-48fe-7dfc-a1c0" type="profile">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="eeb3-5378-9724-11ce" name="Aura of Fervour" hidden="false" targetId="864f-d20b-8a6f-68a2" type="profile">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="134e-99c9-5f35-05ca" name="Avenging Angel" hidden="false" targetId="14a9-adb9-2854-d505" type="profile">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -15409,53 +15763,10 @@
           <constraints/>
         </categoryLink>
       </categoryLinks>
-      <selectionEntries>
-        <selectionEntry id="7d72-355d-4129-6979" name="Encarmine broadsword" hidden="false" collective="false" type="upgrade">
-          <profiles/>
-          <rules/>
-          <infoLinks>
-            <infoLink id="ad21-f755-a3f5-35c8" name="New InfoLink" hidden="false" targetId="01b7-752b-4a84-fdee" type="profile">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-            </infoLink>
-          </infoLinks>
-          <modifiers/>
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1957-5324-9e51-5d65" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7444-6829-4542-4bbe" type="max"/>
-          </constraints>
-          <categoryLinks/>
-          <selectionEntries/>
-          <selectionEntryGroups/>
-          <entryLinks/>
-          <costs>
-            <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="0.0"/>
-            <cost name="pts" costTypeId="points" value="0.0"/>
-          </costs>
-        </selectionEntry>
-      </selectionEntries>
+      <selectionEntries/>
       <selectionEntryGroups/>
       <entryLinks>
-        <entryLink id="5be9-8843-1590-4e05" name="" hidden="false" targetId="e897-c8fa-0976-e2d3" type="selectionEntry">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers>
-            <modifier type="set" field="points" value="0.0">
-              <repeats/>
-              <conditions/>
-              <conditionGroups/>
-            </modifier>
-          </modifiers>
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="10a2-f4c8-4c82-c041" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e85d-a0d2-63ec-7e81" type="max"/>
-          </constraints>
-          <categoryLinks/>
-        </entryLink>
-        <entryLink id="24c6-8dbf-4ece-4b70" name="" hidden="false" targetId="073b-2de5-765f-a4f2" type="selectionEntry">
+        <entryLink id="24c6-8dbf-4ece-4b70" name="Frag &amp; Krak grenades" hidden="false" targetId="cddf-945e-1335-e681" type="selectionEntry">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -15472,7 +15783,7 @@
           </constraints>
           <categoryLinks/>
         </entryLink>
-        <entryLink id="1c94-2ae4-e77f-d421" name="" hidden="false" targetId="2f38-7256-aeae-fc13" type="selectionEntry">
+        <entryLink id="1c94-2ae4-e77f-d421" name="Death mask" hidden="false" targetId="2f38-7256-aeae-fc13" type="selectionEntry">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -15506,6 +15817,60 @@
           </constraints>
           <categoryLinks/>
         </entryLink>
+        <entryLink id="38f7-e880-a057-27d8" name="Encarmine broadsword" hidden="false" targetId="7be2-e824-4848-0e2a" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="69bc-6343-dad0-14a7" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="02cf-e747-a779-3312" type="max"/>
+          </constraints>
+          <categoryLinks/>
+        </entryLink>
+        <entryLink id="0ae9-1d2e-239e-c413" name="Warlord" hidden="false" targetId="33f6-60da-7b70-5fee" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d6a5-ce7a-396a-65e5" type="max"/>
+          </constraints>
+          <categoryLinks/>
+        </entryLink>
+        <entryLink id="0e84-3bdc-f1cf-b423" name="4. Heroic Bearing" hidden="true" targetId="f000-3a97-306f-1264" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers>
+            <modifier type="set" field="82c1-ad20-c027-3130" value="1">
+              <repeats/>
+              <conditions>
+                <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="33f6-60da-7b70-5fee" type="equalTo"/>
+              </conditions>
+              <conditionGroups/>
+            </modifier>
+            <modifier type="set" field="e823-5f8d-1477-9980" value="1">
+              <repeats/>
+              <conditions>
+                <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="33f6-60da-7b70-5fee" type="equalTo"/>
+              </conditions>
+              <conditionGroups/>
+            </modifier>
+            <modifier type="set" field="hidden" value="false">
+              <repeats/>
+              <conditions>
+                <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="33f6-60da-7b70-5fee" type="equalTo"/>
+              </conditions>
+              <conditionGroups/>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e823-5f8d-1477-9980" type="min"/>
+            <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="82c1-ad20-c027-3130" type="max"/>
+          </constraints>
+          <categoryLinks/>
+        </entryLink>
       </entryLinks>
       <costs>
         <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="9.0"/>
@@ -15513,26 +15878,7 @@
       </costs>
     </selectionEntry>
     <selectionEntry id="d3c0-214a-dd06-b140" name="Astorath" hidden="false" collective="false" type="model">
-      <profiles>
-        <profile id="6d90-c0bc-a6f7-4100" name="Redeemer of the Lost" hidden="false" profileTypeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" profileTypeName="Abilities">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <characteristics>
-            <characteristic name="Description" characteristicTypeId="21befb24-fc85-4f52-a745-64b2e48f8228" value="All friendly BLOOD ANGELS units within 6&quot; of Astorath can use his Leadership instead of their own. In addition, friendly DEATH COMPANY units automatically pass Morale tests if they are within 6&quot; of Astorath."/>
-          </characteristics>
-        </profile>
-        <profile id="0f9d-d5d0-8746-1db5" name="Mass of Doom" hidden="false" profileTypeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" profileTypeName="Abilities">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <characteristics>
-            <characteristic name="Description" characteristicTypeId="21befb24-fc85-4f52-a745-64b2e48f8228" value="Once per battle, at the start of your Movement phase, Astorath may chant the Mass of Doom. Roll a D6 for each friendly BLOOD ANGELS INFANTRY unit within 6&quot; of Astorath and apply the result below:  1 - Frenzied Death Throes: The unit suffers a mortal wound. 2-5 - Dark Wrath: You can add 1 to hit rolls made for this unit in the Fight phase until the end of your turn. 6 - Vessel of Sanguinius: You can add 1 to hit rolls made for this unit in the Fight phase until the end of your turn. In addition, the unit has a 4+ invulnerable save until the end of your turn."/>
-          </characteristics>
-        </profile>
-      </profiles>
+      <profiles/>
       <rules/>
       <infoLinks>
         <infoLink id="ef9c-e469-fa95-bcd3" name="Astorath" hidden="false" targetId="e4da-df0a-d51b-10ee" type="profile">
@@ -15553,7 +15899,19 @@
           <infoLinks/>
           <modifiers/>
         </infoLink>
-        <infoLink id="9266-ed63-b278-ea99" name="Litanies of Hate (Blood Angels)" hidden="false" targetId="8697-90ba-a77e-22ab" type="profile">
+        <infoLink id="9266-ed63-b278-ea99" name="Litanies of Hate" hidden="false" targetId="5aec-11fa-8ca0-f951" type="profile">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="3eaa-bf18-c15d-fa38" name="Redeemer of the Lost" hidden="false" targetId="a67d-7d3e-07a2-fdd1" type="profile">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="556f-6d27-e208-b8a3" name="Mass of Doom" hidden="false" targetId="f290-bf22-5e14-e8c1" type="profile">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -15636,53 +15994,10 @@
           <constraints/>
         </categoryLink>
       </categoryLinks>
-      <selectionEntries>
-        <selectionEntry id="6000-6476-ef8a-8687" name="The Executioner&apos;s Axe" hidden="false" collective="false" type="upgrade">
-          <profiles/>
-          <rules/>
-          <infoLinks>
-            <infoLink id="b2ef-ec17-7a61-0cfa" name="New InfoLink" hidden="false" targetId="e42a-8c10-b370-1325" type="profile">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-            </infoLink>
-          </infoLinks>
-          <modifiers/>
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9785-850a-201e-05b2" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4fbf-85e4-1988-e84e" type="max"/>
-          </constraints>
-          <categoryLinks/>
-          <selectionEntries/>
-          <selectionEntryGroups/>
-          <entryLinks/>
-          <costs>
-            <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="0.0"/>
-            <cost name="pts" costTypeId="points" value="0.0"/>
-          </costs>
-        </selectionEntry>
-      </selectionEntries>
+      <selectionEntries/>
       <selectionEntryGroups/>
       <entryLinks>
-        <entryLink id="804b-1c63-3bfe-4371" name="" hidden="false" targetId="e897-c8fa-0976-e2d3" type="selectionEntry">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers>
-            <modifier type="set" field="points" value="0.0">
-              <repeats/>
-              <conditions/>
-              <conditionGroups/>
-            </modifier>
-          </modifiers>
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="cbdb-8602-2f55-3d87" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="431e-b05f-7caf-0f2f" type="max"/>
-          </constraints>
-          <categoryLinks/>
-        </entryLink>
-        <entryLink id="0ea8-b663-9e80-7557" name="" hidden="false" targetId="073b-2de5-765f-a4f2" type="selectionEntry">
+        <entryLink id="0ea8-b663-9e80-7557" name="Frag &amp; Krak grenades" hidden="false" targetId="cddf-945e-1335-e681" type="selectionEntry">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -15699,7 +16014,7 @@
           </constraints>
           <categoryLinks/>
         </entryLink>
-        <entryLink id="6770-b202-b4fa-8a35" name="" hidden="false" targetId="0367-b42c-b6b4-0a58" type="selectionEntry">
+        <entryLink id="6770-b202-b4fa-8a35" name="Bolt pistol" hidden="false" targetId="37d3-7098-d596-9948" type="selectionEntry">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -15716,7 +16031,7 @@
           </constraints>
           <categoryLinks/>
         </entryLink>
-        <entryLink id="1c99-9b9d-1a8a-11ca" name="" hidden="false" targetId="8eda-5cb2-0c31-56da" type="selectionEntry">
+        <entryLink id="1c99-9b9d-1a8a-11ca" name="Jump Pack" hidden="false" targetId="8eda-5cb2-0c31-56da" type="selectionEntry">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -15730,6 +16045,60 @@
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="03d5-df0b-4ada-d979" type="min"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5fc1-7a82-a7cb-8da1" type="max"/>
+          </constraints>
+          <categoryLinks/>
+        </entryLink>
+        <entryLink id="5914-47dc-c2c0-80ca" name="The Executioner&apos;s Axe" hidden="false" targetId="fec3-9185-e75c-d57d" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="99f8-5af3-dda9-df4a" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c658-73f2-2406-667d" type="max"/>
+          </constraints>
+          <categoryLinks/>
+        </entryLink>
+        <entryLink id="4ea4-7867-e2df-a7ad" name="Warlord" hidden="false" targetId="33f6-60da-7b70-5fee" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6739-be0a-d476-0185" type="max"/>
+          </constraints>
+          <categoryLinks/>
+        </entryLink>
+        <entryLink id="95c0-9e3f-5c9f-603e" name="3. Soulwarden" hidden="true" targetId="58d2-aee8-1337-a246" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers>
+            <modifier type="set" field="e551-cb48-7ebf-bf45" value="1">
+              <repeats/>
+              <conditions>
+                <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="33f6-60da-7b70-5fee" type="equalTo"/>
+              </conditions>
+              <conditionGroups/>
+            </modifier>
+            <modifier type="set" field="b244-d9b8-ac21-388c" value="1">
+              <repeats/>
+              <conditions>
+                <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="33f6-60da-7b70-5fee" type="equalTo"/>
+              </conditions>
+              <conditionGroups/>
+            </modifier>
+            <modifier type="set" field="hidden" value="false">
+              <repeats/>
+              <conditions>
+                <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="33f6-60da-7b70-5fee" type="equalTo"/>
+              </conditions>
+              <conditionGroups/>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e551-cb48-7ebf-bf45" type="min"/>
+            <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b244-d9b8-ac21-388c" type="max"/>
           </constraints>
           <categoryLinks/>
         </entryLink>
@@ -15749,7 +16118,7 @@
           <infoLinks/>
           <modifiers/>
         </infoLink>
-        <infoLink id="963d-583d-d6e0-fae0" name="New InfoLink" hidden="false" targetId="ec15-683f-e88e-e642" type="profile">
+        <infoLink id="963d-583d-d6e0-fae0" name="Sanguinary Priest" hidden="false" targetId="ec15-683f-e88e-e642" type="profile">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -15844,7 +16213,7 @@
           <selectionEntries/>
           <selectionEntryGroups/>
           <entryLinks>
-            <entryLink id="28b6-bbfd-1fc7-07b0" name="Bolt pistol" hidden="false" targetId="bf86-1c1b-6871-da0b" type="selectionEntry">
+            <entryLink id="28b6-bbfd-1fc7-07b0" name="Bolt pistol" hidden="false" targetId="0334-f487-8229-0c1a" type="selectionEntry">
               <profiles/>
               <rules/>
               <infoLinks/>
@@ -15854,7 +16223,7 @@
               </constraints>
               <categoryLinks/>
             </entryLink>
-            <entryLink id="f5d2-5165-0605-c9fd" name="Boltgun" hidden="false" targetId="8e23-a2e7-23c4-cac7" type="selectionEntry">
+            <entryLink id="f5d2-5165-0605-c9fd" name="Boltgun" hidden="false" targetId="b61f-a3c1-827d-c5b6" type="selectionEntry">
               <profiles/>
               <rules/>
               <infoLinks/>
@@ -15884,7 +16253,7 @@
               </constraints>
               <categoryLinks/>
             </entryLink>
-            <entryLink id="6b36-60c6-7f0d-f842" name="New EntryLink" hidden="false" targetId="ed23-9d40-c441-5d0d" type="selectionEntryGroup">
+            <entryLink id="6b36-60c6-7f0d-f842" name="Melee weapons" hidden="false" targetId="ed23-9d40-c441-5d0d" type="selectionEntryGroup">
               <profiles/>
               <rules/>
               <infoLinks/>
@@ -15898,18 +16267,7 @@
         </selectionEntryGroup>
       </selectionEntryGroups>
       <entryLinks>
-        <entryLink id="33e7-c7fe-6e90-3e21" name="New EntryLink" hidden="false" targetId="e897-c8fa-0976-e2d3" type="selectionEntry">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4c7c-8e68-60a5-841c" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f0b2-eeb2-587d-efa0" type="max"/>
-          </constraints>
-          <categoryLinks/>
-        </entryLink>
-        <entryLink id="265a-986d-c3a2-401c" name="New EntryLink" hidden="false" targetId="073b-2de5-765f-a4f2" type="selectionEntry">
+        <entryLink id="265a-986d-c3a2-401c" name="Frag &amp; Krak grenades" hidden="false" targetId="cddf-945e-1335-e681" type="selectionEntry">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -15960,6 +16318,32 @@
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ee56-9f48-487a-051c" type="min"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="00ea-9355-5497-a0c9" type="max"/>
           </constraints>
+          <categoryLinks/>
+        </entryLink>
+        <entryLink id="dd72-9760-c319-9575" name="Warlord" hidden="false" targetId="33f6-60da-7b70-5fee" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f0aa-f57c-6d1f-06fd" type="max"/>
+          </constraints>
+          <categoryLinks/>
+        </entryLink>
+        <entryLink id="dfdd-6bf6-adec-3d18" name="Warlord Traits" hidden="false" targetId="c25d-2fbc-47b3-9e39" type="selectionEntryGroup">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+          <categoryLinks/>
+        </entryLink>
+        <entryLink id="9dc5-220f-f3c8-86e2" name="Relics of Baal" hidden="false" targetId="441f-1714-0777-c202" type="selectionEntryGroup">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
           <categoryLinks/>
         </entryLink>
       </entryLinks>
@@ -16071,7 +16455,7 @@
           <selectionEntries/>
           <selectionEntryGroups/>
           <entryLinks>
-            <entryLink id="0382-3c7a-8745-ea75" name="Bolt pistol" hidden="false" targetId="bf86-1c1b-6871-da0b" type="selectionEntry">
+            <entryLink id="0382-3c7a-8745-ea75" name="Bolt pistol" hidden="false" targetId="0334-f487-8229-0c1a" type="selectionEntry">
               <profiles/>
               <rules/>
               <infoLinks/>
@@ -16081,7 +16465,7 @@
               </constraints>
               <categoryLinks/>
             </entryLink>
-            <entryLink id="e663-6d0a-09de-d290" name="Boltgun" hidden="false" targetId="8e23-a2e7-23c4-cac7" type="selectionEntry">
+            <entryLink id="e663-6d0a-09de-d290" name="Boltgun" hidden="false" targetId="b61f-a3c1-827d-c5b6" type="selectionEntry">
               <profiles/>
               <rules/>
               <infoLinks/>
@@ -16125,18 +16509,7 @@
         </selectionEntryGroup>
       </selectionEntryGroups>
       <entryLinks>
-        <entryLink id="e520-0ee8-2923-a850" name="New EntryLink" hidden="false" targetId="e897-c8fa-0976-e2d3" type="selectionEntry">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="82f6-c31b-5a71-0182" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="78be-8bec-0249-0e3c" type="max"/>
-          </constraints>
-          <categoryLinks/>
-        </entryLink>
-        <entryLink id="90e1-fbd0-2040-b5a7" name="New EntryLink" hidden="false" targetId="073b-2de5-765f-a4f2" type="selectionEntry">
+        <entryLink id="90e1-fbd0-2040-b5a7" name="Frag &amp; Krak grenades" hidden="false" targetId="cddf-945e-1335-e681" type="selectionEntry">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -16158,6 +16531,32 @@
           </constraints>
           <categoryLinks/>
         </entryLink>
+        <entryLink id="1177-5b96-7212-8bea" name="Warlord" hidden="false" targetId="33f6-60da-7b70-5fee" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2fbf-edc5-c510-8e30" type="max"/>
+          </constraints>
+          <categoryLinks/>
+        </entryLink>
+        <entryLink id="4ccd-b78c-d5cb-9bdd" name="Warlord Traits" hidden="false" targetId="c25d-2fbc-47b3-9e39" type="selectionEntryGroup">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+          <categoryLinks/>
+        </entryLink>
+        <entryLink id="816c-1350-f629-1e57" name="Relics of Baal" hidden="false" targetId="441f-1714-0777-c202" type="selectionEntryGroup">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+          <categoryLinks/>
+        </entryLink>
       </entryLinks>
       <costs>
         <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="6.0"/>
@@ -16165,26 +16564,7 @@
       </costs>
     </selectionEntry>
     <selectionEntry id="6c94-843b-6d57-359a" name="Brother Corbulo" hidden="false" collective="false" type="model">
-      <profiles>
-        <profile id="3727-85c4-0a30-1b47" name="Far-Seeing Eye" hidden="false" profileTypeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" profileTypeName="Abilities">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <characteristics>
-            <characteristic name="Description" characteristicTypeId="21befb24-fc85-4f52-a745-64b2e48f8228" value="Once per turn you can re-roll a single dice roll made for Brother Corbulo."/>
-          </characteristics>
-        </profile>
-        <profile id="8a17-bd02-9745-fba5" name="The Red Grail" hidden="false" profileTypeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" profileTypeName="Abilities">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <characteristics>
-            <characteristic name="Description" characteristicTypeId="21befb24-fc85-4f52-a745-64b2e48f8228" value="Friendly BLOOD ANGELS INFANTRY and BIKER units increase their Strength characteristic by 1 whilst they are within 6&quot; of any SANGUINARY PRIESTS. In addition, each time you make a hit roll of 6+ in the Fight phase for a model in a friendly BLOOD ANGELS unit that is within 6&quot; of Brother Corbulo, that model may immediately make another close combat attack using the same weapons. These bonus attacks cannot themselves generate any additional close combat attacks."/>
-          </characteristics>
-        </profile>
-      </profiles>
+      <profiles/>
       <rules/>
       <infoLinks>
         <infoLink id="0ac1-da10-0226-7966" name="Brother Corbulo" hidden="false" targetId="9148-9168-71bb-9ca3" type="profile">
@@ -16199,7 +16579,19 @@
           <infoLinks/>
           <modifiers/>
         </infoLink>
-        <infoLink id="1abf-4765-0833-6eeb" name="Narthecium (Blood Angels)" hidden="false" targetId="009e-0690-8de7-0d28" type="profile">
+        <infoLink id="1abf-4765-0833-6eeb" name="Narthecium" hidden="false" targetId="476b-ab90-c1b2-0c9d" type="profile">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="692b-7ea4-1c12-9b4e" name="Far-Seeing Eye" hidden="false" targetId="7d74-8891-217b-ed7c" type="profile">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="ca01-d274-9655-7656" name="The Red Grail" hidden="false" targetId="d7cf-f036-a3b4-1551" type="profile">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -16268,36 +16660,10 @@
           <constraints/>
         </categoryLink>
       </categoryLinks>
-      <selectionEntries>
-        <selectionEntry id="da80-33ae-f30b-0c67" name="Heaven&apos;s Teeth" hidden="false" collective="false" type="upgrade">
-          <profiles/>
-          <rules/>
-          <infoLinks>
-            <infoLink id="1da5-2329-46d1-b8e9" name="New InfoLink" hidden="false" targetId="1e86-60cc-27f7-4b48" type="profile">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-            </infoLink>
-          </infoLinks>
-          <modifiers/>
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3994-eb72-9893-6adb" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d085-9d15-bd48-2291" type="max"/>
-          </constraints>
-          <categoryLinks/>
-          <selectionEntries/>
-          <selectionEntryGroups/>
-          <entryLinks/>
-          <costs>
-            <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="0.0"/>
-            <cost name="pts" costTypeId="points" value="0.0"/>
-          </costs>
-        </selectionEntry>
-      </selectionEntries>
+      <selectionEntries/>
       <selectionEntryGroups/>
       <entryLinks>
-        <entryLink id="1fd0-85e1-965e-c180" name="Bolt pistol" hidden="false" targetId="bf86-1c1b-6871-da0b" type="selectionEntry">
+        <entryLink id="1fd0-85e1-965e-c180" name="Bolt pistol" hidden="false" targetId="0334-f487-8229-0c1a" type="selectionEntry">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -16314,24 +16680,7 @@
           </constraints>
           <categoryLinks/>
         </entryLink>
-        <entryLink id="7605-69fb-968f-f91b" name="Frag grenade" hidden="false" targetId="e897-c8fa-0976-e2d3" type="selectionEntry">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers>
-            <modifier type="set" field="points" value="0">
-              <repeats/>
-              <conditions/>
-              <conditionGroups/>
-            </modifier>
-          </modifiers>
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b0e2-27ff-b5c2-53df" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e3a0-bc86-e970-c7a5" type="max"/>
-          </constraints>
-          <categoryLinks/>
-        </entryLink>
-        <entryLink id="616e-60c7-3703-dc65" name="New EntryLink" hidden="false" targetId="073b-2de5-765f-a4f2" type="selectionEntry">
+        <entryLink id="616e-60c7-3703-dc65" name="Frag &amp; Krak grenades" hidden="false" targetId="cddf-945e-1335-e681" type="selectionEntry">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -16348,27 +16697,71 @@
           </constraints>
           <categoryLinks/>
         </entryLink>
+        <entryLink id="125e-5d24-5ffc-e497" name="Heaven&apos;s Teeth" hidden="false" targetId="5045-016e-62bb-80ee" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a093-39b8-4ac5-16a7" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fe15-41e6-c6b3-274d" type="max"/>
+          </constraints>
+          <categoryLinks/>
+        </entryLink>
+        <entryLink id="ca19-2976-efd5-3d85" name="Warlord" hidden="false" targetId="33f6-60da-7b70-5fee" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="834f-c181-3e4d-9e20" type="max"/>
+          </constraints>
+          <categoryLinks/>
+        </entryLink>
+        <entryLink id="ff70-43a0-47bd-bed9" name="5. Gift of Foresight" hidden="true" targetId="1d05-f4aa-e4ff-548f" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers>
+            <modifier type="set" field="d0e9-483e-23f5-0261" value="1">
+              <repeats/>
+              <conditions>
+                <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="33f6-60da-7b70-5fee" type="equalTo"/>
+              </conditions>
+              <conditionGroups/>
+            </modifier>
+            <modifier type="set" field="1afc-8f0f-247d-76b3" value="1">
+              <repeats/>
+              <conditions>
+                <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="33f6-60da-7b70-5fee" type="equalTo"/>
+              </conditions>
+              <conditionGroups/>
+            </modifier>
+            <modifier type="set" field="hidden" value="false">
+              <repeats/>
+              <conditions>
+                <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="33f6-60da-7b70-5fee" type="equalTo"/>
+              </conditions>
+              <conditionGroups/>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1afc-8f0f-247d-76b3" type="min"/>
+            <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d0e9-483e-23f5-0261" type="max"/>
+          </constraints>
+          <categoryLinks/>
+        </entryLink>
       </entryLinks>
       <costs>
         <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="5.0"/>
         <cost name="pts" costTypeId="points" value="94.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="316a-4885-0888-7e6c" name="Sanguinary Guard Ancient" hidden="false" collective="false" type="model">
-      <profiles>
-        <profile id="95fc-8858-dc67-ba23" name="Chapter Banner" hidden="false" profileTypeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" profileTypeName="Abilities">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <characteristics>
-            <characteristic name="Description" characteristicTypeId="21befb24-fc85-4f52-a745-64b2e48f8228" value="Friendly &amp;lt;CHAPTER&amp;gt; units within 6&quot; of a Chapter Banner do not need to take Morale tests and re-roll wounds roll of 1 in the Fight phase."/>
-          </characteristics>
-        </profile>
-      </profiles>
+    <selectionEntry id="316a-4885-0888-7e6c" name="Sanguinary Ancient" hidden="false" collective="false" type="model">
+      <profiles/>
       <rules/>
       <infoLinks>
-        <infoLink id="20db-cd95-3455-c799" name="New InfoLink" hidden="false" targetId="e5c4-93dc-1669-9916" type="profile">
+        <infoLink id="20db-cd95-3455-c799" name="Sanguinary Ancient" hidden="false" targetId="e5c4-93dc-1669-9916" type="profile">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -16380,7 +16773,13 @@
           <infoLinks/>
           <modifiers/>
         </infoLink>
-        <infoLink id="d70c-ebd5-902b-a466" name="New InfoLink" hidden="false" targetId="8037-2d12-0452-a463" type="profile">
+        <infoLink id="d70c-ebd5-902b-a466" name="Heirs of Azkaellon" hidden="false" targetId="8037-2d12-0452-a463" type="profile">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="3207-6943-d2b2-1225" name="Blood Angels Chapter Banner" hidden="false" targetId="f604-9de6-748d-422c" type="profile">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -16486,7 +16885,7 @@
               </constraints>
               <categoryLinks/>
             </entryLink>
-            <entryLink id="48e8-1ee8-ec8c-489d" name="Inferno pistol" hidden="false" targetId="12fb-6600-667f-5922" type="selectionEntry">
+            <entryLink id="48e8-1ee8-ec8c-489d" name="Inferno pistol" hidden="false" targetId="83f0-56d1-b852-f21c" type="selectionEntry">
               <profiles/>
               <rules/>
               <infoLinks/>
@@ -16496,7 +16895,7 @@
               </constraints>
               <categoryLinks/>
             </entryLink>
-            <entryLink id="8109-a7a8-d3cd-368c" name="Plasma pistol" hidden="false" targetId="b333-4c80-2f72-6b45" type="selectionEntry">
+            <entryLink id="8109-a7a8-d3cd-368c" name="Plasma pistol" hidden="false" targetId="83be-1ba9-c326-4760" type="selectionEntry">
               <profiles/>
               <rules/>
               <infoLinks/>
@@ -16541,7 +16940,7 @@
               </constraints>
               <categoryLinks/>
             </entryLink>
-            <entryLink id="ce66-ad9c-2481-c00f" name="Power fist" hidden="false" targetId="3102-2dd8-4f31-3af7" type="selectionEntry">
+            <entryLink id="ce66-ad9c-2481-c00f" name="Power fist" hidden="false" targetId="f122-3720-fa32-4215" type="selectionEntry">
               <profiles/>
               <rules/>
               <infoLinks/>
@@ -16555,7 +16954,7 @@
         </selectionEntryGroup>
       </selectionEntryGroups>
       <entryLinks>
-        <entryLink id="ed56-eb22-f98c-a31b" name="New EntryLink" hidden="false" targetId="8eda-5cb2-0c31-56da" type="selectionEntry">
+        <entryLink id="ed56-eb22-f98c-a31b" name="Jump Pack" hidden="false" targetId="8eda-5cb2-0c31-56da" type="selectionEntry">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -16572,18 +16971,7 @@
           </constraints>
           <categoryLinks/>
         </entryLink>
-        <entryLink id="bd0c-4ec1-c5cb-3987" name="New EntryLink" hidden="false" targetId="e897-c8fa-0976-e2d3" type="selectionEntry">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="dfb0-ed0e-212a-574a" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9200-6c3d-cd9a-2fb6" type="max"/>
-          </constraints>
-          <categoryLinks/>
-        </entryLink>
-        <entryLink id="211c-f775-9858-2b7b" name="New EntryLink" hidden="false" targetId="073b-2de5-765f-a4f2" type="selectionEntry">
+        <entryLink id="211c-f775-9858-2b7b" name="Frag &amp; Krak grenades" hidden="false" targetId="cddf-945e-1335-e681" type="selectionEntry">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -16594,7 +16982,7 @@
           </constraints>
           <categoryLinks/>
         </entryLink>
-        <entryLink id="f240-7da3-effb-bee6" name="New EntryLink" hidden="false" targetId="2f38-7256-aeae-fc13" type="selectionEntry">
+        <entryLink id="f240-7da3-effb-bee6" name="Death mask" hidden="false" targetId="2f38-7256-aeae-fc13" type="selectionEntry">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -16604,6 +16992,32 @@
           </constraints>
           <categoryLinks/>
         </entryLink>
+        <entryLink id="7703-606d-fece-f03f" name="Warlord" hidden="false" targetId="33f6-60da-7b70-5fee" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ba03-de9a-367d-e5fc" type="max"/>
+          </constraints>
+          <categoryLinks/>
+        </entryLink>
+        <entryLink id="5480-d650-07f1-7cb4" name="Warlord Traits" hidden="false" targetId="c25d-2fbc-47b3-9e39" type="selectionEntryGroup">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+          <categoryLinks/>
+        </entryLink>
+        <entryLink id="e869-adc9-32d9-2141" name="Relics of Baal" hidden="false" targetId="441f-1714-0777-c202" type="selectionEntryGroup">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+          <categoryLinks/>
+        </entryLink>
       </entryLinks>
       <costs>
         <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="6.0"/>
@@ -16611,41 +17025,34 @@
       </costs>
     </selectionEntry>
     <selectionEntry id="af58-656a-c98c-9e92" name="Terminator Ancient" hidden="false" collective="false" type="model">
-      <profiles>
-        <profile id="8dd8-4e4e-8bcb-4b1c" name="Terminator Armour" hidden="false" profileTypeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" profileTypeName="Abilities">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <characteristics>
-            <characteristic name="Description" characteristicTypeId="21befb24-fc85-4f52-a745-64b2e48f8228" value="This model has a 5+ invulnerable save."/>
-          </characteristics>
-        </profile>
-        <profile id="193c-7bb4-3de5-d6a3" name="Archangel Standard" hidden="false" profileTypeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" profileTypeName="Abilities">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <characteristics>
-            <characteristic name="Description" characteristicTypeId="21befb24-fc85-4f52-a745-64b2e48f8228" value="Friendly &lt;CHAPTER&gt; units within 6&quot; of an Archangel standard add 1 to their Leadership characteristic, and you can re-roll failed hit rolls for them in the Fight phase."/>
-          </characteristics>
-        </profile>
-      </profiles>
+      <profiles/>
       <rules/>
       <infoLinks>
-        <infoLink id="9ab9-2394-6375-a16e" name="New InfoLink" hidden="false" targetId="eb92-1b6d-b645-12ad" type="profile">
+        <infoLink id="9ab9-2394-6375-a16e" name="Terminator Ancient" hidden="false" targetId="eb92-1b6d-b645-12ad" type="profile">
           <profiles/>
           <rules/>
           <infoLinks/>
           <modifiers/>
         </infoLink>
-        <infoLink id="d603-f45c-1686-2e1a" name="New InfoLink" hidden="false" targetId="4243-5016-c4d9-2b6b" type="profile">
+        <infoLink id="d603-f45c-1686-2e1a" name="Teleport Strike" hidden="false" targetId="4243-5016-c4d9-2b6b" type="profile">
           <profiles/>
           <rules/>
           <infoLinks/>
           <modifiers/>
         </infoLink>
         <infoLink id="6283-6eb1-feaf-c27a" name="And They Shall Know No Fear" hidden="false" targetId="4ea8-94d3-ba39-042f" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="6d42-9c09-7288-d4ab" name="Archangel Standard" hidden="false" targetId="7936-65c7-1887-2388" type="profile">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="b669-55a9-d36a-2565" name="Crux Terminatus" hidden="false" targetId="5263-7a0c-08ad-f754" type="profile">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -16737,7 +17144,7 @@
               </constraints>
               <categoryLinks/>
             </entryLink>
-            <entryLink id="763a-1434-9227-9af1" name="Thunder hammer" hidden="false" targetId="7057-ee87-f5bf-5e42" type="selectionEntry">
+            <entryLink id="763a-1434-9227-9af1" name="Thunder hammer" hidden="false" targetId="0e57-eaf5-763f-9c45" type="selectionEntry">
               <profiles/>
               <rules/>
               <infoLinks/>
@@ -16747,10 +17154,47 @@
               </constraints>
               <categoryLinks/>
             </entryLink>
+            <entryLink id="c066-1ae6-84ef-c9da" name="Storm bolter" hidden="false" targetId="2b03-8d64-3711-f300" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0728-6e3d-cb72-81a0" type="max"/>
+              </constraints>
+              <categoryLinks/>
+            </entryLink>
           </entryLinks>
         </selectionEntryGroup>
       </selectionEntryGroups>
-      <entryLinks/>
+      <entryLinks>
+        <entryLink id="c942-da32-562a-3385" name="Warlord" hidden="false" targetId="33f6-60da-7b70-5fee" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b83b-fe71-e701-7b61" type="max"/>
+          </constraints>
+          <categoryLinks/>
+        </entryLink>
+        <entryLink id="dcd8-e811-3fad-8720" name="Warlord Traits" hidden="false" targetId="c25d-2fbc-47b3-9e39" type="selectionEntryGroup">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+          <categoryLinks/>
+        </entryLink>
+        <entryLink id="44f4-5818-bf38-4933" name="Relics of Baal" hidden="false" targetId="441f-1714-0777-c202" type="selectionEntryGroup">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+          <categoryLinks/>
+        </entryLink>
+      </entryLinks>
       <costs>
         <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="6.0"/>
         <cost name="pts" costTypeId="points" value="108.0"/>
@@ -16774,14 +17218,14 @@
         </infoLink>
       </infoLinks>
       <modifiers>
-        <modifier type="increment" field="e356-c769-5920-6e14" value="9">
+        <modifier type="increment" field="e356-c769-5920-6e14" value="8">
           <repeats/>
           <conditions>
             <condition field="selections" scope="b420-bd15-adb5-f6e1" value="5.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d3a3-483e-c3fd-81fa" type="greaterThan"/>
           </conditions>
           <conditionGroups/>
         </modifier>
-        <modifier type="increment" field="e356-c769-5920-6e14" value="9">
+        <modifier type="increment" field="e356-c769-5920-6e14" value="8">
           <repeats/>
           <conditions>
             <condition field="selections" scope="b420-bd15-adb5-f6e1" value="10.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d3a3-483e-c3fd-81fa" type="greaterThan"/>
@@ -16912,7 +17356,7 @@
                   <selectionEntries/>
                   <selectionEntryGroups/>
                   <entryLinks>
-                    <entryLink id="564e-0693-bada-af09" name="New EntryLink" hidden="false" targetId="bf86-1c1b-6871-da0b" type="selectionEntry">
+                    <entryLink id="564e-0693-bada-af09" name="Bolt pistol" hidden="false" targetId="0334-f487-8229-0c1a" type="selectionEntry">
                       <profiles/>
                       <rules/>
                       <infoLinks/>
@@ -16923,7 +17367,7 @@
                       </constraints>
                       <categoryLinks/>
                     </entryLink>
-                    <entryLink id="c58c-7fc8-3539-2b69" name="New EntryLink" hidden="false" targetId="5905-f299-f23c-f9c1" type="selectionEntry">
+                    <entryLink id="c58c-7fc8-3539-2b69" name="Chainsword" hidden="false" targetId="4334-d2da-32f5-dc53" type="selectionEntry">
                       <profiles/>
                       <rules/>
                       <infoLinks/>
@@ -16954,7 +17398,7 @@
                   <selectionEntries/>
                   <selectionEntryGroups/>
                   <entryLinks>
-                    <entryLink id="0079-d154-229e-bb8e" name="New EntryLink" hidden="false" targetId="5f85-cddd-00b5-41f8" type="selectionEntry">
+                    <entryLink id="0079-d154-229e-bb8e" name="Chainsword" hidden="false" targetId="0dd1-2e2b-7dd1-5495" type="selectionEntry">
                       <profiles/>
                       <rules/>
                       <infoLinks/>
@@ -16964,7 +17408,7 @@
                       </constraints>
                       <categoryLinks/>
                     </entryLink>
-                    <entryLink id="4a10-8ec3-2ff7-0684" name="New EntryLink" hidden="false" targetId="8d13-0f69-a808-e300" type="selectionEntry">
+                    <entryLink id="4a10-8ec3-2ff7-0684" name="Power axe" hidden="false" targetId="3292-34e6-f679-d5b9" type="selectionEntry">
                       <profiles/>
                       <rules/>
                       <infoLinks/>
@@ -16974,7 +17418,7 @@
                       </constraints>
                       <categoryLinks/>
                     </entryLink>
-                    <entryLink id="6a0d-74e6-6a14-f18f" name="New EntryLink" hidden="false" targetId="3102-2dd8-4f31-3af7" type="selectionEntry">
+                    <entryLink id="6a0d-74e6-6a14-f18f" name="Power fist" hidden="false" targetId="f122-3720-fa32-4215" type="selectionEntry">
                       <profiles/>
                       <rules/>
                       <infoLinks/>
@@ -16984,7 +17428,7 @@
                       </constraints>
                       <categoryLinks/>
                     </entryLink>
-                    <entryLink id="dcad-a293-fe54-d239" name="New EntryLink" hidden="false" targetId="b22c-5019-c613-fb74" type="selectionEntry">
+                    <entryLink id="dcad-a293-fe54-d239" name="Power maul" hidden="false" targetId="6ea7-1195-7144-438e" type="selectionEntry">
                       <profiles/>
                       <rules/>
                       <infoLinks/>
@@ -16994,7 +17438,7 @@
                       </constraints>
                       <categoryLinks/>
                     </entryLink>
-                    <entryLink id="a94e-4359-c335-10fe" name="New EntryLink" hidden="false" targetId="c3d0-2567-35c6-3f29" type="selectionEntry">
+                    <entryLink id="a94e-4359-c335-10fe" name="Power sword" hidden="false" targetId="bc9e-551d-9afb-78d5" type="selectionEntry">
                       <profiles/>
                       <rules/>
                       <infoLinks/>
@@ -17018,7 +17462,7 @@
                   <selectionEntries/>
                   <selectionEntryGroups/>
                   <entryLinks>
-                    <entryLink id="b5d1-d2ba-c1fb-d6f3" name="New EntryLink" hidden="false" targetId="bf86-1c1b-6871-da0b" type="selectionEntry">
+                    <entryLink id="b5d1-d2ba-c1fb-d6f3" name="Bolt pistol" hidden="false" targetId="0334-f487-8229-0c1a" type="selectionEntry">
                       <profiles/>
                       <rules/>
                       <infoLinks/>
@@ -17028,7 +17472,7 @@
                       </constraints>
                       <categoryLinks/>
                     </entryLink>
-                    <entryLink id="fe65-a70e-4c3e-3dc8" name="New EntryLink" hidden="false" targetId="8e23-a2e7-23c4-cac7" type="selectionEntry">
+                    <entryLink id="fe65-a70e-4c3e-3dc8" name="Boltgun" hidden="false" targetId="b61f-a3c1-827d-c5b6" type="selectionEntry">
                       <profiles/>
                       <rules/>
                       <infoLinks/>
@@ -17048,7 +17492,7 @@
                       </constraints>
                       <categoryLinks/>
                     </entryLink>
-                    <entryLink id="c464-76d9-17e6-dded" name="New EntryLink" hidden="false" targetId="12fb-6600-667f-5922" type="selectionEntry">
+                    <entryLink id="c464-76d9-17e6-dded" name="Inferno pistol" hidden="false" targetId="83f0-56d1-b852-f21c" type="selectionEntry">
                       <profiles/>
                       <rules/>
                       <infoLinks/>
@@ -17058,7 +17502,7 @@
                       </constraints>
                       <categoryLinks/>
                     </entryLink>
-                    <entryLink id="5a3f-3755-d751-c9a3" name="New EntryLink" hidden="false" targetId="b333-4c80-2f72-6b45" type="selectionEntry">
+                    <entryLink id="5a3f-3755-d751-c9a3" name="Plasma pistol" hidden="false" targetId="83be-1ba9-c326-4760" type="selectionEntry">
                       <profiles/>
                       <rules/>
                       <infoLinks/>
@@ -17068,7 +17512,7 @@
                       </constraints>
                       <categoryLinks/>
                     </entryLink>
-                    <entryLink id="2474-3f6d-7c5e-8dc9" name="New EntryLink" hidden="false" targetId="8d13-0f69-a808-e300" type="selectionEntry">
+                    <entryLink id="2474-3f6d-7c5e-8dc9" name="Power axe" hidden="false" targetId="3292-34e6-f679-d5b9" type="selectionEntry">
                       <profiles/>
                       <rules/>
                       <infoLinks/>
@@ -17078,7 +17522,7 @@
                       </constraints>
                       <categoryLinks/>
                     </entryLink>
-                    <entryLink id="9818-7c3b-c1c5-9706" name="New EntryLink" hidden="false" targetId="3102-2dd8-4f31-3af7" type="selectionEntry">
+                    <entryLink id="9818-7c3b-c1c5-9706" name="Power fist" hidden="false" targetId="f122-3720-fa32-4215" type="selectionEntry">
                       <profiles/>
                       <rules/>
                       <infoLinks/>
@@ -17088,7 +17532,7 @@
                       </constraints>
                       <categoryLinks/>
                     </entryLink>
-                    <entryLink id="77ea-a069-b71b-fff1" name="New EntryLink" hidden="false" targetId="b22c-5019-c613-fb74" type="selectionEntry">
+                    <entryLink id="77ea-a069-b71b-fff1" name="Power maul" hidden="false" targetId="6ea7-1195-7144-438e" type="selectionEntry">
                       <profiles/>
                       <rules/>
                       <infoLinks/>
@@ -17098,7 +17542,7 @@
                       </constraints>
                       <categoryLinks/>
                     </entryLink>
-                    <entryLink id="6dd1-996f-7b78-4816" name="New EntryLink" hidden="false" targetId="c3d0-2567-35c6-3f29" type="selectionEntry">
+                    <entryLink id="6dd1-996f-7b78-4816" name="Power sword" hidden="false" targetId="bc9e-551d-9afb-78d5" type="selectionEntry">
                       <profiles/>
                       <rules/>
                       <infoLinks/>
@@ -17112,7 +17556,7 @@
                 </selectionEntryGroup>
               </selectionEntryGroups>
               <entryLinks>
-                <entryLink id="cbaf-7fb5-e66d-fea0" name="New EntryLink" hidden="false" targetId="7057-ee87-f5bf-5e42" type="selectionEntry">
+                <entryLink id="cbaf-7fb5-e66d-fea0" name="Thunder hammer" hidden="false" targetId="0e57-eaf5-763f-9c45" type="selectionEntry">
                   <profiles/>
                   <rules/>
                   <infoLinks/>
@@ -17126,18 +17570,7 @@
             </selectionEntryGroup>
           </selectionEntryGroups>
           <entryLinks>
-            <entryLink id="f41d-e2f5-386e-11a3" name="Frag grenades" hidden="false" targetId="e897-c8fa-0976-e2d3" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2d29-66bc-491f-d11f" type="min"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1546-5a23-a5a8-186e" type="max"/>
-              </constraints>
-              <categoryLinks/>
-            </entryLink>
-            <entryLink id="4685-c8b3-7116-c92c" name="New EntryLink" hidden="false" targetId="073b-2de5-765f-a4f2" type="selectionEntry">
+            <entryLink id="4685-c8b3-7116-c92c" name="Frag &amp; Krak grenades" hidden="false" targetId="cddf-945e-1335-e681" type="selectionEntry">
               <profiles/>
               <rules/>
               <infoLinks/>
@@ -17191,31 +17624,12 @@
         </entryLink>
       </entryLinks>
       <costs>
-        <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="9.0"/>
+        <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="8.0"/>
         <cost name="pts" costTypeId="points" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="c199-ee13-f09e-ac72" name="Lemartes" hidden="false" collective="false" type="model">
-      <profiles>
-        <profile id="4b9e-cbc3-0b2d-eb62" name="Guardian of the Lost" hidden="false" profileTypeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" profileTypeName="Abilities">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <characteristics>
-            <characteristic name="Description" characteristicTypeId="21befb24-fc85-4f52-a745-64b2e48f8228" value="All friendly DEATH COMPANY units within 6&quot; of Lemartes can use his Leadership instead of their own."/>
-          </characteristics>
-        </profile>
-        <profile id="45e4-e44c-be82-b186" name="Fury Unbound" hidden="false" profileTypeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" profileTypeName="Abilities">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <characteristics>
-            <characteristic name="Description" characteristicTypeId="21befb24-fc85-4f52-a745-64b2e48f8228" value="You can re-roll failed charge rolls and failed hit rolls in the Fight phase for friendly DEATH COMPANY units within 6&quot; of Lemartes."/>
-          </characteristics>
-        </profile>
-      </profiles>
+      <profiles/>
       <rules/>
       <infoLinks>
         <infoLink id="84a2-213c-61ff-9ffd" name="Lemartes" hidden="false" targetId="01ff-36fe-04ea-6743" type="profile">
@@ -17237,6 +17651,18 @@
           <modifiers/>
         </infoLink>
         <infoLink id="3dd0-56d1-8669-667e" name="Black Rage" hidden="false" targetId="8d72-906f-dbea-c860" type="profile">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="c8fb-247e-1fce-ee73" name="Fury Unbound" hidden="false" targetId="a051-8cfb-aa05-8a9c" type="profile">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="8dfd-2107-a634-3251" name="Guardian of the Lost" hidden="false" targetId="b8bb-e7b3-5df7-690e" type="profile">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -17326,53 +17752,10 @@
           <constraints/>
         </categoryLink>
       </categoryLinks>
-      <selectionEntries>
-        <selectionEntry id="ed3d-688b-ee51-4039" name="The Blood Crozius" hidden="false" collective="false" type="upgrade">
-          <profiles/>
-          <rules/>
-          <infoLinks>
-            <infoLink id="dca3-29ff-1efb-a5a5" name="New InfoLink" hidden="false" targetId="800f-fd1d-4eaf-8b88" type="profile">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-            </infoLink>
-          </infoLinks>
-          <modifiers/>
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="18be-d103-0569-81f2" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1da0-a6d7-10be-4c55" type="max"/>
-          </constraints>
-          <categoryLinks/>
-          <selectionEntries/>
-          <selectionEntryGroups/>
-          <entryLinks/>
-          <costs>
-            <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="0.0"/>
-            <cost name="pts" costTypeId="points" value="0.0"/>
-          </costs>
-        </selectionEntry>
-      </selectionEntries>
+      <selectionEntries/>
       <selectionEntryGroups/>
       <entryLinks>
-        <entryLink id="3c9e-8b4b-e0e3-1f6f" name="" hidden="false" targetId="e897-c8fa-0976-e2d3" type="selectionEntry">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers>
-            <modifier type="set" field="points" value="0.0">
-              <repeats/>
-              <conditions/>
-              <conditionGroups/>
-            </modifier>
-          </modifiers>
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c151-261b-84f4-6202" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7703-cb12-2f62-5e1d" type="max"/>
-          </constraints>
-          <categoryLinks/>
-        </entryLink>
-        <entryLink id="eb89-5c85-e962-ee14" name="" hidden="false" targetId="073b-2de5-765f-a4f2" type="selectionEntry">
+        <entryLink id="eb89-5c85-e962-ee14" name="Frag &amp; Krak grenades" hidden="false" targetId="cddf-945e-1335-e681" type="selectionEntry">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -17389,7 +17772,7 @@
           </constraints>
           <categoryLinks/>
         </entryLink>
-        <entryLink id="aba7-5014-bb58-4d28" name="Bolt pistol" hidden="false" targetId="bf86-1c1b-6871-da0b" type="selectionEntry">
+        <entryLink id="aba7-5014-bb58-4d28" name="Bolt pistol" hidden="false" targetId="0334-f487-8229-0c1a" type="selectionEntry">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -17423,6 +17806,60 @@
           </constraints>
           <categoryLinks/>
         </entryLink>
+        <entryLink id="01a9-01c5-3769-5e12" name="The Blood Crozius" hidden="false" targetId="f243-591a-5d01-f20f" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b888-a048-51f0-6026" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d3e8-de42-4df1-1841" type="max"/>
+          </constraints>
+          <categoryLinks/>
+        </entryLink>
+        <entryLink id="e01b-5a6d-37a7-2279" name="Warlord" hidden="false" targetId="33f6-60da-7b70-5fee" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5b41-6678-efe4-44a9" type="max"/>
+          </constraints>
+          <categoryLinks/>
+        </entryLink>
+        <entryLink id="d437-f247-2372-5d3d" name="3. Soulwarden" hidden="true" targetId="58d2-aee8-1337-a246" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers>
+            <modifier type="set" field="9c0a-2135-6a91-aa4e" value="1">
+              <repeats/>
+              <conditions>
+                <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="33f6-60da-7b70-5fee" type="equalTo"/>
+              </conditions>
+              <conditionGroups/>
+            </modifier>
+            <modifier type="set" field="1132-b51b-be9c-137e" value="1">
+              <repeats/>
+              <conditions>
+                <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="33f6-60da-7b70-5fee" type="equalTo"/>
+              </conditions>
+              <conditionGroups/>
+            </modifier>
+            <modifier type="set" field="hidden" value="false">
+              <repeats/>
+              <conditions>
+                <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="33f6-60da-7b70-5fee" type="equalTo"/>
+              </conditions>
+              <conditionGroups/>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9c0a-2135-6a91-aa4e" type="min"/>
+            <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1132-b51b-be9c-137e" type="max"/>
+          </constraints>
+          <categoryLinks/>
+        </entryLink>
       </entryLinks>
       <costs>
         <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="7.0"/>
@@ -17444,7 +17881,7 @@
         <modifier type="increment" field="e356-c769-5920-6e14" value="12">
           <repeats/>
           <conditions>
-            <condition field="selections" scope="e7be-397e-ddd1-65ae" value="4.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="059f-0314-8cdb-17b7" type="greaterThan"/>
+            <condition field="selections" scope="e7be-397e-ddd1-65ae" value="4.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="model" type="greaterThan"/>
           </conditions>
           <conditionGroups/>
         </modifier>
@@ -17547,7 +17984,7 @@
               <selectionEntries/>
               <selectionEntryGroups/>
               <entryLinks>
-                <entryLink id="ba43-7023-260e-8546" name="New EntryLink" hidden="false" targetId="3416-2170-2d36-e76e" type="selectionEntry">
+                <entryLink id="ba43-7023-260e-8546" name="Angelus boltgun" hidden="false" targetId="3416-2170-2d36-e76e" type="selectionEntry">
                   <profiles/>
                   <rules/>
                   <infoLinks/>
@@ -17557,7 +17994,7 @@
                   </constraints>
                   <categoryLinks/>
                 </entryLink>
-                <entryLink id="c53b-505c-e0fb-648d" name="New EntryLink" hidden="false" targetId="12fb-6600-667f-5922" type="selectionEntry">
+                <entryLink id="c53b-505c-e0fb-648d" name="Inferno pistol" hidden="false" targetId="83f0-56d1-b852-f21c" type="selectionEntry">
                   <profiles/>
                   <rules/>
                   <infoLinks/>
@@ -17567,7 +18004,7 @@
                   </constraints>
                   <categoryLinks/>
                 </entryLink>
-                <entryLink id="1233-74eb-066c-a940" name="New EntryLink" hidden="false" targetId="b333-4c80-2f72-6b45" type="selectionEntry">
+                <entryLink id="1233-74eb-066c-a940" name="Plasma pistol" hidden="false" targetId="83be-1ba9-c326-4760" type="selectionEntry">
                   <profiles/>
                   <rules/>
                   <infoLinks/>
@@ -17592,7 +18029,7 @@
               <selectionEntries/>
               <selectionEntryGroups/>
               <entryLinks>
-                <entryLink id="1d51-b0e7-499f-527c" name="New EntryLink" hidden="false" targetId="c6b0-3f26-775c-7232" type="selectionEntry">
+                <entryLink id="1d51-b0e7-499f-527c" name="Encarmine axe" hidden="false" targetId="c6b0-3f26-775c-7232" type="selectionEntry">
                   <profiles/>
                   <rules/>
                   <infoLinks/>
@@ -17602,7 +18039,7 @@
                   </constraints>
                   <categoryLinks/>
                 </entryLink>
-                <entryLink id="efbc-e867-59d3-fb09" name="New EntryLink" hidden="false" targetId="537e-2cf9-80d7-1f5d" type="selectionEntry">
+                <entryLink id="efbc-e867-59d3-fb09" name="Encarmine sword" hidden="false" targetId="537e-2cf9-80d7-1f5d" type="selectionEntry">
                   <profiles/>
                   <rules/>
                   <infoLinks/>
@@ -17612,7 +18049,7 @@
                   </constraints>
                   <categoryLinks/>
                 </entryLink>
-                <entryLink id="63f7-8346-5e72-9ae9" name="New EntryLink" hidden="false" targetId="3102-2dd8-4f31-3af7" type="selectionEntry">
+                <entryLink id="63f7-8346-5e72-9ae9" name="Power fist" hidden="false" targetId="f122-3720-fa32-4215" type="selectionEntry">
                   <profiles/>
                   <rules/>
                   <infoLinks/>
@@ -17626,7 +18063,7 @@
             </selectionEntryGroup>
           </selectionEntryGroups>
           <entryLinks>
-            <entryLink id="ad1e-4ea7-b07f-8068" name="New EntryLink" hidden="false" targetId="8eda-5cb2-0c31-56da" type="selectionEntry">
+            <entryLink id="ad1e-4ea7-b07f-8068" name="Jump Pack" hidden="false" targetId="8eda-5cb2-0c31-56da" type="selectionEntry">
               <profiles/>
               <rules/>
               <infoLinks/>
@@ -17643,18 +18080,7 @@
               </constraints>
               <categoryLinks/>
             </entryLink>
-            <entryLink id="3fb4-7c2c-4a96-8f61" name="New EntryLink" hidden="false" targetId="e897-c8fa-0976-e2d3" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4dc6-a3f7-c0b1-5eab" type="min"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ce5b-3c12-ca26-8027" type="max"/>
-              </constraints>
-              <categoryLinks/>
-            </entryLink>
-            <entryLink id="0a2d-7576-ca1e-d938" name="New EntryLink" hidden="false" targetId="073b-2de5-765f-a4f2" type="selectionEntry">
+            <entryLink id="0a2d-7576-ca1e-d938" name="Frag &amp; Krak grenades" hidden="false" targetId="cddf-945e-1335-e681" type="selectionEntry">
               <profiles/>
               <rules/>
               <infoLinks/>
@@ -17665,7 +18091,7 @@
               </constraints>
               <categoryLinks/>
             </entryLink>
-            <entryLink id="a114-1b82-ab04-a889" name="New EntryLink" hidden="false" targetId="2f38-7256-aeae-fc13" type="selectionEntry">
+            <entryLink id="a114-1b82-ab04-a889" name="Death mask" hidden="false" targetId="2f38-7256-aeae-fc13" type="selectionEntry">
               <profiles/>
               <rules/>
               <infoLinks/>
@@ -17677,7 +18103,7 @@
             </entryLink>
           </entryLinks>
           <costs>
-            <cost name="pts" costTypeId="points" value="22.0"/>
+            <cost name="pts" costTypeId="points" value="20.0"/>
             <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="0.0"/>
           </costs>
         </selectionEntry>
@@ -17685,40 +18111,39 @@
       <selectionEntryGroups/>
       <entryLinks/>
       <costs>
-        <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="10.0"/>
+        <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="8.0"/>
         <cost name="pts" costTypeId="points" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="21f2-e1ac-6dd2-3e34" name="Death Company Dreadnought" hidden="false" collective="false" type="model">
       <profiles>
-        <profile id="1d39-1071-d12b-b946" name="Explodes" hidden="false" profileTypeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" profileTypeName="Abilities">
+        <profile id="1d39-1071-d12b-b946" name="Explodes" hidden="false" profileTypeId="818c-0db1-36f0-462a" profileTypeName="Explosion">
           <profiles/>
           <rules/>
           <infoLinks/>
           <modifiers/>
           <characteristics>
-            <characteristic name="Description" characteristicTypeId="21befb24-fc85-4f52-a745-64b2e48f8228" value="If this model is reduced to 0 wounds, roll a D6 before removing the model from the battlefield; on a 6 it explodes, and each unit within 3&quot; suffers D3 mortal wounds."/>
-          </characteristics>
-        </profile>
-        <profile id="b7b3-5977-a738-e6ef" name="Insatiable" hidden="false" profileTypeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" profileTypeName="Abilities">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <characteristics>
-            <characteristic name="Description" characteristicTypeId="21befb24-fc85-4f52-a745-64b2e48f8228" value="This model may move up to 6&quot; when consolidating at the end of the Fight phase."/>
+            <characteristic name="Dice roll" characteristicTypeId="f21d-8f6d-180d-36ff" value="6"/>
+            <characteristic name="Distance" characteristicTypeId="d69e-be07-1682-ebcc" value="3&quot;"/>
+            <characteristic name="Mortal wounds" characteristicTypeId="29f1-65a1-2c5d-8c7d" value="D3"/>
           </characteristics>
         </profile>
       </profiles>
       <rules/>
       <infoLinks>
-        <infoLink id="cea2-0af9-9144-dfb0" name="New InfoLink" hidden="false" targetId="ca8d-d7f0-5257-90b6" type="profile">
+        <infoLink id="cea2-0af9-9144-dfb0" name="Death Company Dreadnought" hidden="false" targetId="ca8d-d7f0-5257-90b6" type="profile">
           <profiles/>
           <rules/>
           <infoLinks/>
           <modifiers/>
         </infoLink>
         <infoLink id="4411-006a-af71-f8c0" name="New InfoLink" hidden="false" targetId="8d72-906f-dbea-c860" type="profile">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="a85c-56d2-bdff-d75b" name="Insatiable" hidden="false" targetId="4a79-e8eb-c017-08c5" type="profile">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -17800,7 +18225,7 @@
           <selectionEntries/>
           <selectionEntryGroups/>
           <entryLinks>
-            <entryLink id="07f3-2a61-3084-7449" name="New EntryLink" hidden="false" targetId="c738-c7d6-89bc-3b46" type="selectionEntry">
+            <entryLink id="07f3-2a61-3084-7449" name="Furioso fist (pair)" hidden="false" targetId="c738-c7d6-89bc-3b46" type="selectionEntry">
               <profiles/>
               <rules/>
               <infoLinks/>
@@ -17810,7 +18235,7 @@
               </constraints>
               <categoryLinks/>
             </entryLink>
-            <entryLink id="3b6e-8ba9-0dbd-9cea" name="New EntryLink" hidden="false" targetId="e92b-41d1-511b-54a7" type="selectionEntry">
+            <entryLink id="3b6e-8ba9-0dbd-9cea" name="Blood talons" hidden="false" targetId="e92b-41d1-511b-54a7" type="selectionEntry">
               <profiles/>
               <rules/>
               <infoLinks/>
@@ -17835,7 +18260,7 @@
           <selectionEntries/>
           <selectionEntryGroups/>
           <entryLinks>
-            <entryLink id="85de-8ea3-496f-017a" name="New EntryLink" hidden="false" targetId="d74a-2fee-abea-1b42" type="selectionEntry">
+            <entryLink id="85de-8ea3-496f-017a" name="Storm bolter" hidden="false" targetId="2b03-8d64-3711-f300" type="selectionEntry">
               <profiles/>
               <rules/>
               <infoLinks/>
@@ -17845,7 +18270,7 @@
               </constraints>
               <categoryLinks/>
             </entryLink>
-            <entryLink id="16fa-0ba3-f3e3-8b39" name="New EntryLink" hidden="false" targetId="7eb4-1d78-9058-f71a" type="selectionEntry">
+            <entryLink id="16fa-0ba3-f3e3-8b39" name="Heavy flamer" hidden="false" targetId="18bc-b335-29c2-2ae2" type="selectionEntry">
               <profiles/>
               <rules/>
               <infoLinks/>
@@ -17870,7 +18295,7 @@
           <selectionEntries/>
           <selectionEntryGroups/>
           <entryLinks>
-            <entryLink id="02d7-d8ff-2043-7cd7" name="New EntryLink" hidden="false" targetId="9ec1-5584-a623-fdda" type="selectionEntry">
+            <entryLink id="02d7-d8ff-2043-7cd7" name="Meltagun" hidden="false" targetId="efc8-c51d-5b02-a3a2" type="selectionEntry">
               <profiles/>
               <rules/>
               <infoLinks/>
@@ -17880,7 +18305,7 @@
               </constraints>
               <categoryLinks/>
             </entryLink>
-            <entryLink id="1d18-2fac-a690-cf91" name="New EntryLink" hidden="false" targetId="7eb4-1d78-9058-f71a" type="selectionEntry">
+            <entryLink id="1d18-2fac-a690-cf91" name="Heavy flamer" hidden="false" targetId="18bc-b335-29c2-2ae2" type="selectionEntry">
               <profiles/>
               <rules/>
               <infoLinks/>
@@ -17907,7 +18332,7 @@
               <profiles/>
               <rules/>
               <infoLinks>
-                <infoLink id="9b7a-f6d8-d582-b42c" name="New InfoLink" hidden="false" targetId="c883-3078-1367-cc2c" type="profile">
+                <infoLink id="9b7a-f6d8-d582-b42c" name="Smoke Launchers" hidden="false" targetId="c883-3078-1367-cc2c" type="profile">
                   <profiles/>
                   <rules/>
                   <infoLinks/>
@@ -17915,7 +18340,9 @@
                 </infoLink>
               </infoLinks>
               <modifiers/>
-              <constraints/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="67ae-d217-bb45-ff7c" type="max"/>
+              </constraints>
               <categoryLinks/>
               <selectionEntries/>
               <selectionEntryGroups/>
@@ -17928,7 +18355,7 @@
           </selectionEntries>
           <selectionEntryGroups/>
           <entryLinks>
-            <entryLink id="40b8-470c-747f-4ea5" name="New EntryLink" hidden="false" targetId="04b8-72ed-b68b-f715" type="selectionEntry">
+            <entryLink id="40b8-470c-747f-4ea5" name="Magna-grapple" hidden="false" targetId="04b8-72ed-b68b-f715" type="selectionEntry">
               <profiles/>
               <rules/>
               <infoLinks/>
@@ -17943,25 +18370,27 @@
       </selectionEntryGroups>
       <entryLinks/>
       <costs>
-        <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="11.0"/>
-        <cost name="pts" costTypeId="points" value="128.0"/>
+        <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="9.0"/>
+        <cost name="pts" costTypeId="points" value="90.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="9e33-7e96-16f8-6986" name="Furioso Dreadnought" hidden="false" collective="false" type="model">
       <profiles>
-        <profile id="bade-7ccf-3f61-dbb3" name="Explodes" hidden="false" profileTypeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" profileTypeName="Abilities">
+        <profile id="bade-7ccf-3f61-dbb3" name="Explodes" hidden="false" profileTypeId="818c-0db1-36f0-462a" profileTypeName="Explosion">
           <profiles/>
           <rules/>
           <infoLinks/>
           <modifiers/>
           <characteristics>
-            <characteristic name="Description" characteristicTypeId="21befb24-fc85-4f52-a745-64b2e48f8228" value="If this model is reduced to 0 wounds, roll a D6 before removing the model from the battlefield; on a 6 it explodes, and each unit within 3&quot; suffers D3 mortal wounds."/>
+            <characteristic name="Dice roll" characteristicTypeId="f21d-8f6d-180d-36ff" value="6"/>
+            <characteristic name="Distance" characteristicTypeId="d69e-be07-1682-ebcc" value="3&quot;"/>
+            <characteristic name="Mortal wounds" characteristicTypeId="29f1-65a1-2c5d-8c7d" value="D3"/>
           </characteristics>
         </profile>
       </profiles>
       <rules/>
       <infoLinks>
-        <infoLink id="97a7-1d2b-5eb7-d05b" name="New InfoLink" hidden="false" targetId="79b1-6a5e-70fc-d572" type="profile">
+        <infoLink id="97a7-1d2b-5eb7-d05b" name="Furioso Dreadnought" hidden="false" targetId="79b1-6a5e-70fc-d572" type="profile">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -18047,7 +18476,7 @@
               <selectionEntries/>
               <selectionEntryGroups/>
               <entryLinks>
-                <entryLink id="3102-d3e1-46f8-c0a3" name="New EntryLink" hidden="false" targetId="9ec1-5584-a623-fdda" type="selectionEntry">
+                <entryLink id="3102-d3e1-46f8-c0a3" name="Meltagun" hidden="false" targetId="efc8-c51d-5b02-a3a2" type="selectionEntry">
                   <profiles/>
                   <rules/>
                   <infoLinks/>
@@ -18057,7 +18486,7 @@
                   </constraints>
                   <categoryLinks/>
                 </entryLink>
-                <entryLink id="60e6-6596-118b-4efc" name="New EntryLink" hidden="false" targetId="7eb4-1d78-9058-f71a" type="selectionEntry">
+                <entryLink id="60e6-6596-118b-4efc" name="Heavy flamer" hidden="false" targetId="18bc-b335-29c2-2ae2" type="selectionEntry">
                   <profiles/>
                   <rules/>
                   <infoLinks/>
@@ -18081,7 +18510,7 @@
               <selectionEntries/>
               <selectionEntryGroups/>
               <entryLinks>
-                <entryLink id="a8a3-f676-948e-212e" name="New EntryLink" hidden="false" targetId="d74a-2fee-abea-1b42" type="selectionEntry">
+                <entryLink id="a8a3-f676-948e-212e" name="Storm bolter" hidden="false" targetId="2b03-8d64-3711-f300" type="selectionEntry">
                   <profiles/>
                   <rules/>
                   <infoLinks/>
@@ -18091,7 +18520,7 @@
                   </constraints>
                   <categoryLinks/>
                 </entryLink>
-                <entryLink id="ddc1-81a9-f2a5-6e9c" name="New EntryLink" hidden="false" targetId="7eb4-1d78-9058-f71a" type="selectionEntry">
+                <entryLink id="ddc1-81a9-f2a5-6e9c" name="Heavy flamer" hidden="false" targetId="18bc-b335-29c2-2ae2" type="selectionEntry">
                   <profiles/>
                   <rules/>
                   <infoLinks/>
@@ -18237,19 +18666,21 @@
       </selectionEntryGroups>
       <entryLinks/>
       <costs>
-        <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="10.0"/>
-        <cost name="pts" costTypeId="points" value="122.0"/>
+        <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="9.0"/>
+        <cost name="pts" costTypeId="points" value="80.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="343e-10d0-174e-ce90" name="Baal Predator" hidden="false" collective="false" type="model">
       <profiles>
-        <profile id="72a1-60b4-38eb-e04a" name="Explodes" hidden="false" profileTypeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" profileTypeName="Abilities">
+        <profile id="72a1-60b4-38eb-e04a" name="Explodes" hidden="false" profileTypeId="818c-0db1-36f0-462a" profileTypeName="Explosion">
           <profiles/>
           <rules/>
           <infoLinks/>
           <modifiers/>
           <characteristics>
-            <characteristic name="Description" characteristicTypeId="21befb24-fc85-4f52-a745-64b2e48f8228" value="If this model is reduced to 0 wounds, roll a D6 before removing the model from the battlefield; on a 6 it explodes, and each unit within 6&quot; suffers D3 mortal wounds."/>
+            <characteristic name="Dice roll" characteristicTypeId="f21d-8f6d-180d-36ff" value="6"/>
+            <characteristic name="Distance" characteristicTypeId="d69e-be07-1682-ebcc" value="6&quot;"/>
+            <characteristic name="Mortal wounds" characteristicTypeId="29f1-65a1-2c5d-8c7d" value="D3"/>
           </characteristics>
         </profile>
         <profile id="2f71-3868-a808-7ef0" name="Baal Predator" hidden="false" profileTypeId="5f4f-ea74-0630-4afe" profileTypeName="Wound Track">
@@ -18300,15 +18731,6 @@
             <characteristic name="Characteristic 3" characteristicTypeId="df06-8eca-150f-90ba" value="1"/>
           </characteristics>
         </profile>
-        <profile id="77fe-a7a5-435e-6458" name="Overcharged Engines" hidden="false" profileTypeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" profileTypeName="Abilities">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <characteristics>
-            <characteristic name="Description" characteristicTypeId="21befb24-fc85-4f52-a745-64b2e48f8228" value="When this model Advances roll 2 dice and pick the highest result."/>
-          </characteristics>
-        </profile>
       </profiles>
       <rules/>
       <infoLinks>
@@ -18319,6 +18741,12 @@
           <modifiers/>
         </infoLink>
         <infoLink id="df4f-d313-15fe-9a39" name="New InfoLink" hidden="false" targetId="c883-3078-1367-cc2c" type="profile">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="4378-d004-cbb2-5f7e" name="Overcharged Engines" hidden="false" targetId="7864-15b6-247d-2bed" type="profile">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -18393,7 +18821,7 @@
           <selectionEntries/>
           <selectionEntryGroups/>
           <entryLinks>
-            <entryLink id="ef01-2d99-4a0e-4d1a" name="Twin assault cannon" hidden="false" targetId="2f94-6e2f-de15-4a6c" type="selectionEntry">
+            <entryLink id="ef01-2d99-4a0e-4d1a" name="Twin assault cannon" book="" hidden="false" targetId="f787-a3af-72b5-60d1" type="selectionEntry">
               <profiles/>
               <rules/>
               <infoLinks/>
@@ -18403,7 +18831,7 @@
               </constraints>
               <categoryLinks/>
             </entryLink>
-            <entryLink id="e8a2-368c-dce7-787e" name="Flamestorm cannon" hidden="false" targetId="baef-4ad5-c92f-ac19" type="selectionEntry">
+            <entryLink id="e8a2-368c-dce7-787e" name="Flamestorm cannon" hidden="false" targetId="f09b-e29b-c7e0-c9e1" type="selectionEntry">
               <profiles/>
               <rules/>
               <infoLinks/>
@@ -18437,7 +18865,7 @@
               <selectionEntries/>
               <selectionEntryGroups/>
               <entryLinks>
-                <entryLink id="aa9d-6089-e09a-c9b8" name="New EntryLink" hidden="false" targetId="290a-8ad2-2af9-5ebc" type="selectionEntry">
+                <entryLink id="aa9d-6089-e09a-c9b8" name="Heavy bolter" hidden="false" targetId="05ab-e7cc-e856-c36f" type="selectionEntry">
                   <profiles/>
                   <rules/>
                   <infoLinks/>
@@ -18466,7 +18894,7 @@
               <selectionEntries/>
               <selectionEntryGroups/>
               <entryLinks>
-                <entryLink id="07b4-dc13-b7cf-f337" name="New EntryLink" hidden="false" targetId="7eb4-1d78-9058-f71a" type="selectionEntry">
+                <entryLink id="07b4-dc13-b7cf-f337" name="Heavy flamer" hidden="false" targetId="18bc-b335-29c2-2ae2" type="selectionEntry">
                   <profiles/>
                   <rules/>
                   <infoLinks/>
@@ -18489,7 +18917,7 @@
         </selectionEntryGroup>
       </selectionEntryGroups>
       <entryLinks>
-        <entryLink id="7735-1bee-2317-6885" name="Hunter-killer missile" hidden="false" targetId="4dda-f43f-5335-f49f" type="selectionEntry">
+        <entryLink id="7735-1bee-2317-6885" name="Hunter-killer missile" hidden="false" targetId="32bf-b117-4ecf-5165" type="selectionEntry">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -18499,7 +18927,7 @@
           </constraints>
           <categoryLinks/>
         </entryLink>
-        <entryLink id="08a2-37d1-3f59-0b3d" name="Storm bolter" hidden="false" targetId="d74a-2fee-abea-1b42" type="selectionEntry">
+        <entryLink id="08a2-37d1-3f59-0b3d" name="Storm bolter" hidden="false" targetId="2b03-8d64-3711-f300" type="selectionEntry">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -18512,30 +18940,11 @@
       </entryLinks>
       <costs>
         <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="8.0"/>
-        <cost name="pts" costTypeId="points" value="107.0"/>
+        <cost name="pts" costTypeId="points" value="100.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="11e1-8868-c4c7-3964" name="Gabriel Seth" hidden="false" collective="false" type="model">
-      <profiles>
-        <profile id="022d-97f4-bacd-19a0" name="Lord of Slaughter" hidden="false" profileTypeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" profileTypeName="Abilities">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <characteristics>
-            <characteristic name="Description" characteristicTypeId="21befb24-fc85-4f52-a745-64b2e48f8228" value="You can re-roll failed hit rolls for friendly FLESH TEARERS within 6&quot; of Gabriel Seth."/>
-          </characteristics>
-        </profile>
-        <profile id="43ba-5534-7af7-4956" name="Whirlwind of Gore" hidden="false" profileTypeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" profileTypeName="Abilities">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <characteristics>
-            <characteristic name="Description" characteristicTypeId="21befb24-fc85-4f52-a745-64b2e48f8228" value="Roll a D6 each time a friendly FLESH TEARERS unit finishes its move within 6&quot; of Gabriel Seth when it consolidates; on a 6 that unit can immediately fight for a second and final time."/>
-          </characteristics>
-        </profile>
-      </profiles>
+      <profiles/>
       <rules/>
       <infoLinks>
         <infoLink id="fe38-92d7-dce6-a292" name="Gabriel Seth" hidden="false" targetId="cf7e-f173-5071-b04f" type="profile">
@@ -18633,36 +19042,10 @@
           <constraints/>
         </categoryLink>
       </categoryLinks>
-      <selectionEntries>
-        <selectionEntry id="9bc0-d606-8779-ed54" name="Blood Reaver" hidden="false" collective="false" type="upgrade">
-          <profiles/>
-          <rules/>
-          <infoLinks>
-            <infoLink id="ed3d-8daf-5af3-1e80" name="New InfoLink" hidden="false" targetId="3bff-938a-ad45-efca" type="profile">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-            </infoLink>
-          </infoLinks>
-          <modifiers/>
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9186-b4f8-f50e-da9f" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5d94-bb03-1d80-0fad" type="max"/>
-          </constraints>
-          <categoryLinks/>
-          <selectionEntries/>
-          <selectionEntryGroups/>
-          <entryLinks/>
-          <costs>
-            <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="0.0"/>
-            <cost name="pts" costTypeId="points" value="0.0"/>
-          </costs>
-        </selectionEntry>
-      </selectionEntries>
+      <selectionEntries/>
       <selectionEntryGroups/>
       <entryLinks>
-        <entryLink id="65bc-8e90-2413-3739" name="Bolt pistol" hidden="false" targetId="bf86-1c1b-6871-da0b" type="selectionEntry">
+        <entryLink id="65bc-8e90-2413-3739" name="Bolt pistol" hidden="false" targetId="0334-f487-8229-0c1a" type="selectionEntry">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -18679,24 +19062,7 @@
           </constraints>
           <categoryLinks/>
         </entryLink>
-        <entryLink id="e153-bc58-b2c5-a333" name="New EntryLink" hidden="false" targetId="e897-c8fa-0976-e2d3" type="selectionEntry">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers>
-            <modifier type="set" field="points" value="0">
-              <repeats/>
-              <conditions/>
-              <conditionGroups/>
-            </modifier>
-          </modifiers>
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f341-6bf2-c3a1-fc81" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4b80-9a33-07b0-37cb" type="max"/>
-          </constraints>
-          <categoryLinks/>
-        </entryLink>
-        <entryLink id="2a91-8bbd-45b5-309d" name="Krak grenade" hidden="false" targetId="073b-2de5-765f-a4f2" type="selectionEntry">
+        <entryLink id="2a91-8bbd-45b5-309d" name="Frag &amp; Krak grenades" hidden="false" targetId="cddf-945e-1335-e681" type="selectionEntry">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -18713,1236 +19079,64 @@
           </constraints>
           <categoryLinks/>
         </entryLink>
+        <entryLink id="4d4f-d487-82ad-2047" name="Blood Reaver" hidden="false" targetId="24c2-f6fd-0c1f-dfe4" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0b62-5136-c10b-8a7c" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c304-8a8f-bad1-55db" type="max"/>
+          </constraints>
+          <categoryLinks/>
+        </entryLink>
+        <entryLink id="f57d-6426-f46c-38d6" name="Warlord" hidden="false" targetId="33f6-60da-7b70-5fee" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8cb0-4988-3ed6-41ed" type="max"/>
+          </constraints>
+          <categoryLinks/>
+        </entryLink>
+        <entryLink id="2a69-8f91-4940-0c51" name="6. Selfless Valour" hidden="true" targetId="5aac-e94d-2bcf-c1d1" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers>
+            <modifier type="set" field="2d68-eeb9-f598-cc14" value="1">
+              <repeats/>
+              <conditions>
+                <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="33f6-60da-7b70-5fee" type="equalTo"/>
+              </conditions>
+              <conditionGroups/>
+            </modifier>
+            <modifier type="set" field="0f7c-55cf-2846-0e8d" value="1">
+              <repeats/>
+              <conditions>
+                <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="33f6-60da-7b70-5fee" type="equalTo"/>
+              </conditions>
+              <conditionGroups/>
+            </modifier>
+            <modifier type="set" field="hidden" value="false">
+              <repeats/>
+              <conditions>
+                <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="33f6-60da-7b70-5fee" type="equalTo"/>
+              </conditions>
+              <conditionGroups/>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2d68-eeb9-f598-cc14" type="min"/>
+            <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0f7c-55cf-2846-0e8d" type="max"/>
+          </constraints>
+          <categoryLinks/>
+        </entryLink>
       </entryLinks>
       <costs>
         <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="7.0"/>
         <cost name="pts" costTypeId="points" value="135.0"/>
-      </costs>
-    </selectionEntry>
-    <selectionEntry id="7b26-e6ac-dce0-6897" name="Boltgun" hidden="false" collective="true" type="upgrade">
-      <profiles/>
-      <rules/>
-      <infoLinks>
-        <infoLink id="46a7-071d-7786-dfb5" name="New InfoLink" hidden="false" targetId="3d4b-95ea-f860-dd22" type="profile">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </infoLink>
-      </infoLinks>
-      <modifiers/>
-      <constraints/>
-      <categoryLinks/>
-      <selectionEntries/>
-      <selectionEntryGroups/>
-      <entryLinks/>
-      <costs>
-        <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="0.0"/>
-        <cost name="pts" costTypeId="points" value="0.0"/>
-      </costs>
-    </selectionEntry>
-    <selectionEntry id="e897-c8fa-0976-e2d3" name="Frag grenades" hidden="false" collective="true" type="upgrade">
-      <profiles/>
-      <rules/>
-      <infoLinks>
-        <infoLink id="eaec-42c7-1cc5-e609" name="New InfoLink" hidden="false" targetId="fdd8-1a5f-5722-d6ee" type="profile">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </infoLink>
-      </infoLinks>
-      <modifiers/>
-      <constraints/>
-      <categoryLinks/>
-      <selectionEntries/>
-      <selectionEntryGroups/>
-      <entryLinks/>
-      <costs>
-        <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="0.0"/>
-        <cost name="pts" costTypeId="points" value="0.0"/>
-      </costs>
-    </selectionEntry>
-    <selectionEntry id="073b-2de5-765f-a4f2" name="Krak grenades" hidden="false" collective="true" type="upgrade">
-      <profiles/>
-      <rules/>
-      <infoLinks>
-        <infoLink id="5444-8d6d-c386-5862" name="Krak grenade" hidden="false" targetId="3bf6-b4f7-6b2f-bb7b" type="profile">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </infoLink>
-      </infoLinks>
-      <modifiers/>
-      <constraints/>
-      <categoryLinks/>
-      <selectionEntries/>
-      <selectionEntryGroups/>
-      <entryLinks/>
-      <costs>
-        <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="0.0"/>
-        <cost name="pts" costTypeId="points" value="0.0"/>
-      </costs>
-    </selectionEntry>
-    <selectionEntry id="0367-b42c-b6b4-0a58" name="Bolt pistol" hidden="false" collective="true" type="upgrade">
-      <profiles/>
-      <rules/>
-      <infoLinks>
-        <infoLink id="08bd-1875-1262-39a6" name="Bolt pistol" hidden="false" targetId="e6d5-677a-d8ed-f6a5" type="profile">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </infoLink>
-      </infoLinks>
-      <modifiers/>
-      <constraints/>
-      <categoryLinks/>
-      <selectionEntries/>
-      <selectionEntryGroups/>
-      <entryLinks/>
-      <costs>
-        <cost name="pts" costTypeId="points" value="0.0"/>
-        <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="0.0"/>
-      </costs>
-    </selectionEntry>
-    <selectionEntry id="96be-57ab-99fc-4420" name="Bolt rifle" hidden="false" collective="true" type="upgrade">
-      <profiles/>
-      <rules/>
-      <infoLinks>
-        <infoLink id="983f-6400-1c09-2565" name="Bolt rifle" hidden="false" targetId="cddb-d686-f7b9-ec39" type="profile">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </infoLink>
-      </infoLinks>
-      <modifiers/>
-      <constraints/>
-      <categoryLinks/>
-      <selectionEntries/>
-      <selectionEntryGroups/>
-      <entryLinks/>
-      <costs>
-        <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="0.0"/>
-        <cost name="pts" costTypeId="points" value="0.0"/>
-      </costs>
-    </selectionEntry>
-    <selectionEntry id="e0b5-8115-e721-81f6" name="Assault bolter" hidden="false" collective="true" type="upgrade">
-      <profiles/>
-      <rules/>
-      <infoLinks>
-        <infoLink id="0b1e-cab7-48c0-2f41" name="Assault bolter" hidden="false" targetId="21ef-7459-ad22-ece0" type="profile">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </infoLink>
-      </infoLinks>
-      <modifiers/>
-      <constraints/>
-      <categoryLinks/>
-      <selectionEntries/>
-      <selectionEntryGroups/>
-      <entryLinks/>
-      <costs>
-        <cost name="pts" costTypeId="points" value="10.0"/>
-        <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="0.0"/>
-      </costs>
-    </selectionEntry>
-    <selectionEntry id="640e-ce8b-bba2-ce5f" name="Assault cannon" book="" hidden="false" collective="false" type="upgrade">
-      <profiles/>
-      <rules/>
-      <infoLinks>
-        <infoLink id="f6fc-0576-194a-921d" name="Assault cannon" hidden="false" targetId="20dc-1fbb-dc65-7f04" type="profile">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </infoLink>
-      </infoLinks>
-      <modifiers/>
-      <constraints/>
-      <categoryLinks/>
-      <selectionEntries/>
-      <selectionEntryGroups/>
-      <entryLinks/>
-      <costs>
-        <cost name="pts" costTypeId="points" value="22.0"/>
-        <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="0.0"/>
-      </costs>
-    </selectionEntry>
-    <selectionEntry id="22e0-2773-0a0f-ae62" name="Astartes grenade launcher" book="" hidden="false" collective="false" type="upgrade">
-      <profiles/>
-      <rules/>
-      <infoLinks>
-        <infoLink id="720f-d313-8664-10c6" name="Astartes grenade launcher" hidden="false" targetId="3735-f76f-f06c-1d71" type="profile">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </infoLink>
-        <infoLink id="d5fe-6d07-1df7-0d18" name="Astartes grenade launcher" hidden="false" targetId="ac6d-bf1b-73d0-e6af" type="profile">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </infoLink>
-      </infoLinks>
-      <modifiers/>
-      <constraints/>
-      <categoryLinks/>
-      <selectionEntries/>
-      <selectionEntryGroups/>
-      <entryLinks/>
-      <costs>
-        <cost name="pts" costTypeId="points" value="11.0"/>
-        <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="0.0"/>
-      </costs>
-    </selectionEntry>
-    <selectionEntry id="9ccd-823b-e317-5e31" name="Astartes shotgun" hidden="false" collective="false" type="upgrade">
-      <profiles/>
-      <rules/>
-      <infoLinks>
-        <infoLink id="44d6-1c42-eda5-d0d0" name="Astartes shotgun" hidden="false" targetId="961a-afdd-b0a9-f43d" type="profile">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </infoLink>
-      </infoLinks>
-      <modifiers/>
-      <constraints/>
-      <categoryLinks/>
-      <selectionEntries/>
-      <selectionEntryGroups/>
-      <entryLinks/>
-      <costs>
-        <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="0.0"/>
-        <cost name="pts" costTypeId="points" value="0.0"/>
-      </costs>
-    </selectionEntry>
-    <selectionEntry id="c62f-12cb-ee6b-ccaa" name="Autocannon" hidden="false" collective="true" type="upgrade">
-      <profiles/>
-      <rules/>
-      <infoLinks>
-        <infoLink id="930e-6114-ec52-b4cb" name="New InfoLink" hidden="false" targetId="fa99-0671-b31a-22d7" type="profile">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </infoLink>
-      </infoLinks>
-      <modifiers/>
-      <constraints/>
-      <categoryLinks/>
-      <selectionEntries/>
-      <selectionEntryGroups/>
-      <entryLinks/>
-      <costs>
-        <cost name="pts" costTypeId="points" value="20.0"/>
-        <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="0.0"/>
-      </costs>
-    </selectionEntry>
-    <selectionEntry id="805b-66bf-45d2-fcd3" name="Camo cloak" hidden="false" collective="false" type="upgrade">
-      <profiles/>
-      <rules/>
-      <infoLinks>
-        <infoLink id="613e-c4b5-e73f-4d3d" name="Camo cloak" hidden="false" targetId="b754-9672-4689-cefb" type="profile">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </infoLink>
-      </infoLinks>
-      <modifiers/>
-      <constraints/>
-      <categoryLinks/>
-      <selectionEntries/>
-      <selectionEntryGroups/>
-      <entryLinks/>
-      <costs>
-        <cost name="pts" costTypeId="points" value="3.0"/>
-        <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="0.0"/>
-      </costs>
-    </selectionEntry>
-    <selectionEntry id="587a-cf0a-2336-3117" name="Eviscerator" hidden="false" collective="false" type="upgrade">
-      <profiles/>
-      <rules/>
-      <infoLinks>
-        <infoLink id="889d-0829-8abf-08bd" name="Eviscerator" hidden="false" targetId="bb9f-390b-3b92-197c" type="profile">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </infoLink>
-      </infoLinks>
-      <modifiers/>
-      <constraints/>
-      <categoryLinks/>
-      <selectionEntries/>
-      <selectionEntryGroups/>
-      <entryLinks/>
-      <costs>
-        <cost name="pts" costTypeId="points" value="22.0"/>
-        <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="0.0"/>
-      </costs>
-    </selectionEntry>
-    <selectionEntry id="a255-3b4c-89e4-e6b3" name="Flamer" hidden="false" collective="false" type="upgrade">
-      <profiles/>
-      <rules/>
-      <infoLinks>
-        <infoLink id="9976-1fb2-222e-c44d" name="Flamer" hidden="false" targetId="cdc3-3459-a28c-a9cf" type="profile">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </infoLink>
-      </infoLinks>
-      <modifiers/>
-      <constraints/>
-      <categoryLinks/>
-      <selectionEntries/>
-      <selectionEntryGroups/>
-      <entryLinks/>
-      <costs>
-        <cost name="pts" costTypeId="points" value="9.0"/>
-        <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="0.0"/>
-      </costs>
-    </selectionEntry>
-    <selectionEntry id="5905-f299-f23c-f9c1" name="Chainsword" hidden="false" collective="true" type="upgrade">
-      <profiles/>
-      <rules/>
-      <infoLinks>
-        <infoLink id="d312-da6d-42be-eaa3" name="Chainsword" hidden="false" targetId="9b1e-61f9-4a5b-0044" type="profile">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </infoLink>
-      </infoLinks>
-      <modifiers/>
-      <constraints/>
-      <categoryLinks/>
-      <selectionEntries/>
-      <selectionEntryGroups/>
-      <entryLinks/>
-      <costs>
-        <cost name="pts" costTypeId="points" value="0.0"/>
-        <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="0.0"/>
-      </costs>
-    </selectionEntry>
-    <selectionEntry id="d83e-4dc3-0722-4206" name="Plasma pistol" hidden="false" collective="true" type="upgrade">
-      <profiles/>
-      <rules/>
-      <infoLinks>
-        <infoLink id="6616-b042-4279-e241" name="Plasma pistol" hidden="false" targetId="ff12-161a-ca85-339f" type="profile">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </infoLink>
-        <infoLink id="9c4b-e223-f20e-a91c" name="Plasma pistol" hidden="false" targetId="5779-2931-fe17-2b27" type="profile">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </infoLink>
-      </infoLinks>
-      <modifiers/>
-      <constraints/>
-      <categoryLinks/>
-      <selectionEntries/>
-      <selectionEntryGroups/>
-      <entryLinks/>
-      <costs>
-        <cost name="pts" costTypeId="points" value="7.0"/>
-        <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="0.0"/>
-      </costs>
-    </selectionEntry>
-    <selectionEntry id="5f8b-b9f4-ec1c-3316" name="Melta bombs" hidden="false" collective="false" type="upgrade">
-      <profiles/>
-      <rules/>
-      <infoLinks>
-        <infoLink id="09b8-47b7-883c-bf05" name="Melta bomb" hidden="false" targetId="df40-a3f4-91be-f0fe" type="profile">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </infoLink>
-      </infoLinks>
-      <modifiers/>
-      <constraints/>
-      <categoryLinks/>
-      <selectionEntries/>
-      <selectionEntryGroups/>
-      <entryLinks/>
-      <costs>
-        <cost name="pts" costTypeId="points" value="5.0"/>
-        <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="0.0"/>
-      </costs>
-    </selectionEntry>
-    <selectionEntry id="311e-ae83-ed70-26e9" name="Twin boltgun" hidden="false" collective="true" type="upgrade">
-      <profiles/>
-      <rules/>
-      <infoLinks>
-        <infoLink id="e887-dca3-8edd-30d8" name="Twin boltgun" hidden="false" targetId="6471-9a1a-0f1d-acb1" type="profile">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </infoLink>
-      </infoLinks>
-      <modifiers/>
-      <constraints/>
-      <categoryLinks/>
-      <selectionEntries/>
-      <selectionEntryGroups/>
-      <entryLinks/>
-      <costs>
-        <cost name="pts" costTypeId="points" value="2.0"/>
-        <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="0.0"/>
-      </costs>
-    </selectionEntry>
-    <selectionEntry id="290a-8ad2-2af9-5ebc" name="Heavy bolter" hidden="false" collective="false" type="upgrade">
-      <profiles/>
-      <rules/>
-      <infoLinks>
-        <infoLink id="a547-da0a-1907-c50d" name="Heavy bolter" hidden="false" targetId="e2b0-b9f1-6c38-584c" type="profile">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </infoLink>
-      </infoLinks>
-      <modifiers/>
-      <constraints/>
-      <categoryLinks/>
-      <selectionEntries/>
-      <selectionEntryGroups/>
-      <entryLinks/>
-      <costs>
-        <cost name="pts" costTypeId="points" value="10.0"/>
-        <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="0.0"/>
-      </costs>
-    </selectionEntry>
-    <selectionEntry id="9523-8395-ca20-2849" name="Multi-melta" hidden="false" collective="false" type="upgrade">
-      <profiles/>
-      <rules/>
-      <infoLinks>
-        <infoLink id="4ae3-830f-db9a-5457" name="Multi-melta" hidden="false" targetId="1768-d7b9-37ba-f3bf" type="profile">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </infoLink>
-      </infoLinks>
-      <modifiers/>
-      <constraints/>
-      <categoryLinks/>
-      <selectionEntries/>
-      <selectionEntryGroups/>
-      <entryLinks/>
-      <costs>
-        <cost name="pts" costTypeId="points" value="27.0"/>
-        <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="0.0"/>
-      </costs>
-    </selectionEntry>
-    <selectionEntry id="7eb4-1d78-9058-f71a" name="Heavy flamer" hidden="false" collective="false" type="upgrade">
-      <profiles/>
-      <rules/>
-      <infoLinks>
-        <infoLink id="8847-420f-eda2-ab16" name="Heavy flamer" hidden="false" targetId="2608-8425-4f4f-7f41" type="profile">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </infoLink>
-      </infoLinks>
-      <modifiers/>
-      <constraints/>
-      <categoryLinks/>
-      <selectionEntries/>
-      <selectionEntryGroups/>
-      <entryLinks/>
-      <costs>
-        <cost name="pts" costTypeId="points" value="17.0"/>
-        <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="0.0"/>
-      </costs>
-    </selectionEntry>
-    <selectionEntry id="2f94-6e2f-de15-4a6c" name="Twin assault cannon" hidden="false" collective="false" type="upgrade">
-      <profiles/>
-      <rules/>
-      <infoLinks>
-        <infoLink id="9301-c195-a490-1e1b" name="Twin assault cannon" hidden="false" targetId="acb8-7501-1f1b-b483" type="profile">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </infoLink>
-      </infoLinks>
-      <modifiers/>
-      <constraints/>
-      <categoryLinks/>
-      <selectionEntries/>
-      <selectionEntryGroups/>
-      <entryLinks/>
-      <costs>
-        <cost name="pts" costTypeId="points" value="44.0"/>
-        <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="0.0"/>
-      </costs>
-    </selectionEntry>
-    <selectionEntry id="ef67-7b07-f5c3-7d6c" name="Master-crafted boltgun" hidden="false" collective="false" type="upgrade">
-      <profiles/>
-      <rules/>
-      <infoLinks>
-        <infoLink id="41d9-1ce6-488f-23c6" name="Master-crafted boltgun" hidden="false" targetId="d6e5-a8cf-4602-28e0" type="profile">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </infoLink>
-      </infoLinks>
-      <modifiers/>
-      <constraints/>
-      <categoryLinks/>
-      <selectionEntries/>
-      <selectionEntryGroups/>
-      <entryLinks/>
-      <costs>
-        <cost name="pts" costTypeId="points" value="3.0"/>
-        <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="0.0"/>
-      </costs>
-    </selectionEntry>
-    <selectionEntry id="dc83-fc73-b7ae-62b6" name="Relic blade" hidden="false" collective="false" type="upgrade">
-      <profiles/>
-      <rules/>
-      <infoLinks>
-        <infoLink id="9a71-ce8a-7156-f3a7" name="Relic blade" hidden="false" targetId="ea0a-a19e-1e9a-b830" type="profile">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </infoLink>
-      </infoLinks>
-      <modifiers/>
-      <constraints/>
-      <categoryLinks/>
-      <selectionEntries/>
-      <selectionEntryGroups/>
-      <entryLinks/>
-      <costs>
-        <cost name="pts" costTypeId="points" value="21.0"/>
-        <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="0.0"/>
-      </costs>
-    </selectionEntry>
-    <selectionEntry id="4376-c122-ff61-5a1c" name="Storm shield" hidden="false" collective="false" type="upgrade">
-      <profiles/>
-      <rules/>
-      <infoLinks>
-        <infoLink id="1d15-5a67-ecf5-11bb" name="Storm shield" hidden="false" targetId="541d-ade9-7496-9c62" type="profile">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </infoLink>
-      </infoLinks>
-      <modifiers>
-        <modifier type="set" field="points" value="15">
-          <repeats/>
-          <conditions>
-            <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="ef18-746a-369f-43a4" type="instanceOf"/>
-          </conditions>
-          <conditionGroups/>
-        </modifier>
-      </modifiers>
-      <constraints/>
-      <categoryLinks/>
-      <selectionEntries/>
-      <selectionEntryGroups/>
-      <entryLinks/>
-      <costs>
-        <cost name="pts" costTypeId="points" value="5.0"/>
-        <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="0.0"/>
-      </costs>
-    </selectionEntry>
-    <selectionEntry id="7636-00cc-752b-c59b" name="Master-crafted power sword" hidden="false" collective="false" type="upgrade">
-      <profiles/>
-      <rules/>
-      <infoLinks>
-        <infoLink id="d30d-1cbf-6182-010d" name="Master-crafted power sword" hidden="false" targetId="4242-3014-c49c-9fe6" type="profile">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </infoLink>
-      </infoLinks>
-      <modifiers/>
-      <constraints/>
-      <categoryLinks/>
-      <selectionEntries/>
-      <selectionEntryGroups/>
-      <entryLinks/>
-      <costs>
-        <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="0.0"/>
-        <cost name="pts" costTypeId="points" value="10.0"/>
-      </costs>
-    </selectionEntry>
-    <selectionEntry id="ac6d-335e-9f02-e4f1" name="Boltstorm gauntlet" hidden="false" collective="false" type="upgrade">
-      <profiles/>
-      <rules/>
-      <infoLinks>
-        <infoLink id="20d5-55f1-1a23-48a5" name="Boltstorm gauntlet" hidden="false" targetId="a795-7f46-c006-36f9" type="profile">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </infoLink>
-        <infoLink id="8e3e-37c3-4db9-c7e9" name="Boltstorm gauntlet" hidden="false" targetId="eb60-1a3c-5699-dadb" type="profile">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </infoLink>
-      </infoLinks>
-      <modifiers/>
-      <constraints/>
-      <categoryLinks/>
-      <selectionEntries/>
-      <selectionEntryGroups/>
-      <entryLinks/>
-      <costs>
-        <cost name="pts" costTypeId="points" value="22.0"/>
-        <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="0.0"/>
-      </costs>
-    </selectionEntry>
-    <selectionEntry id="fdc6-5770-1177-74f4" name="Chainfist" hidden="false" collective="false" type="upgrade">
-      <profiles/>
-      <rules/>
-      <infoLinks>
-        <infoLink id="3f9f-3781-5b24-fb7e" name="Chainfist" hidden="false" targetId="8194-4688-65b3-f996" type="profile">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </infoLink>
-      </infoLinks>
-      <modifiers/>
-      <constraints/>
-      <categoryLinks/>
-      <selectionEntries/>
-      <selectionEntryGroups/>
-      <entryLinks/>
-      <costs>
-        <cost name="pts" costTypeId="points" value="22.0"/>
-        <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="0.0"/>
-      </costs>
-    </selectionEntry>
-    <selectionEntry id="8250-8444-3124-6714" name="Combat knife" hidden="false" collective="false" type="upgrade">
-      <profiles/>
-      <rules/>
-      <infoLinks>
-        <infoLink id="f2d4-e537-18c5-6c6f" name="Combat knife" hidden="false" targetId="397f-3a5d-7443-5144" type="profile">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </infoLink>
-      </infoLinks>
-      <modifiers/>
-      <constraints/>
-      <categoryLinks/>
-      <selectionEntries/>
-      <selectionEntryGroups/>
-      <entryLinks/>
-      <costs>
-        <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="0.0"/>
-        <cost name="pts" costTypeId="points" value="0.0"/>
-      </costs>
-    </selectionEntry>
-    <selectionEntry id="a052-e708-7e92-feb7" name="Combat shield" hidden="false" collective="true" type="upgrade">
-      <profiles/>
-      <rules/>
-      <infoLinks>
-        <infoLink id="131f-41bc-e3ea-eda5" name="Combat shield" hidden="false" targetId="d0a0-002c-8278-a70e" type="profile">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </infoLink>
-      </infoLinks>
-      <modifiers/>
-      <constraints/>
-      <categoryLinks/>
-      <selectionEntries/>
-      <selectionEntryGroups/>
-      <entryLinks/>
-      <costs>
-        <cost name="pts" costTypeId="points" value="4.0"/>
-        <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="0.0"/>
-      </costs>
-    </selectionEntry>
-    <selectionEntry id="a070-091c-f79c-7838" name="Combi-flamer" hidden="false" collective="false" type="upgrade">
-      <profiles/>
-      <rules/>
-      <infoLinks>
-        <infoLink id="b739-b80b-2911-9071" name="Combi-flamer" hidden="false" targetId="3d4b-95ea-f860-dd22" type="profile">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </infoLink>
-        <infoLink id="f718-a7fc-a816-9d6a" name="Combi-flamer" hidden="false" targetId="cdc3-3459-a28c-a9cf" type="profile">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </infoLink>
-      </infoLinks>
-      <modifiers/>
-      <constraints/>
-      <categoryLinks/>
-      <selectionEntries/>
-      <selectionEntryGroups/>
-      <entryLinks/>
-      <costs>
-        <cost name="pts" costTypeId="points" value="11.0"/>
-        <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="0.0"/>
-      </costs>
-    </selectionEntry>
-    <selectionEntry id="a80a-0476-1ef9-e1cc" name="Combi-grav" hidden="false" collective="false" type="upgrade">
-      <profiles/>
-      <rules/>
-      <infoLinks>
-        <infoLink id="4b54-6c80-f33d-2e44" name="Combi-grav" hidden="false" targetId="3d4b-95ea-f860-dd22" type="profile">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </infoLink>
-        <infoLink id="08e2-41e0-f275-aab5" name="Combi-grav" hidden="false" targetId="a3d2-b0d7-70bc-695e" type="profile">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </infoLink>
-      </infoLinks>
-      <modifiers/>
-      <constraints/>
-      <categoryLinks/>
-      <selectionEntries/>
-      <selectionEntryGroups/>
-      <entryLinks/>
-      <costs>
-        <cost name="pts" costTypeId="points" value="17.0"/>
-        <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="0.0"/>
-      </costs>
-    </selectionEntry>
-    <selectionEntry id="ce34-2e18-b818-b255" name="Combi-melta" hidden="false" collective="false" type="upgrade">
-      <profiles/>
-      <rules/>
-      <infoLinks>
-        <infoLink id="2bde-1a44-719e-7cef" name="Combi-melta" hidden="false" targetId="3d4b-95ea-f860-dd22" type="profile">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </infoLink>
-        <infoLink id="ed7f-9e89-ec0d-bb93" name="Combi-melta" hidden="false" targetId="ec4c-1132-ddaf-db8e" type="profile">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </infoLink>
-      </infoLinks>
-      <modifiers/>
-      <constraints/>
-      <categoryLinks/>
-      <selectionEntries/>
-      <selectionEntryGroups/>
-      <entryLinks/>
-      <costs>
-        <cost name="pts" costTypeId="points" value="19.0"/>
-        <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="0.0"/>
-      </costs>
-    </selectionEntry>
-    <selectionEntry id="1e2d-40cf-18d3-db7f" name="Combi-plasma" hidden="false" collective="false" type="upgrade">
-      <profiles/>
-      <rules/>
-      <infoLinks>
-        <infoLink id="1d75-b79d-a623-7fec" name="Combi-plasma" book="" hidden="false" targetId="3d4b-95ea-f860-dd22" type="profile">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </infoLink>
-        <infoLink id="0f0c-811f-b2de-f867" name="Combi-plasma" hidden="false" targetId="03e5-60f2-4726-5cdd" type="profile">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </infoLink>
-        <infoLink id="0594-1e31-c5e8-1e23" name="Combi-plasma" hidden="false" targetId="acb5-7b58-0d17-a33a" type="profile">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </infoLink>
-      </infoLinks>
-      <modifiers/>
-      <constraints/>
-      <categoryLinks/>
-      <selectionEntries/>
-      <selectionEntryGroups/>
-      <entryLinks/>
-      <costs>
-        <cost name="pts" costTypeId="points" value="15.0"/>
-        <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="0.0"/>
-      </costs>
-    </selectionEntry>
-    <selectionEntry id="0fb1-018a-de93-8509" name="Conversion beamer" hidden="false" collective="false" type="upgrade">
-      <profiles/>
-      <rules/>
-      <infoLinks>
-        <infoLink id="ca48-12bc-ee47-4e0e" name="Conversion beamer" hidden="false" targetId="60d6-1b2a-e2a8-5106" type="profile">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </infoLink>
-      </infoLinks>
-      <modifiers/>
-      <constraints/>
-      <categoryLinks/>
-      <selectionEntries/>
-      <selectionEntryGroups/>
-      <entryLinks/>
-      <costs>
-        <cost name="pts" costTypeId="points" value="20.0"/>
-        <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="0.0"/>
-      </costs>
-    </selectionEntry>
-    <selectionEntry id="5333-870f-3451-fcfa" name="Crozius arcanum" hidden="false" collective="false" type="upgrade">
-      <profiles/>
-      <rules/>
-      <infoLinks>
-        <infoLink id="b9c9-be88-92bf-6597" name="Crozius arcanum" hidden="false" targetId="e854-e9be-4a79-d56d" type="profile">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </infoLink>
-      </infoLinks>
-      <modifiers/>
-      <constraints/>
-      <categoryLinks/>
-      <selectionEntries/>
-      <selectionEntryGroups/>
-      <entryLinks/>
-      <costs>
-        <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="0.0"/>
-        <cost name="pts" costTypeId="points" value="0.0"/>
-      </costs>
-    </selectionEntry>
-    <selectionEntry id="25ce-f4e3-f00d-5035" name="Cyclone missile launcher" hidden="false" collective="false" type="upgrade">
-      <profiles/>
-      <rules/>
-      <infoLinks>
-        <infoLink id="7689-8c39-63d3-ad1a" name="Cyclone missile launcher" hidden="false" targetId="5207-ef08-27f7-166d" type="profile">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </infoLink>
-        <infoLink id="ab0c-d4ba-36b8-b6f6" name="Cyclone missile launcher" hidden="false" targetId="d9ac-d70c-de0b-1897" type="profile">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </infoLink>
-      </infoLinks>
-      <modifiers/>
-      <constraints/>
-      <categoryLinks/>
-      <selectionEntries/>
-      <selectionEntryGroups/>
-      <entryLinks/>
-      <costs>
-        <cost name="pts" costTypeId="points" value="50.0"/>
-        <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="0.0"/>
-      </costs>
-    </selectionEntry>
-    <selectionEntry id="d5e7-c159-7d9a-f6eb" name="Deathwind launcher" hidden="false" collective="false" type="upgrade">
-      <profiles/>
-      <rules/>
-      <infoLinks>
-        <infoLink id="12a9-7043-4837-c69d" name="Deathwind launcher" hidden="false" targetId="b1a9-6785-fb1a-a5cb" type="profile">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </infoLink>
-      </infoLinks>
-      <modifiers/>
-      <constraints/>
-      <categoryLinks/>
-      <selectionEntries/>
-      <selectionEntryGroups/>
-      <entryLinks/>
-      <costs>
-        <cost name="pts" costTypeId="points" value="5.0"/>
-        <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="0.0"/>
-      </costs>
-    </selectionEntry>
-    <selectionEntry id="0e25-be06-59c9-4f34" name="Demolisher cannon" hidden="false" collective="false" type="upgrade">
-      <profiles/>
-      <rules/>
-      <infoLinks>
-        <infoLink id="5c39-e772-313f-9474" name="Demolisher cannon" hidden="false" targetId="d2d1-43d6-8c52-7a6a" type="profile">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </infoLink>
-      </infoLinks>
-      <modifiers/>
-      <constraints/>
-      <categoryLinks/>
-      <selectionEntries/>
-      <selectionEntryGroups/>
-      <entryLinks/>
-      <costs>
-        <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="0.0"/>
-        <cost name="pts" costTypeId="points" value="0.0"/>
-      </costs>
-    </selectionEntry>
-    <selectionEntry id="7ac2-1efb-acb1-6277" name="Disintegration combi-gun" hidden="false" collective="false" type="upgrade">
-      <profiles/>
-      <rules/>
-      <infoLinks>
-        <infoLink id="f1f9-ba94-daba-d035" name="Disintegration combi-gun" hidden="false" targetId="3d4b-95ea-f860-dd22" type="profile">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </infoLink>
-        <infoLink id="32b5-7d8f-02ea-ea4e" name="Disintegration combi-gun" hidden="false" targetId="c86e-fd57-5a10-6b61" type="profile">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </infoLink>
-      </infoLinks>
-      <modifiers/>
-      <constraints/>
-      <categoryLinks/>
-      <selectionEntries/>
-      <selectionEntryGroups/>
-      <entryLinks/>
-      <costs>
-        <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="0.0"/>
-        <cost name="pts" costTypeId="points" value="0.0"/>
-      </costs>
-    </selectionEntry>
-    <selectionEntry id="5b44-7240-a6a2-459f" name="Disintegration pistol" hidden="false" collective="false" type="upgrade">
-      <profiles/>
-      <rules/>
-      <infoLinks>
-        <infoLink id="e83b-b060-2bb9-094e" name="Disintegration pistol" hidden="false" targetId="d015-8e37-8b3f-59b9" type="profile">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </infoLink>
-      </infoLinks>
-      <modifiers/>
-      <constraints/>
-      <categoryLinks/>
-      <selectionEntries/>
-      <selectionEntryGroups/>
-      <entryLinks/>
-      <costs>
-        <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="0.0"/>
-        <cost name="pts" costTypeId="points" value="0.0"/>
-      </costs>
-    </selectionEntry>
-    <selectionEntry id="078d-6aa5-2461-2185" name="Dreadnought combat weapon" hidden="false" collective="false" type="upgrade">
-      <profiles/>
-      <rules/>
-      <infoLinks>
-        <infoLink id="0e21-3ec5-3a6f-0013" name="Dreadnought combat weapon" hidden="false" targetId="3b26-3098-155f-0e58" type="profile">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </infoLink>
-      </infoLinks>
-      <modifiers>
-        <modifier type="set" field="points" value="0.0">
-          <repeats/>
-          <conditions>
-            <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="ad76-d653-9f96-093a" type="instanceOf"/>
-          </conditions>
-          <conditionGroups/>
-        </modifier>
-      </modifiers>
-      <constraints/>
-      <categoryLinks/>
-      <selectionEntries/>
-      <selectionEntryGroups/>
-      <entryLinks/>
-      <costs>
-        <cost name="pts" costTypeId="points" value="40.0"/>
-        <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="0.0"/>
-      </costs>
-    </selectionEntry>
-    <selectionEntry id="baef-4ad5-c92f-ac19" name="Flamestorm cannon" hidden="false" collective="false" type="upgrade">
-      <profiles/>
-      <rules/>
-      <infoLinks>
-        <infoLink id="0ac9-304f-2f42-0ee9" name="Flamestorm cannon" hidden="false" targetId="49ae-4451-9bc0-5238" type="profile">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </infoLink>
-      </infoLinks>
-      <modifiers/>
-      <constraints/>
-      <categoryLinks/>
-      <selectionEntries/>
-      <selectionEntryGroups/>
-      <entryLinks/>
-      <costs>
-        <cost name="pts" costTypeId="points" value="30.0"/>
-        <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="0.0"/>
-      </costs>
-    </selectionEntry>
-    <selectionEntry id="759c-5bf6-02f6-e772" name="Force axe" hidden="false" collective="false" type="upgrade">
-      <profiles/>
-      <rules/>
-      <infoLinks>
-        <infoLink id="554c-80d2-2663-a898" name="Force axe" hidden="false" targetId="c019-5c9a-c1f4-4b4f" type="profile">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </infoLink>
-      </infoLinks>
-      <modifiers/>
-      <constraints/>
-      <categoryLinks/>
-      <selectionEntries/>
-      <selectionEntryGroups/>
-      <entryLinks/>
-      <costs>
-        <cost name="pts" costTypeId="points" value="10.0"/>
-        <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="0.0"/>
-      </costs>
-    </selectionEntry>
-    <selectionEntry id="c7c7-c781-6eb6-a672" name="Force stave" hidden="false" collective="false" type="upgrade">
-      <profiles/>
-      <rules/>
-      <infoLinks>
-        <infoLink id="b580-48db-424e-542f" name="Force stave" hidden="false" targetId="ed69-f85e-5982-9ab8" type="profile">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </infoLink>
-      </infoLinks>
-      <modifiers/>
-      <constraints/>
-      <categoryLinks/>
-      <selectionEntries/>
-      <selectionEntryGroups/>
-      <entryLinks/>
-      <costs>
-        <cost name="pts" costTypeId="points" value="8.0"/>
-        <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="0.0"/>
-      </costs>
-    </selectionEntry>
-    <selectionEntry id="63d7-bf06-757d-3da2" name="Force sword" hidden="false" collective="false" type="upgrade">
-      <profiles/>
-      <rules/>
-      <infoLinks>
-        <infoLink id="83bc-1985-64a1-bcf4" name="Force sword" hidden="false" targetId="29c5-cff6-7f7c-96d6" type="profile">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </infoLink>
-      </infoLinks>
-      <modifiers/>
-      <constraints/>
-      <categoryLinks/>
-      <selectionEntries/>
-      <selectionEntryGroups/>
-      <entryLinks/>
-      <costs>
-        <cost name="pts" costTypeId="points" value="8.0"/>
-        <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="0.0"/>
-      </costs>
-    </selectionEntry>
-    <selectionEntry id="68f5-b30c-1556-e4ac" name="Grav-cannon and grav-amp" hidden="false" collective="false" type="upgrade">
-      <profiles/>
-      <rules/>
-      <infoLinks>
-        <infoLink id="b1a0-2205-2ef6-78c6" name="Grav-cannon and grav-amp" hidden="false" targetId="c76b-4051-dbf4-d5b8" type="profile">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </infoLink>
-      </infoLinks>
-      <modifiers/>
-      <constraints/>
-      <categoryLinks/>
-      <selectionEntries/>
-      <selectionEntryGroups/>
-      <entryLinks/>
-      <costs>
-        <cost name="pts" costTypeId="points" value="28.0"/>
-        <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="0.0"/>
-      </costs>
-    </selectionEntry>
-    <selectionEntry id="5043-0a0a-25d7-3c6d" name="Grav-gun" hidden="false" collective="false" type="upgrade">
-      <profiles/>
-      <rules/>
-      <infoLinks>
-        <infoLink id="9949-7474-b377-fe96" name="Grav-gun" hidden="false" targetId="a3d2-b0d7-70bc-695e" type="profile">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </infoLink>
-      </infoLinks>
-      <modifiers/>
-      <constraints/>
-      <categoryLinks/>
-      <selectionEntries/>
-      <selectionEntryGroups/>
-      <entryLinks/>
-      <costs>
-        <cost name="pts" costTypeId="points" value="15.0"/>
-        <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="0.0"/>
-      </costs>
-    </selectionEntry>
-    <selectionEntry id="9f58-3b91-fa2e-32e2" name="Grav-pistol" hidden="false" collective="false" type="upgrade">
-      <profiles/>
-      <rules/>
-      <infoLinks>
-        <infoLink id="0ca4-269a-b347-1fc1" name="Grav-pistol" hidden="false" targetId="7b30-68a4-3745-c6fa" type="profile">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </infoLink>
-      </infoLinks>
-      <modifiers/>
-      <constraints/>
-      <categoryLinks/>
-      <selectionEntries/>
-      <selectionEntryGroups/>
-      <entryLinks/>
-      <costs>
-        <cost name="pts" costTypeId="points" value="8.0"/>
-        <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="0.0"/>
-      </costs>
-    </selectionEntry>
-    <selectionEntry id="82cc-cf20-dcc6-ab64" name="Heavy plasma cannon" hidden="false" collective="false" type="upgrade">
-      <profiles/>
-      <rules/>
-      <infoLinks>
-        <infoLink id="e2d4-1ad1-46e9-187f" name="Heavy plasma cannon" hidden="false" targetId="9272-c0bc-9bd7-e6e0" type="profile">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </infoLink>
-        <infoLink id="3be2-8144-82f7-e6f0" name="Heavy plasma cannon" hidden="false" targetId="691d-11e2-ebfb-d4ad" type="profile">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </infoLink>
-      </infoLinks>
-      <modifiers/>
-      <constraints/>
-      <categoryLinks/>
-      <selectionEntries/>
-      <selectionEntryGroups/>
-      <entryLinks/>
-      <costs>
-        <cost name="pts" costTypeId="points" value="30.0"/>
-        <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="0.0"/>
-      </costs>
-    </selectionEntry>
-    <selectionEntry id="4dda-f43f-5335-f49f" name="Hunter-killer missile" hidden="false" collective="false" type="upgrade">
-      <profiles/>
-      <rules/>
-      <infoLinks>
-        <infoLink id="dcad-bcef-4155-a56f" name="Hunter-killer missile" hidden="false" targetId="e2a9-e8fc-3a6b-2eec" type="profile">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </infoLink>
-      </infoLinks>
-      <modifiers/>
-      <constraints/>
-      <categoryLinks/>
-      <selectionEntries/>
-      <selectionEntryGroups/>
-      <entryLinks/>
-      <costs>
-        <cost name="pts" costTypeId="points" value="6.0"/>
-        <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="0.0"/>
-      </costs>
-    </selectionEntry>
-    <selectionEntry id="96fa-18f1-3b9d-974c" name="Hurricane bolter" hidden="false" collective="false" type="upgrade">
-      <profiles/>
-      <rules/>
-      <infoLinks>
-        <infoLink id="2638-aa31-7b80-5e41" name="Hurricane bolter" hidden="false" targetId="0c32-fc5b-5235-f6ba" type="profile">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </infoLink>
-      </infoLinks>
-      <modifiers/>
-      <constraints/>
-      <categoryLinks/>
-      <selectionEntries/>
-      <selectionEntryGroups/>
-      <entryLinks/>
-      <costs>
-        <cost name="pts" costTypeId="points" value="10.0"/>
-        <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="0.0"/>
-      </costs>
-    </selectionEntry>
-    <selectionEntry id="7c7d-abb2-d8b9-2d9c" name="Lascannon" hidden="false" collective="false" type="upgrade">
-      <profiles/>
-      <rules/>
-      <infoLinks>
-        <infoLink id="7c8b-4ebe-84a7-bb7c" name="Lascannon" hidden="false" targetId="f14a-07e5-5465-69cf" type="profile">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </infoLink>
-      </infoLinks>
-      <modifiers/>
-      <constraints/>
-      <categoryLinks/>
-      <selectionEntries/>
-      <selectionEntryGroups/>
-      <entryLinks/>
-      <costs>
-        <cost name="pts" costTypeId="points" value="25.0"/>
-        <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="4fd6-1688-d86c-3510" name="Lightning Claw" hidden="false" collective="false" type="upgrade">
@@ -19997,841 +19191,9 @@
         <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="aab9-369a-8f8d-1606" name="Master-crafted auto bolt rifle" hidden="false" collective="false" type="upgrade">
-      <profiles/>
-      <rules/>
-      <infoLinks>
-        <infoLink id="95f9-dc36-6d89-3d38" name="Master-crafted auto bolt rifle" hidden="false" targetId="1f2f-512e-9ca3-13f9" type="profile">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </infoLink>
-      </infoLinks>
-      <modifiers/>
-      <constraints/>
-      <categoryLinks/>
-      <selectionEntries/>
-      <selectionEntryGroups/>
-      <entryLinks/>
-      <costs>
-        <cost name="pts" costTypeId="points" value="4.0"/>
-        <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="0.0"/>
-      </costs>
-    </selectionEntry>
-    <selectionEntry id="9ec1-5584-a623-fdda" name="Meltagun" hidden="false" collective="false" type="upgrade">
-      <profiles/>
-      <rules/>
-      <infoLinks>
-        <infoLink id="ee20-9f63-e421-bb9b" name="Meltagun" hidden="false" targetId="ec4c-1132-ddaf-db8e" type="profile">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </infoLink>
-      </infoLinks>
-      <modifiers/>
-      <constraints/>
-      <categoryLinks/>
-      <selectionEntries/>
-      <selectionEntryGroups/>
-      <entryLinks/>
-      <costs>
-        <cost name="pts" costTypeId="points" value="17.0"/>
-        <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="0.0"/>
-      </costs>
-    </selectionEntry>
-    <selectionEntry id="96f3-141e-f073-d314" name="Missile launcher" hidden="false" collective="false" type="upgrade">
-      <profiles/>
-      <rules/>
-      <infoLinks>
-        <infoLink id="6f8a-e99c-90d5-1678" name="Missile launcher" hidden="false" targetId="603d-3e82-38f6-c5c3" type="profile">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </infoLink>
-        <infoLink id="b28e-1216-fb06-aacb" name="Missile launcher" hidden="false" targetId="8161-3b0e-8048-0e83" type="profile">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </infoLink>
-      </infoLinks>
-      <modifiers/>
-      <constraints/>
-      <categoryLinks/>
-      <selectionEntries/>
-      <selectionEntryGroups/>
-      <entryLinks/>
-      <costs>
-        <cost name="pts" costTypeId="points" value="25.0"/>
-        <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="0.0"/>
-      </costs>
-    </selectionEntry>
-    <selectionEntry id="cc33-411c-60b0-fdec" name="Plasma cannon" hidden="false" collective="false" type="upgrade">
-      <profiles/>
-      <rules/>
-      <infoLinks>
-        <infoLink id="1c99-705a-fb41-6f27" name="Plasma cannon" hidden="false" targetId="7983-8451-cdc3-ce7e" type="profile">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </infoLink>
-        <infoLink id="ce4f-7cfa-4daa-5243" name="Plasma cannon" hidden="false" targetId="fbb2-f4cb-e47d-1d10" type="profile">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </infoLink>
-      </infoLinks>
-      <modifiers/>
-      <constraints/>
-      <categoryLinks/>
-      <selectionEntries/>
-      <selectionEntryGroups/>
-      <entryLinks/>
-      <costs>
-        <cost name="pts" costTypeId="points" value="21.0"/>
-        <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="0.0"/>
-      </costs>
-    </selectionEntry>
-    <selectionEntry id="c3f2-5ecb-a2ae-a92f" name="Plasma cutter" hidden="false" collective="false" type="upgrade">
-      <profiles/>
-      <rules/>
-      <infoLinks>
-        <infoLink id="3299-48f6-db28-1828" name="Plasma cutter" hidden="false" targetId="614c-c09f-c4b4-504f" type="profile">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </infoLink>
-        <infoLink id="a44e-67eb-86eb-945e" name="Plasma cutter" hidden="false" targetId="7eea-38c1-0f2c-ce0f" type="profile">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </infoLink>
-      </infoLinks>
-      <modifiers/>
-      <constraints/>
-      <categoryLinks/>
-      <selectionEntries/>
-      <selectionEntryGroups/>
-      <entryLinks/>
-      <costs>
-        <cost name="pts" costTypeId="points" value="7.0"/>
-        <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="0.0"/>
-      </costs>
-    </selectionEntry>
-    <selectionEntry id="be22-4d06-c69b-5310" name="Plasma gun" hidden="false" collective="false" type="upgrade">
-      <profiles/>
-      <rules/>
-      <infoLinks>
-        <infoLink id="6d4c-c4ea-3bba-d84e" name="Plasma gun" hidden="false" targetId="03e5-60f2-4726-5cdd" type="profile">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </infoLink>
-        <infoLink id="bdec-5d9b-1fd0-4de5" name="Plasma gun" hidden="false" targetId="acb5-7b58-0d17-a33a" type="profile">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </infoLink>
-      </infoLinks>
-      <modifiers/>
-      <constraints/>
-      <categoryLinks/>
-      <selectionEntries/>
-      <selectionEntryGroups/>
-      <entryLinks/>
-      <costs>
-        <cost name="pts" costTypeId="points" value="13.0"/>
-        <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="0.0"/>
-      </costs>
-    </selectionEntry>
-    <selectionEntry id="0919-4387-aaf7-b60c" name="Plasma incinerator" hidden="false" collective="true" type="upgrade">
-      <profiles/>
-      <rules/>
-      <infoLinks>
-        <infoLink id="d6e5-0cbe-0ee8-1f28" name="Plasma incinerator" hidden="false" targetId="474e-aeec-1b23-c181" type="profile">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </infoLink>
-        <infoLink id="8056-2ea2-2c6e-d005" name="Plasma incinerator" hidden="false" targetId="bd7b-6edf-e450-9b4a" type="profile">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </infoLink>
-      </infoLinks>
-      <modifiers/>
-      <constraints/>
-      <categoryLinks/>
-      <selectionEntries/>
-      <selectionEntryGroups/>
-      <entryLinks/>
-      <costs>
-        <cost name="pts" costTypeId="points" value="15.0"/>
-        <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="0.0"/>
-      </costs>
-    </selectionEntry>
-    <selectionEntry id="8d13-0f69-a808-e300" name="Power axe" hidden="false" collective="false" type="upgrade">
-      <profiles/>
-      <rules/>
-      <infoLinks>
-        <infoLink id="fd30-3972-5de4-f48a" name="Power axe" hidden="false" targetId="4635-64e7-2344-ea7c" type="profile">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </infoLink>
-      </infoLinks>
-      <modifiers/>
-      <constraints/>
-      <categoryLinks/>
-      <selectionEntries/>
-      <selectionEntryGroups/>
-      <entryLinks/>
-      <costs>
-        <cost name="pts" costTypeId="points" value="5.0"/>
-        <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="0.0"/>
-      </costs>
-    </selectionEntry>
-    <selectionEntry id="3102-2dd8-4f31-3af7" name="Power fist" hidden="false" collective="false" type="upgrade">
-      <profiles/>
-      <rules/>
-      <infoLinks>
-        <infoLink id="3bd9-a4c2-c1c2-7c61" name="Power fist" hidden="false" targetId="3520-0bb4-90f2-084b" type="profile">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </infoLink>
-      </infoLinks>
-      <modifiers/>
-      <constraints/>
-      <categoryLinks/>
-      <selectionEntries/>
-      <selectionEntryGroups/>
-      <entryLinks/>
-      <costs>
-        <cost name="pts" costTypeId="points" value="12.0"/>
-        <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="0.0"/>
-      </costs>
-    </selectionEntry>
-    <selectionEntry id="f2c7-e0ae-58d4-205a" name="Power lance" hidden="false" collective="false" type="upgrade">
-      <profiles/>
-      <rules/>
-      <infoLinks>
-        <infoLink id="8ad8-b4a6-b933-dfe2" name="Power lance" hidden="false" targetId="de62-5c9a-e27d-3fa3" type="profile">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </infoLink>
-      </infoLinks>
-      <modifiers/>
-      <constraints/>
-      <categoryLinks/>
-      <selectionEntries/>
-      <selectionEntryGroups/>
-      <entryLinks/>
-      <costs>
-        <cost name="pts" costTypeId="points" value="4.0"/>
-        <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="0.0"/>
-      </costs>
-    </selectionEntry>
-    <selectionEntry id="b22c-5019-c613-fb74" name="Power maul" hidden="false" collective="false" type="upgrade">
-      <profiles/>
-      <rules/>
-      <infoLinks>
-        <infoLink id="99e6-1491-84a8-1e94" name="Power maul" hidden="false" targetId="ca27-e5ee-f6eb-652d" type="profile">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </infoLink>
-      </infoLinks>
-      <modifiers/>
-      <constraints/>
-      <categoryLinks/>
-      <selectionEntries/>
-      <selectionEntryGroups/>
-      <entryLinks/>
-      <costs>
-        <cost name="pts" costTypeId="points" value="4.0"/>
-        <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="0.0"/>
-      </costs>
-    </selectionEntry>
-    <selectionEntry id="c3d0-2567-35c6-3f29" name="Power sword" hidden="false" collective="false" type="upgrade">
-      <profiles/>
-      <rules/>
-      <infoLinks>
-        <infoLink id="ba3b-f6af-9417-764d" name="Power sword" hidden="false" targetId="47df-8e01-d0cf-58e8" type="profile">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </infoLink>
-      </infoLinks>
-      <modifiers/>
-      <constraints/>
-      <categoryLinks/>
-      <selectionEntries/>
-      <selectionEntryGroups/>
-      <entryLinks/>
-      <costs>
-        <cost name="pts" costTypeId="points" value="4.0"/>
-        <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="0.0"/>
-      </costs>
-    </selectionEntry>
-    <selectionEntry id="4b5e-82ac-65a7-7d9a" name="Predator autocannon" hidden="false" collective="false" type="upgrade">
-      <profiles/>
-      <rules/>
-      <infoLinks>
-        <infoLink id="df93-92ef-9664-b03d" name="Predator autocannon" hidden="false" targetId="2c56-ff56-a155-032d" type="profile">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </infoLink>
-      </infoLinks>
-      <modifiers/>
-      <constraints/>
-      <categoryLinks/>
-      <selectionEntries/>
-      <selectionEntryGroups/>
-      <entryLinks/>
-      <costs>
-        <cost name="pts" costTypeId="points" value="40.0"/>
-        <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="0.0"/>
-      </costs>
-    </selectionEntry>
-    <selectionEntry id="fb0f-7f69-e952-07dc" name="Servo-arm" hidden="false" collective="false" type="upgrade">
-      <profiles/>
-      <rules/>
-      <infoLinks>
-        <infoLink id="a547-293a-65c3-fb80" name="Servo-arm" hidden="false" targetId="9112-c49a-ee46-0f81" type="profile">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </infoLink>
-      </infoLinks>
-      <modifiers/>
-      <constraints/>
-      <categoryLinks/>
-      <selectionEntries/>
-      <selectionEntryGroups/>
-      <entryLinks/>
-      <costs>
-        <cost name="pts" costTypeId="points" value="12.0"/>
-        <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="0.0"/>
-      </costs>
-    </selectionEntry>
-    <selectionEntry id="012c-bc61-0ee5-aff4" name="Sniper rifle" hidden="false" collective="false" type="upgrade">
-      <profiles/>
-      <rules/>
-      <infoLinks>
-        <infoLink id="d73e-d197-2513-e600" name="Sniper rifle" hidden="false" targetId="45a4-5982-7f8b-fb33" type="profile">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </infoLink>
-      </infoLinks>
-      <modifiers/>
-      <constraints/>
-      <categoryLinks/>
-      <selectionEntries/>
-      <selectionEntryGroups/>
-      <entryLinks/>
-      <costs>
-        <cost name="pts" costTypeId="points" value="4.0"/>
-        <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="0.0"/>
-      </costs>
-    </selectionEntry>
-    <selectionEntry id="ac47-fbfd-4381-3191" name="Special issue boltgun" hidden="false" collective="false" type="upgrade">
-      <profiles/>
-      <rules/>
-      <infoLinks>
-        <infoLink id="8298-345b-a066-85d5" name="Special issue boltgun" hidden="false" targetId="a57c-ff3f-49d4-f3b8" type="profile">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </infoLink>
-      </infoLinks>
-      <modifiers/>
-      <constraints/>
-      <categoryLinks/>
-      <selectionEntries/>
-      <selectionEntryGroups/>
-      <entryLinks/>
-      <costs>
-        <cost name="pts" costTypeId="points" value="2.0"/>
-        <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="0.0"/>
-      </costs>
-    </selectionEntry>
-    <selectionEntry id="d74a-2fee-abea-1b42" name="Storm bolter" hidden="false" collective="false" type="upgrade">
-      <profiles/>
-      <rules/>
-      <infoLinks>
-        <infoLink id="5e53-bb9f-4954-4e74" name="Storm bolter" hidden="false" targetId="505e-a5aa-edab-6d5b" type="profile">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </infoLink>
-      </infoLinks>
-      <modifiers/>
-      <constraints/>
-      <categoryLinks/>
-      <selectionEntries/>
-      <selectionEntryGroups/>
-      <entryLinks/>
-      <costs>
-        <cost name="pts" costTypeId="points" value="2.0"/>
-        <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="0.0"/>
-      </costs>
-    </selectionEntry>
-    <selectionEntry id="7057-ee87-f5bf-5e42" name="Thunder hammer" hidden="false" collective="false" type="upgrade">
-      <profiles/>
-      <rules/>
-      <infoLinks>
-        <infoLink id="f85d-6115-aa25-572e" name="Thunder hammer" hidden="false" targetId="87b3-3f6b-ada0-da8d" type="profile">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </infoLink>
-      </infoLinks>
-      <modifiers>
-        <modifier type="set" field="points" value="21">
-          <repeats/>
-          <conditions>
-            <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="ef18-746a-369f-43a4" type="instanceOf"/>
-          </conditions>
-          <conditionGroups/>
-        </modifier>
-      </modifiers>
-      <constraints/>
-      <categoryLinks/>
-      <selectionEntries/>
-      <selectionEntryGroups/>
-      <entryLinks/>
-      <costs>
-        <cost name="pts" costTypeId="points" value="16.0"/>
-        <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="0.0"/>
-      </costs>
-    </selectionEntry>
-    <selectionEntry id="2837-2f42-e4d7-56c6" name="Twin autocannon" hidden="false" collective="false" type="upgrade">
-      <profiles/>
-      <rules/>
-      <infoLinks>
-        <infoLink id="082e-7b3d-365f-9023" name="Twin autocannon" hidden="false" targetId="3a89-dec9-f41d-7719" type="profile">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </infoLink>
-      </infoLinks>
-      <modifiers/>
-      <constraints/>
-      <categoryLinks/>
-      <selectionEntries/>
-      <selectionEntryGroups/>
-      <entryLinks/>
-      <costs>
-        <cost name="pts" costTypeId="points" value="33.0"/>
-        <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="0.0"/>
-      </costs>
-    </selectionEntry>
-    <selectionEntry id="b310-1fca-9564-5812" name="Twin heavy bolter" hidden="false" collective="false" type="upgrade">
-      <profiles/>
-      <rules/>
-      <infoLinks>
-        <infoLink id="12e7-0263-237f-db86" name="Twin heavy bolter" hidden="false" targetId="6644-7150-c910-865d" type="profile">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </infoLink>
-      </infoLinks>
-      <modifiers/>
-      <constraints/>
-      <categoryLinks/>
-      <selectionEntries/>
-      <selectionEntryGroups/>
-      <entryLinks/>
-      <costs>
-        <cost name="pts" costTypeId="points" value="17.0"/>
-        <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="0.0"/>
-      </costs>
-    </selectionEntry>
-    <selectionEntry id="a2b8-1ccb-c9d3-1141" name="Orbital array" hidden="false" collective="false" type="upgrade">
-      <profiles/>
-      <rules/>
-      <infoLinks>
-        <infoLink id="0530-ed66-bc89-45e1" name="Orbital array" hidden="false" targetId="f434-6eb5-9a60-79cf" type="profile">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </infoLink>
-      </infoLinks>
-      <modifiers/>
-      <constraints/>
-      <categoryLinks/>
-      <selectionEntries/>
-      <selectionEntryGroups/>
-      <entryLinks/>
-      <costs>
-        <cost name="pts" costTypeId="points" value="50.0"/>
-        <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="0.0"/>
-      </costs>
-    </selectionEntry>
-    <selectionEntry id="256f-ce46-d4c9-02dc" name="Twin heavy flamer" hidden="false" collective="false" type="upgrade">
-      <profiles/>
-      <rules/>
-      <infoLinks>
-        <infoLink id="dba6-dd64-3e0e-861b" name="Twin heavy flamer" hidden="false" targetId="1a79-9730-f078-07b6" type="profile">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </infoLink>
-      </infoLinks>
-      <modifiers/>
-      <constraints/>
-      <categoryLinks/>
-      <selectionEntries/>
-      <selectionEntryGroups/>
-      <entryLinks/>
-      <costs>
-        <cost name="pts" costTypeId="points" value="34.0"/>
-        <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="0.0"/>
-      </costs>
-    </selectionEntry>
-    <selectionEntry id="13b6-1003-db44-fdb0" name="Twin heavy plasma cannon" hidden="false" collective="false" type="upgrade">
-      <profiles/>
-      <rules/>
-      <infoLinks>
-        <infoLink id="84d2-826d-93bc-cf62" name="Twin heavy plasma cannon" hidden="false" targetId="3f51-8cbe-78c2-0b36" type="profile">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </infoLink>
-        <infoLink id="af7f-9711-ca9e-b3fb" name="Twin heavy plasma cannon" hidden="false" targetId="f2db-d913-989b-2841" type="profile">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </infoLink>
-      </infoLinks>
-      <modifiers/>
-      <constraints/>
-      <categoryLinks/>
-      <selectionEntries/>
-      <selectionEntryGroups/>
-      <entryLinks/>
-      <costs>
-        <cost name="pts" costTypeId="points" value="34.0"/>
-        <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="0.0"/>
-      </costs>
-    </selectionEntry>
-    <selectionEntry id="de7a-7bba-e2c5-c37c" name="Twin lascannon" hidden="false" collective="false" type="upgrade">
-      <profiles/>
-      <rules/>
-      <infoLinks>
-        <infoLink id="a00c-dcb6-4768-76e3" name="Twin lascannon" hidden="false" targetId="1662-54b9-46da-fefc" type="profile">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </infoLink>
-      </infoLinks>
-      <modifiers/>
-      <constraints/>
-      <categoryLinks/>
-      <selectionEntries/>
-      <selectionEntryGroups/>
-      <entryLinks/>
-      <costs>
-        <cost name="pts" costTypeId="points" value="50.0"/>
-        <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="0.0"/>
-      </costs>
-    </selectionEntry>
-    <selectionEntry id="abe0-0b05-cdd5-6f52" name="Twin plasma gun" hidden="false" collective="false" type="upgrade">
-      <profiles/>
-      <rules/>
-      <infoLinks>
-        <infoLink id="8623-7801-d815-a667" name="Twin plasma gun" hidden="false" targetId="f7ba-88b9-c604-cd89" type="profile">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </infoLink>
-        <infoLink id="c7ae-eccf-c190-c186" name="Twin plasma gun" hidden="false" targetId="840a-7f35-72ad-baef" type="profile">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </infoLink>
-      </infoLinks>
-      <modifiers/>
-      <constraints/>
-      <categoryLinks/>
-      <selectionEntries/>
-      <selectionEntryGroups/>
-      <entryLinks/>
-      <costs>
-        <cost name="pts" costTypeId="points" value="20.0"/>
-        <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="0.0"/>
-      </costs>
-    </selectionEntry>
-    <selectionEntry id="a44a-4a6a-4886-274c" name="Typhoon missile launcher" hidden="false" collective="false" type="upgrade">
-      <profiles/>
-      <rules/>
-      <infoLinks>
-        <infoLink id="b878-56a5-b6e7-4c42" name="Typhoon missile launcher" hidden="false" targetId="b1e6-7453-eb78-87c1" type="profile">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </infoLink>
-        <infoLink id="ff3e-4727-05e2-67ba" name="Typhoon missile launcher" hidden="false" targetId="aea5-27f0-dcde-06c1" type="profile">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </infoLink>
-      </infoLinks>
-      <modifiers/>
-      <constraints/>
-      <categoryLinks/>
-      <selectionEntries/>
-      <selectionEntryGroups/>
-      <entryLinks/>
-      <costs>
-        <cost name="pts" costTypeId="points" value="50.0"/>
-        <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="0.0"/>
-      </costs>
-    </selectionEntry>
-    <selectionEntry id="fb0f-73a0-7ebe-6c86" name="Whirlwind castellan launcher" hidden="false" collective="false" type="upgrade">
-      <profiles/>
-      <rules/>
-      <infoLinks>
-        <infoLink id="0adb-2824-fc5d-1884" name="Whirlwind castellan launcher" hidden="false" targetId="b4c9-cb72-ef2f-76cb" type="profile">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </infoLink>
-      </infoLinks>
-      <modifiers/>
-      <constraints/>
-      <categoryLinks/>
-      <selectionEntries/>
-      <selectionEntryGroups/>
-      <entryLinks/>
-      <costs>
-        <cost name="pts" costTypeId="points" value="25.0"/>
-        <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="0.0"/>
-      </costs>
-    </selectionEntry>
-    <selectionEntry id="ca0d-b6b8-d8a5-2299" name="Whirlwind vengeance launcher" hidden="false" collective="false" type="upgrade">
-      <profiles/>
-      <rules/>
-      <infoLinks>
-        <infoLink id="701c-16bb-52c3-c65e" name="Whirlwind vengeance launcher" hidden="false" targetId="f4df-b39c-08a7-5255" type="profile">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </infoLink>
-      </infoLinks>
-      <modifiers/>
-      <constraints/>
-      <categoryLinks/>
-      <selectionEntries/>
-      <selectionEntryGroups/>
-      <entryLinks/>
-      <costs>
-        <cost name="pts" costTypeId="points" value="34.0"/>
-        <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="0.0"/>
-      </costs>
-    </selectionEntry>
-    <selectionEntry id="e651-01ab-4ca9-0077" name="Wrist-mounted grenade launcher" hidden="false" collective="false" type="upgrade">
-      <profiles/>
-      <rules/>
-      <infoLinks>
-        <infoLink id="b8f3-29ac-39fc-eb64" name="Wrist-mounted grenade launcher" hidden="false" targetId="802b-8d1b-8b9f-41e2" type="profile">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </infoLink>
-      </infoLinks>
-      <modifiers/>
-      <constraints/>
-      <categoryLinks/>
-      <selectionEntries/>
-      <selectionEntryGroups/>
-      <entryLinks/>
-      <costs>
-        <cost name="pts" costTypeId="points" value="4.0"/>
-        <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="0.0"/>
-      </costs>
-    </selectionEntry>
-    <selectionEntry id="e865-ee84-fe7d-9455" name="Stormstrike missile launcher" hidden="false" collective="false" type="upgrade">
-      <profiles/>
-      <rules/>
-      <infoLinks>
-        <infoLink id="b71e-9ced-e8e1-e6d0" name="Stormstrike missile launcher" hidden="false" targetId="f465-e051-3946-f328" type="profile">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </infoLink>
-      </infoLinks>
-      <modifiers/>
-      <constraints/>
-      <categoryLinks/>
-      <selectionEntries/>
-      <selectionEntryGroups/>
-      <entryLinks/>
-      <costs>
-        <cost name="pts" costTypeId="points" value="21.0"/>
-        <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="0.0"/>
-      </costs>
-    </selectionEntry>
-    <selectionEntry id="eeee-810f-767d-9e8f" name="Twin multi-melta" hidden="false" collective="false" type="upgrade">
-      <profiles/>
-      <rules/>
-      <infoLinks>
-        <infoLink id="4b3a-d33e-c6f9-85ae" name="Twin multi-melta" hidden="false" targetId="c3c9-08d7-bfae-4ff7" type="profile">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </infoLink>
-      </infoLinks>
-      <modifiers/>
-      <constraints/>
-      <categoryLinks/>
-      <selectionEntries/>
-      <selectionEntryGroups/>
-      <entryLinks/>
-      <costs>
-        <cost name="pts" costTypeId="points" value="54.0"/>
-        <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="0.0"/>
-      </costs>
-    </selectionEntry>
-    <selectionEntry id="bf86-1c1b-6871-da0b" name="Bolt pistol" hidden="false" collective="false" type="upgrade">
-      <profiles/>
-      <rules/>
-      <infoLinks>
-        <infoLink id="43f1-1c18-8dd0-e093" name="Bolt pistol" hidden="false" targetId="e6d5-677a-d8ed-f6a5" type="profile">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </infoLink>
-      </infoLinks>
-      <modifiers/>
-      <constraints/>
-      <categoryLinks/>
-      <selectionEntries/>
-      <selectionEntryGroups/>
-      <entryLinks/>
-      <costs>
-        <cost name="pts" costTypeId="points" value="0.0"/>
-        <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="0.0"/>
-      </costs>
-    </selectionEntry>
-    <selectionEntry id="8e23-a2e7-23c4-cac7" name="Boltgun" hidden="false" collective="false" type="upgrade">
-      <profiles/>
-      <rules/>
-      <infoLinks>
-        <infoLink id="4258-a11c-2506-31c3" name="New InfoLink" hidden="false" targetId="3d4b-95ea-f860-dd22" type="profile">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </infoLink>
-      </infoLinks>
-      <modifiers/>
-      <constraints/>
-      <categoryLinks/>
-      <selectionEntries/>
-      <selectionEntryGroups/>
-      <entryLinks/>
-      <costs>
-        <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="0.0"/>
-        <cost name="pts" costTypeId="points" value="0.0"/>
-      </costs>
-    </selectionEntry>
-    <selectionEntry id="5f85-cddd-00b5-41f8" name="Chainsword" hidden="false" collective="false" type="upgrade">
-      <profiles/>
-      <rules/>
-      <infoLinks>
-        <infoLink id="d5c7-b428-f8a5-f9a4" name="Chainsword" hidden="false" targetId="9b1e-61f9-4a5b-0044" type="profile">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </infoLink>
-      </infoLinks>
-      <modifiers/>
-      <constraints/>
-      <categoryLinks/>
-      <selectionEntries/>
-      <selectionEntryGroups/>
-      <entryLinks/>
-      <costs>
-        <cost name="pts" costTypeId="points" value="0.0"/>
-        <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="0.0"/>
-      </costs>
-    </selectionEntry>
-    <selectionEntry id="b333-4c80-2f72-6b45" name="Plasma pistol" hidden="false" collective="false" type="upgrade">
-      <profiles/>
-      <rules/>
-      <infoLinks>
-        <infoLink id="bb5a-0454-a96f-c419" name="Plasma pistol" hidden="false" targetId="ff12-161a-ca85-339f" type="profile">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </infoLink>
-        <infoLink id="9477-0aa8-7bb3-8fb8" name="Plasma pistol" hidden="false" targetId="5779-2931-fe17-2b27" type="profile">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </infoLink>
-      </infoLinks>
-      <modifiers/>
-      <constraints/>
-      <categoryLinks/>
-      <selectionEntries/>
-      <selectionEntryGroups/>
-      <entryLinks/>
-      <costs>
-        <cost name="pts" costTypeId="points" value="7.0"/>
-        <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="0.0"/>
-      </costs>
-    </selectionEntry>
     <selectionEntry id="3833-7015-21d7-808a" name="Primaris Librarian" hidden="false" collective="false" type="model">
       <profiles>
-        <profile id="bec8-54c1-8968-3949" name="Primaris Librarian" hidden="false" profileTypeId="bc97-dea9-9e88-bb7d" profileTypeName="Psyker">
+        <profile id="bec8-54c1-8968-3949" name="Psyker" hidden="false" profileTypeId="bc97-dea9-9e88-bb7d" profileTypeName="Psyker">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -20963,7 +19325,7 @@
       <selectionEntries/>
       <selectionEntryGroups/>
       <entryLinks>
-        <entryLink id="37aa-d8c4-62b4-0295" name="Force sword" hidden="false" targetId="63d7-bf06-757d-3da2" type="selectionEntry">
+        <entryLink id="37aa-d8c4-62b4-0295" name="Force sword" hidden="false" targetId="07e7-1f9b-4c1c-aad9" type="selectionEntry">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -20974,7 +19336,7 @@
           </constraints>
           <categoryLinks/>
         </entryLink>
-        <entryLink id="1780-5fae-2558-244a" name="Bolt pistol" hidden="false" targetId="bf86-1c1b-6871-da0b" type="selectionEntry">
+        <entryLink id="1780-5fae-2558-244a" name="Bolt pistol" hidden="false" targetId="0334-f487-8229-0c1a" type="selectionEntry">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -20985,18 +19347,7 @@
           </constraints>
           <categoryLinks/>
         </entryLink>
-        <entryLink id="43ea-edc1-24c9-60d2" name="Frag grenade" hidden="false" targetId="e897-c8fa-0976-e2d3" type="selectionEntry">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fa0a-7a80-3be2-7173" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4b2c-5a36-ecd0-0d40" type="max"/>
-          </constraints>
-          <categoryLinks/>
-        </entryLink>
-        <entryLink id="26c6-7bb5-226e-9c59" name="Krak grenade" hidden="false" targetId="073b-2de5-765f-a4f2" type="selectionEntry">
+        <entryLink id="26c6-7bb5-226e-9c59" name="Frag &amp; Krak grenades" hidden="false" targetId="cddf-945e-1335-e681" type="selectionEntry">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -21005,6 +19356,32 @@
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="19b3-05df-e3a1-2fae" type="min"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f7eb-8434-de0a-d569" type="max"/>
           </constraints>
+          <categoryLinks/>
+        </entryLink>
+        <entryLink id="040e-81ed-1c32-0f0a" name="Warlord" hidden="false" targetId="33f6-60da-7b70-5fee" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7024-f1ac-8904-a000" type="max"/>
+          </constraints>
+          <categoryLinks/>
+        </entryLink>
+        <entryLink id="f26a-ba86-982f-6a46" name="Warlord Traits" hidden="false" targetId="c25d-2fbc-47b3-9e39" type="selectionEntryGroup">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+          <categoryLinks/>
+        </entryLink>
+        <entryLink id="b22a-460d-6541-c19f" name="Relics of Baal" hidden="false" targetId="441f-1714-0777-c202" type="selectionEntryGroup">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
           <categoryLinks/>
         </entryLink>
       </entryLinks>
@@ -21132,76 +19509,128 @@
       </categoryLinks>
       <selectionEntries/>
       <selectionEntryGroups>
-        <selectionEntryGroup id="8972-c78c-1a99-e9b8" name="Ranged weapon" hidden="false" collective="false" defaultSelectionEntryId="88fd-c862-e78a-d24f">
+        <selectionEntryGroup id="7ab0-ad9f-f44e-fcae" name="Weapons" hidden="false" collective="false" defaultSelectionEntryId="7da5-0ce3-b863-e763">
           <profiles/>
           <rules/>
           <infoLinks/>
           <modifiers/>
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6d61-fb5a-1f3c-aff5" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ebd3-2722-05e9-c53e" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4c9a-2493-5f86-807f" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3228-7680-a16c-0b73" type="max"/>
           </constraints>
           <categoryLinks/>
-          <selectionEntries/>
+          <selectionEntries>
+            <selectionEntry id="adcf-cbb0-05c9-4b87" name="Power fist and plasma pistol" hidden="false" collective="false" type="upgrade">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="de1a-a3f7-2ea1-2d75" type="max"/>
+              </constraints>
+              <categoryLinks/>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks>
+                <entryLink id="3470-0169-c825-96ed" name="Power fist" book="" hidden="false" targetId="f122-3720-fa32-4215" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="85ce-1aff-fa76-5036" type="min"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="91b2-151b-2164-731f" type="max"/>
+                  </constraints>
+                  <categoryLinks/>
+                </entryLink>
+                <entryLink id="4e3f-f9ec-e401-e439" name="Plasma pistol" book="" hidden="false" targetId="83be-1ba9-c326-4760" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3984-34cd-bc94-8a09" type="min"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="dd26-2ba6-64f8-2721" type="max"/>
+                  </constraints>
+                  <categoryLinks/>
+                </entryLink>
+              </entryLinks>
+              <costs>
+                <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="0.0"/>
+                <cost name="pts" costTypeId="points" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="7da5-0ce3-b863-e763" name="Bolt rifle and bolt pistol with optional power sword" hidden="false" collective="false" type="upgrade">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5f2b-716a-41d9-012b" type="max"/>
+              </constraints>
+              <categoryLinks/>
+              <selectionEntries/>
+              <selectionEntryGroups>
+                <selectionEntryGroup id="b25d-b314-32dc-4668" name="Bolt rifle pattern" hidden="false" collective="false" defaultSelectionEntryId="2f0e-52fc-2eef-7980">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="14a7-61b4-e6f1-eb17" type="min"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e36e-4cf3-fae2-2601" type="max"/>
+                  </constraints>
+                  <categoryLinks/>
+                  <selectionEntries/>
+                  <selectionEntryGroups/>
+                  <entryLinks>
+                    <entryLink id="2f0e-52fc-2eef-7980" name="Master-crafted auto bolt rifle" hidden="false" targetId="f2f6-ed05-f2a9-f46f" type="selectionEntry">
+                      <profiles/>
+                      <rules/>
+                      <infoLinks/>
+                      <modifiers/>
+                      <constraints>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7615-e111-6eda-8e57" type="max"/>
+                      </constraints>
+                      <categoryLinks/>
+                    </entryLink>
+                    <entryLink id="fec2-3a0d-590a-5465" name="Master-crafted stalker bolt rifle" hidden="false" targetId="2949-638c-6eff-c3d8" type="selectionEntry">
+                      <profiles/>
+                      <rules/>
+                      <infoLinks/>
+                      <modifiers/>
+                      <constraints>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5e91-ed22-0f83-c860" type="max"/>
+                      </constraints>
+                      <categoryLinks/>
+                    </entryLink>
+                  </entryLinks>
+                </selectionEntryGroup>
+              </selectionEntryGroups>
+              <entryLinks>
+                <entryLink id="b866-cbdf-2ba5-9de4" name="Power sword" hidden="false" targetId="bc9e-551d-9afb-78d5" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bef4-572c-f2b0-0d21" type="max"/>
+                  </constraints>
+                  <categoryLinks/>
+                </entryLink>
+              </entryLinks>
+              <costs>
+                <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="0.0"/>
+                <cost name="pts" costTypeId="points" value="0.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
           <selectionEntryGroups/>
-          <entryLinks>
-            <entryLink id="88fd-c862-e78a-d24f" name="Master-crafted auto bolt rifle" hidden="false" targetId="aab9-369a-8f8d-1606" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0c9f-bde5-f370-0df8" type="max"/>
-              </constraints>
-              <categoryLinks/>
-            </entryLink>
-            <entryLink id="7ff2-974f-2057-f18b" name="Master-crafted stalker bolt rifle" hidden="false" targetId="2949-638c-6eff-c3d8" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0b2a-f264-db1b-71c0" type="max"/>
-              </constraints>
-              <categoryLinks/>
-            </entryLink>
-          </entryLinks>
+          <entryLinks/>
         </selectionEntryGroup>
       </selectionEntryGroups>
       <entryLinks>
-        <entryLink id="a756-6d0c-4c14-2b9a" name="Power sword" hidden="false" targetId="c3d0-2567-35c6-3f29" type="selectionEntry">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9d67-56f6-9f71-9a4b" type="max"/>
-          </constraints>
-          <categoryLinks/>
-        </entryLink>
-        <entryLink id="5c9d-b7b4-548a-9268" name="Bolt pistol" hidden="false" targetId="bf86-1c1b-6871-da0b" type="selectionEntry">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3592-11e9-ca4f-ef8c" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5b42-eb63-0a75-b9e3" type="max"/>
-          </constraints>
-          <categoryLinks/>
-        </entryLink>
-        <entryLink id="57a3-a3e4-65de-e9e6" name="Frag grenade" hidden="false" targetId="e897-c8fa-0976-e2d3" type="selectionEntry">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="868a-4596-56d6-5141" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="29db-027f-e434-18a7" type="max"/>
-          </constraints>
-          <categoryLinks/>
-        </entryLink>
-        <entryLink id="b4ed-90c4-cdb8-f95f" name="Krak grenade" hidden="false" targetId="073b-2de5-765f-a4f2" type="selectionEntry">
+        <entryLink id="b4ed-90c4-cdb8-f95f" name="Frag &amp; Krak grenades" hidden="false" targetId="cddf-945e-1335-e681" type="selectionEntry">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -21210,6 +19639,32 @@
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="04fe-d6f5-f19e-995f" type="min"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ce92-8933-1c6f-d7e5" type="max"/>
           </constraints>
+          <categoryLinks/>
+        </entryLink>
+        <entryLink id="6ebc-8651-4569-fd95" name="Warlord" hidden="false" targetId="33f6-60da-7b70-5fee" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f105-e5c9-f93a-2e65" type="max"/>
+          </constraints>
+          <categoryLinks/>
+        </entryLink>
+        <entryLink id="6966-fdd4-3150-8427" name="Warlord Traits" hidden="false" targetId="c25d-2fbc-47b3-9e39" type="selectionEntryGroup">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+          <categoryLinks/>
+        </entryLink>
+        <entryLink id="de3e-9d85-f278-84b5" name="Relics of Baal" hidden="false" targetId="441f-1714-0777-c202" type="selectionEntryGroup">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
           <categoryLinks/>
         </entryLink>
       </entryLinks>
@@ -21252,7 +19707,7 @@
       <selectionEntries/>
       <selectionEntryGroups/>
       <entryLinks>
-        <entryLink id="e2aa-c8e9-09a3-f710" name="Servo-arm" hidden="false" targetId="fb0f-7f69-e952-07dc" type="selectionEntry">
+        <entryLink id="e2aa-c8e9-09a3-f710" name="Servo-arm" hidden="false" targetId="61ae-3901-0a79-4ec9" type="selectionEntry">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -21263,7 +19718,7 @@
           </constraints>
           <categoryLinks/>
         </entryLink>
-        <entryLink id="1d8c-d3d2-42d5-0b98" name="New EntryLink" hidden="false" targetId="c3f2-5ecb-a2ae-a92f" type="selectionEntry">
+        <entryLink id="1d8c-d3d2-42d5-0b98" name="Plasma cutter" hidden="false" targetId="d1e1-23e0-2777-dc7b" type="selectionEntry">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -21274,7 +19729,7 @@
           </constraints>
           <categoryLinks/>
         </entryLink>
-        <entryLink id="543e-b8be-02c0-f4fb" name="New EntryLink" hidden="false" targetId="a255-3b4c-89e4-e6b3" type="selectionEntry">
+        <entryLink id="543e-b8be-02c0-f4fb" name="Flamer" hidden="false" targetId="fd22-6743-2d4c-dd62" type="selectionEntry">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -21450,7 +19905,7 @@
           </constraints>
           <categoryLinks/>
         </entryLink>
-        <entryLink id="887f-e49b-6666-3075" name="Crozius arcanum" hidden="false" targetId="5333-870f-3451-fcfa" type="selectionEntry">
+        <entryLink id="887f-e49b-6666-3075" name="Crozius arcanum" hidden="false" targetId="7543-5a4e-0f59-bacc" type="selectionEntry">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -21461,18 +19916,7 @@
           </constraints>
           <categoryLinks/>
         </entryLink>
-        <entryLink id="fad5-b2d2-b194-b2f1" name="Frag grenade" hidden="false" targetId="e897-c8fa-0976-e2d3" type="selectionEntry">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5bdc-82ca-7503-19fd" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5321-8394-a991-5d01" type="max"/>
-          </constraints>
-          <categoryLinks/>
-        </entryLink>
-        <entryLink id="d7bd-57be-9ad2-0b18" name="Krak grenade" hidden="false" targetId="073b-2de5-765f-a4f2" type="selectionEntry">
+        <entryLink id="d7bd-57be-9ad2-0b18" name="Frag &amp; Krak grenades" hidden="false" targetId="cddf-945e-1335-e681" type="selectionEntry">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -21481,6 +19925,32 @@
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d89c-464c-74cd-2ad9" type="min"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e76e-22a4-fcc7-bc53" type="max"/>
           </constraints>
+          <categoryLinks/>
+        </entryLink>
+        <entryLink id="645b-ea7c-5591-4d62" name="Warlord" hidden="false" targetId="33f6-60da-7b70-5fee" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1dbc-12f7-55e0-88a7" type="max"/>
+          </constraints>
+          <categoryLinks/>
+        </entryLink>
+        <entryLink id="9a8e-b9b4-99da-82b5" name="Warlord Traits" hidden="false" targetId="c25d-2fbc-47b3-9e39" type="selectionEntryGroup">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+          <categoryLinks/>
+        </entryLink>
+        <entryLink id="eb0f-0cec-0298-62b3" name="Relics of Baal" hidden="false" targetId="441f-1714-0777-c202" type="selectionEntryGroup">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
           <categoryLinks/>
         </entryLink>
       </entryLinks>
@@ -21647,18 +20117,7 @@
           </constraints>
           <categoryLinks/>
         </entryLink>
-        <entryLink id="5ae4-9213-8861-1fc0" name="Frag grenade" hidden="false" targetId="e897-c8fa-0976-e2d3" type="selectionEntry">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a045-9dc7-ffe5-9775" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2ab7-ce5e-f422-0cef" type="max"/>
-          </constraints>
-          <categoryLinks/>
-        </entryLink>
-        <entryLink id="aac3-6622-3985-73cf" name="Krak grenade" hidden="false" targetId="073b-2de5-765f-a4f2" type="selectionEntry">
+        <entryLink id="aac3-6622-3985-73cf" name="Frag &amp; Krak grenades" hidden="false" targetId="cddf-945e-1335-e681" type="selectionEntry">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -21667,6 +20126,32 @@
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9533-a5f7-7ca9-65d3" type="min"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1ff6-8ac9-d751-9f56" type="max"/>
           </constraints>
+          <categoryLinks/>
+        </entryLink>
+        <entryLink id="55c2-657e-f54f-fbbb" name="Warlord" hidden="false" targetId="33f6-60da-7b70-5fee" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6598-2511-9c36-1480" type="max"/>
+          </constraints>
+          <categoryLinks/>
+        </entryLink>
+        <entryLink id="aec1-6430-2944-8535" name="Warlord Traits" hidden="false" targetId="c25d-2fbc-47b3-9e39" type="selectionEntryGroup">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+          <categoryLinks/>
+        </entryLink>
+        <entryLink id="6ac4-bb06-c26c-5dbb" name="Relics of Baal" hidden="false" targetId="441f-1714-0777-c202" type="selectionEntryGroup">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
           <categoryLinks/>
         </entryLink>
       </entryLinks>
@@ -21834,7 +20319,7 @@
                   </constraints>
                   <categoryLinks/>
                 </entryLink>
-                <entryLink id="fa9f-f8be-55b6-0a7b" name="Combat knife" hidden="false" targetId="8250-8444-3124-6714" type="selectionEntry">
+                <entryLink id="fa9f-f8be-55b6-0a7b" name="Combat knife" hidden="false" targetId="bc0b-c19f-0b71-081e" type="selectionEntry">
                   <profiles/>
                   <rules/>
                   <infoLinks/>
@@ -21870,7 +20355,7 @@
                   </constraints>
                   <categoryLinks/>
                 </entryLink>
-                <entryLink id="7d07-23c0-0946-7d13" name="Combat knife" hidden="false" targetId="8250-8444-3124-6714" type="selectionEntry">
+                <entryLink id="7d07-23c0-0946-7d13" name="Combat knife" hidden="false" targetId="bc0b-c19f-0b71-081e" type="selectionEntry">
                   <profiles/>
                   <rules/>
                   <infoLinks/>
@@ -21885,18 +20370,7 @@
             </selectionEntryGroup>
           </selectionEntryGroups>
           <entryLinks>
-            <entryLink id="de6e-6437-cec1-fb90" name="Frag grenades" hidden="false" targetId="e897-c8fa-0976-e2d3" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="43fb-ae73-b5b0-c3bb" type="min"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="62db-2f74-1c1d-a7c9" type="max"/>
-              </constraints>
-              <categoryLinks/>
-            </entryLink>
-            <entryLink id="9a52-a2c7-20c3-f9af" name="Krak grenades" hidden="false" targetId="073b-2de5-765f-a4f2" type="selectionEntry">
+            <entryLink id="9a52-a2c7-20c3-f9af" name="Frag &amp; Krak grenades" hidden="false" targetId="cddf-945e-1335-e681" type="selectionEntry">
               <profiles/>
               <rules/>
               <infoLinks/>
@@ -21955,18 +20429,7 @@
               </constraints>
               <categoryLinks/>
             </entryLink>
-            <entryLink id="0a14-df2b-3a51-4655" name="Frag grenades" hidden="false" targetId="e897-c8fa-0976-e2d3" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2c3c-cff5-80bb-b01e" type="min"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b2c3-6ce5-3346-3e62" type="max"/>
-              </constraints>
-              <categoryLinks/>
-            </entryLink>
-            <entryLink id="7a06-8d0b-d679-f4b6" name="Krak grenades" hidden="false" targetId="073b-2de5-765f-a4f2" type="selectionEntry">
+            <entryLink id="7a06-8d0b-d679-f4b6" name="Frag &amp; Krak grenades" hidden="false" targetId="cddf-945e-1335-e681" type="selectionEntry">
               <profiles/>
               <rules/>
               <infoLinks/>
@@ -22019,7 +20482,7 @@
               </constraints>
               <categoryLinks/>
             </entryLink>
-            <entryLink id="d8b5-427b-d3d3-771b" name="Combat knife" hidden="false" targetId="8250-8444-3124-6714" type="selectionEntry">
+            <entryLink id="d8b5-427b-d3d3-771b" name="Combat knife" hidden="false" targetId="bc0b-c19f-0b71-081e" type="selectionEntry">
               <profiles/>
               <rules/>
               <infoLinks/>
@@ -22151,28 +20614,6 @@
         <cost name="pts" costTypeId="points" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="21cf-ea45-1f71-3fb3" name="Combat knife" hidden="false" collective="true" type="upgrade">
-      <profiles/>
-      <rules/>
-      <infoLinks>
-        <infoLink id="7352-b9a2-88cf-d16e" name="Combat knife" hidden="false" targetId="397f-3a5d-7443-5144" type="profile">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </infoLink>
-      </infoLinks>
-      <modifiers/>
-      <constraints/>
-      <categoryLinks/>
-      <selectionEntries/>
-      <selectionEntryGroups/>
-      <entryLinks/>
-      <costs>
-        <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="0.0"/>
-        <cost name="pts" costTypeId="points" value="0.0"/>
-      </costs>
-    </selectionEntry>
     <selectionEntry id="0d6a-bda4-3d49-afea" name="Grapnel launcher" hidden="false" collective="true" type="upgrade">
       <profiles/>
       <rules/>
@@ -22217,7 +20658,7 @@
         <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="99d2-d806-5ba5-fac9" name="Auto boltstorm gauntlets" hidden="false" collective="false" type="upgrade">
+    <selectionEntry id="99d2-d806-5ba5-fac9" name="Auto boltstorm gauntlets" hidden="false" collective="true" type="upgrade">
       <profiles/>
       <rules/>
       <infoLinks>
@@ -22245,7 +20686,7 @@
         <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="7b54-8090-d351-0252" name="Flamestorm gauntlets" hidden="false" collective="false" type="upgrade">
+    <selectionEntry id="7b54-8090-d351-0252" name="Flamestorm gauntlets" hidden="false" collective="true" type="upgrade">
       <profiles/>
       <rules/>
       <infoLinks>
@@ -22273,7 +20714,7 @@
         <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="e4c9-be77-2c22-f2f1" name="Fragstorm grenade launcher" hidden="false" collective="false" type="upgrade">
+    <selectionEntry id="e4c9-be77-2c22-f2f1" name="Fragstorm grenade launcher" hidden="false" collective="true" type="upgrade">
       <profiles/>
       <rules/>
       <infoLinks>
@@ -22425,7 +20866,7 @@
         </categoryLink>
       </categoryLinks>
       <selectionEntries>
-        <selectionEntry id="a5b6-d64b-205c-021e" name="Aggressor" hidden="false" collective="false" type="model">
+        <selectionEntry id="a5b6-d64b-205c-021e" name="Aggressor" hidden="false" collective="true" type="model">
           <profiles/>
           <rules/>
           <infoLinks>
@@ -22443,7 +20884,74 @@
           </constraints>
           <categoryLinks/>
           <selectionEntries/>
-          <selectionEntryGroups/>
+          <selectionEntryGroups>
+            <selectionEntryGroup id="f68f-d2d2-5bc5-c242" name="Weapons" hidden="false" collective="true">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a659-a042-ca53-d746" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3a8c-50f3-c866-5e8b" type="max"/>
+              </constraints>
+              <categoryLinks/>
+              <selectionEntries>
+                <selectionEntry id="5fbc-9176-bfb5-0dc6" name="Auto boltstorm gauntlets and fragstorm grenade launcher" hidden="false" collective="true" type="upgrade">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="668a-4e64-af1d-dc6f" type="max"/>
+                  </constraints>
+                  <categoryLinks/>
+                  <selectionEntries/>
+                  <selectionEntryGroups/>
+                  <entryLinks>
+                    <entryLink id="edb6-4ca7-50f6-850b" name="Auto boltstorm gauntlets" hidden="false" targetId="99d2-d806-5ba5-fac9" type="selectionEntry">
+                      <profiles/>
+                      <rules/>
+                      <infoLinks/>
+                      <modifiers/>
+                      <constraints>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8ba3-2d08-e2d4-03bb" type="min"/>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="dd5a-4ec1-c159-82bb" type="max"/>
+                      </constraints>
+                      <categoryLinks/>
+                    </entryLink>
+                    <entryLink id="90bd-5f1a-cbae-3e4e" name="Fragstorm grenade launcher" hidden="false" targetId="e4c9-be77-2c22-f2f1" type="selectionEntry">
+                      <profiles/>
+                      <rules/>
+                      <infoLinks/>
+                      <modifiers/>
+                      <constraints>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="41fc-6d1d-f6d9-0b53" type="min"/>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e14a-1022-f622-eacd" type="max"/>
+                      </constraints>
+                      <categoryLinks/>
+                    </entryLink>
+                  </entryLinks>
+                  <costs>
+                    <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="0.0"/>
+                    <cost name="pts" costTypeId="points" value="0.0"/>
+                  </costs>
+                </selectionEntry>
+              </selectionEntries>
+              <selectionEntryGroups/>
+              <entryLinks>
+                <entryLink id="517a-3d46-6f23-6058" name="Flamestorm gauntlets" hidden="false" targetId="7b54-8090-d351-0252" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1acd-4947-8558-180d" type="max"/>
+                  </constraints>
+                  <categoryLinks/>
+                </entryLink>
+              </entryLinks>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
           <entryLinks/>
           <costs>
             <cost name="pts" costTypeId="points" value="21.0"/>
@@ -22468,7 +20976,90 @@
           </constraints>
           <categoryLinks/>
           <selectionEntries/>
-          <selectionEntryGroups/>
+          <selectionEntryGroups>
+            <selectionEntryGroup id="cea0-b554-4aee-66b0" name="Weapons (same as the rest of unit)" hidden="false" collective="true">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4caf-d1a8-35b3-2ce2" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f2eb-18d0-ac1a-6798" type="max"/>
+              </constraints>
+              <categoryLinks/>
+              <selectionEntries>
+                <selectionEntry id="2fcd-607e-eb1e-0214" name="Auto boltstorm gauntlets and fragstorm grenade launcher" hidden="false" collective="true" type="upgrade">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers>
+                    <modifier type="set" field="092b-9293-9fa9-80ef" value="1">
+                      <repeats/>
+                      <conditions>
+                        <condition field="selections" scope="c13b-c189-2dad-99e5" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="5fbc-9176-bfb5-0dc6" type="greaterThan"/>
+                      </conditions>
+                      <conditionGroups/>
+                    </modifier>
+                  </modifiers>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="092b-9293-9fa9-80ef" type="max"/>
+                  </constraints>
+                  <categoryLinks/>
+                  <selectionEntries/>
+                  <selectionEntryGroups/>
+                  <entryLinks>
+                    <entryLink id="6e6f-3b1b-ac64-6928" name="Auto boltstorm gauntlets" hidden="false" targetId="99d2-d806-5ba5-fac9" type="selectionEntry">
+                      <profiles/>
+                      <rules/>
+                      <infoLinks/>
+                      <modifiers/>
+                      <constraints>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d628-b939-4625-8cab" type="min"/>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="30c5-b266-ac8e-4fb3" type="max"/>
+                      </constraints>
+                      <categoryLinks/>
+                    </entryLink>
+                    <entryLink id="836e-374d-f479-8b49" name="Fragstorm grenade launcher" hidden="false" targetId="e4c9-be77-2c22-f2f1" type="selectionEntry">
+                      <profiles/>
+                      <rules/>
+                      <infoLinks/>
+                      <modifiers/>
+                      <constraints>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="db6e-2bd5-db81-5b2b" type="min"/>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4b75-7660-afc0-3018" type="max"/>
+                      </constraints>
+                      <categoryLinks/>
+                    </entryLink>
+                  </entryLinks>
+                  <costs>
+                    <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="0.0"/>
+                    <cost name="pts" costTypeId="points" value="0.0"/>
+                  </costs>
+                </selectionEntry>
+              </selectionEntries>
+              <selectionEntryGroups/>
+              <entryLinks>
+                <entryLink id="8b80-5f86-1308-77a7" name="Flamestorm gauntlets" hidden="false" targetId="7b54-8090-d351-0252" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers>
+                    <modifier type="set" field="d9e3-69a8-eda7-2072" value="1">
+                      <repeats/>
+                      <conditions>
+                        <condition field="selections" scope="c13b-c189-2dad-99e5" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7b54-8090-d351-0252" type="greaterThan"/>
+                      </conditions>
+                      <conditionGroups/>
+                    </modifier>
+                  </modifiers>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d9e3-69a8-eda7-2072" type="max"/>
+                  </constraints>
+                  <categoryLinks/>
+                </entryLink>
+              </entryLinks>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
           <entryLinks/>
           <costs>
             <cost name="pts" costTypeId="points" value="21.0"/>
@@ -22476,113 +21067,7 @@
           </costs>
         </selectionEntry>
       </selectionEntries>
-      <selectionEntryGroups>
-        <selectionEntryGroup id="5dde-6777-a8ba-5bd6" name="Weapons" hidden="false" collective="false" defaultSelectionEntryId="24ed-f96c-777b-e3ae">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="47be-88e0-81a5-8882" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="43a1-c72e-030f-9462" type="max"/>
-          </constraints>
-          <categoryLinks/>
-          <selectionEntries>
-            <selectionEntry id="24ed-f96c-777b-e3ae" name="Auto boltstorm gauntlets and fragstorm grenade launcher" hidden="false" collective="false" type="upgrade">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9dd7-4581-1370-b14b" type="max"/>
-              </constraints>
-              <categoryLinks/>
-              <selectionEntries/>
-              <selectionEntryGroups/>
-              <entryLinks>
-                <entryLink id="73f7-6102-5bcc-c9e4" name="Auto boltstorm gauntlets" hidden="false" targetId="99d2-d806-5ba5-fac9" type="selectionEntry">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers>
-                    <modifier type="decrement" field="points" value="12">
-                      <repeats/>
-                      <conditions/>
-                      <conditionGroups/>
-                    </modifier>
-                    <modifier type="increment" field="points" value="12">
-                      <repeats>
-                        <repeat field="selections" scope="c13b-c189-2dad-99e5" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="model" repeats="1" roundUp="false"/>
-                      </repeats>
-                      <conditions/>
-                      <conditionGroups/>
-                    </modifier>
-                  </modifiers>
-                  <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b549-b0e3-28ef-b02e" type="min"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ad04-92d9-77c4-eaab" type="max"/>
-                  </constraints>
-                  <categoryLinks/>
-                </entryLink>
-                <entryLink id="bb1f-546b-47c6-658b" name="Fragstorm grenade launcher" hidden="false" targetId="e4c9-be77-2c22-f2f1" type="selectionEntry">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers>
-                    <modifier type="increment" field="points" value="4">
-                      <repeats>
-                        <repeat field="selections" scope="c13b-c189-2dad-99e5" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="model" repeats="1" roundUp="false"/>
-                      </repeats>
-                      <conditions/>
-                      <conditionGroups/>
-                    </modifier>
-                    <modifier type="decrement" field="points" value="4">
-                      <repeats/>
-                      <conditions/>
-                      <conditionGroups/>
-                    </modifier>
-                  </modifiers>
-                  <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="06b8-edff-978d-a153" type="min"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f986-a4f6-71ef-77d2" type="max"/>
-                  </constraints>
-                  <categoryLinks/>
-                </entryLink>
-              </entryLinks>
-              <costs>
-                <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="0.0"/>
-                <cost name="pts" costTypeId="points" value="0.0"/>
-              </costs>
-            </selectionEntry>
-          </selectionEntries>
-          <selectionEntryGroups/>
-          <entryLinks>
-            <entryLink id="2756-8373-bb6d-a8b2" name="Flamestorm gauntlets" hidden="false" targetId="7b54-8090-d351-0252" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers>
-                <modifier type="decrement" field="points" value="18">
-                  <repeats/>
-                  <conditions/>
-                  <conditionGroups/>
-                </modifier>
-                <modifier type="increment" field="points" value="18">
-                  <repeats>
-                    <repeat field="selections" scope="c13b-c189-2dad-99e5" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="model" repeats="1" roundUp="false"/>
-                  </repeats>
-                  <conditions/>
-                  <conditionGroups/>
-                </modifier>
-              </modifiers>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4b29-d381-4592-5e31" type="max"/>
-              </constraints>
-              <categoryLinks/>
-            </entryLink>
-          </entryLinks>
-        </selectionEntryGroup>
-      </selectionEntryGroups>
+      <selectionEntryGroups/>
       <entryLinks/>
       <costs>
         <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="6.0"/>
@@ -22905,7 +21390,7 @@
           <selectionEntries/>
           <selectionEntryGroups/>
           <entryLinks>
-            <entryLink id="a01c-580d-53b9-a205" name="Heavy flamer" hidden="false" targetId="7eb4-1d78-9058-f71a" type="selectionEntry">
+            <entryLink id="a01c-580d-53b9-a205" name="Heavy flamer" hidden="false" targetId="18bc-b335-29c2-2ae2" type="selectionEntry">
               <profiles/>
               <rules/>
               <infoLinks/>
@@ -22979,7 +21464,7 @@
               <selectionEntries/>
               <selectionEntryGroups/>
               <entryLinks>
-                <entryLink id="d0f7-8f4b-e5d1-f3cc" name="Storm bolter" hidden="false" targetId="d74a-2fee-abea-1b42" type="selectionEntry">
+                <entryLink id="d0f7-8f4b-e5d1-f3cc" name="Storm bolter" hidden="false" targetId="2b03-8d64-3711-f300" type="selectionEntry">
                   <profiles/>
                   <rules/>
                   <infoLinks/>
@@ -23114,7 +21599,7 @@
         <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="36fb-ccc7-03d1-93c9" name="Auto bolt rifle" hidden="false" collective="false" type="upgrade">
+    <selectionEntry id="36fb-ccc7-03d1-93c9" name="Auto bolt rifle" hidden="false" collective="true" type="upgrade">
       <profiles/>
       <rules/>
       <infoLinks>
@@ -23136,7 +21621,7 @@
         <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="1840-b6e5-27f2-3436" name="Stalker bolt rifle" hidden="false" collective="false" type="upgrade">
+    <selectionEntry id="1840-b6e5-27f2-3436" name="Stalker bolt rifle" hidden="false" collective="true" type="upgrade">
       <profiles/>
       <rules/>
       <infoLinks>
@@ -23246,28 +21731,6 @@
         <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="ddd6-a578-d257-f72c" name="Las-talon" hidden="false" collective="false" type="upgrade">
-      <profiles/>
-      <rules/>
-      <infoLinks>
-        <infoLink id="0c92-e708-fa44-5cb2" name="Las-talon" hidden="false" targetId="e85f-43e2-24d3-f852" type="profile">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </infoLink>
-      </infoLinks>
-      <modifiers/>
-      <constraints/>
-      <categoryLinks/>
-      <selectionEntries/>
-      <selectionEntryGroups/>
-      <entryLinks/>
-      <costs>
-        <cost name="pts" costTypeId="points" value="40.0"/>
-        <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="0.0"/>
-      </costs>
-    </selectionEntry>
     <selectionEntry id="d969-98cb-7fd2-21ba" name="Auto launchers" hidden="false" collective="false" type="upgrade">
       <profiles/>
       <rules/>
@@ -23340,13 +21803,15 @@
             <characteristic name="Characteristic 3" characteristicTypeId="df06-8eca-150f-90ba" value="1"/>
           </characteristics>
         </profile>
-        <profile id="2922-c603-9fa6-31c1" name="Explodes" hidden="false" profileTypeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" profileTypeName="Abilities">
+        <profile id="2922-c603-9fa6-31c1" name="Explodes" hidden="false" profileTypeId="818c-0db1-36f0-462a" profileTypeName="Explosion">
           <profiles/>
           <rules/>
           <infoLinks/>
           <modifiers/>
           <characteristics>
-            <characteristic name="Description" characteristicTypeId="21befb24-fc85-4f52-a745-64b2e48f8228" value="If this model is reduced to 0 wounds, roll a dice before removing the model from the battlefield and before any embarked models disembark. On a 6 it explodes, and each unit within 6&quot; suffers D6 mortal wounds."/>
+            <characteristic name="Dice roll" characteristicTypeId="f21d-8f6d-180d-36ff" value="6"/>
+            <characteristic name="Distance" characteristicTypeId="d69e-be07-1682-ebcc" value="6&quot;"/>
+            <characteristic name="Mortal wounds" characteristicTypeId="29f1-65a1-2c5d-8c7d" value="D6"/>
           </characteristics>
         </profile>
         <profile id="62bb-d6e8-54f2-b7b4" name="Transport" hidden="false" profileTypeId="b3a8-0452-7436-44d1" profileTypeName="Transport">
@@ -23355,7 +21820,7 @@
           <infoLinks/>
           <modifiers/>
           <characteristics>
-            <characteristic name="Capacity" characteristicTypeId="15aa-1916-a38b-d223" value="This model can transport 10 &lt;CHAPTER&gt; PRIMARIS INFANTRY models. Each MK X GRAVIS model takes up the space of 2 other models. It cannot transport JUMP PACK models."/>
+            <characteristic name="Capacity" characteristicTypeId="15aa-1916-a38b-d223" value="This model can transport 10 BLOOD ANGELS PRIMARIS INFANTRY models. Each MK X GRAVIS model takes up the space of 2 other models. It cannot transport JUMP PACK models."/>
           </characteristics>
         </profile>
       </profiles>
@@ -23499,7 +21964,7 @@
               </constraints>
               <categoryLinks/>
             </entryLink>
-            <entryLink id="22ce-2a66-ff4d-a2a3" name="Las-talon" hidden="false" targetId="ddd6-a578-d257-f72c" type="selectionEntry">
+            <entryLink id="22ce-2a66-ff4d-a2a3" name="Las-talon" hidden="false" targetId="5ca6-11eb-52e7-aad9" type="selectionEntry">
               <profiles/>
               <rules/>
               <infoLinks/>
@@ -23524,7 +21989,7 @@
           <selectionEntries/>
           <selectionEntryGroups/>
           <entryLinks>
-            <entryLink id="7743-3407-b8d9-5330" name="Twin heavy bolter" hidden="false" targetId="b310-1fca-9564-5812" type="selectionEntry">
+            <entryLink id="7743-3407-b8d9-5330" name="Twin heavy bolter" hidden="false" targetId="09d8-7790-ed3f-4d6d" type="selectionEntry">
               <profiles/>
               <rules/>
               <infoLinks/>
@@ -23534,7 +21999,7 @@
               </constraints>
               <categoryLinks/>
             </entryLink>
-            <entryLink id="99a1-d4ba-0280-481b" name="Twin lascannon" hidden="false" targetId="de7a-7bba-e2c5-c37c" type="selectionEntry">
+            <entryLink id="99a1-d4ba-0280-481b" name="Twin lascannon" hidden="false" targetId="ee18-b1cd-6b60-464d" type="selectionEntry">
               <profiles/>
               <rules/>
               <infoLinks/>
@@ -23614,7 +22079,7 @@
               </constraints>
               <categoryLinks/>
             </entryLink>
-            <entryLink id="e97d-2c35-17b8-9f8f" name="Storm bolter" hidden="false" targetId="d74a-2fee-abea-1b42" type="selectionEntry">
+            <entryLink id="e97d-2c35-17b8-9f8f" name="Storm bolter" hidden="false" targetId="2b03-8d64-3711-f300" type="selectionEntry">
               <profiles/>
               <rules/>
               <infoLinks/>
@@ -23659,7 +22124,7 @@
               <selectionEntries/>
               <selectionEntryGroups/>
               <entryLinks>
-                <entryLink id="9220-c9fd-1640-7e45" name="Storm bolter" hidden="false" targetId="d74a-2fee-abea-1b42" type="selectionEntry">
+                <entryLink id="9220-c9fd-1640-7e45" name="Storm bolter" hidden="false" targetId="2b03-8d64-3711-f300" type="selectionEntry">
                   <profiles/>
                   <rules/>
                   <infoLinks/>
@@ -23793,29 +22258,236 @@
         <cost name="pts" costTypeId="points" value="210.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="472a-98ae-1344-5dc5" name="Primaris Captain with Power Fist" hidden="false" collective="false" type="model">
+    <selectionEntry id="7f2b-f495-384a-6e65" name="The Axe Mortalis" hidden="false" collective="false" type="upgrade">
       <profiles/>
       <rules/>
       <infoLinks>
-        <infoLink id="2cc1-0210-1f73-cb8a" name="Primaris Captain" hidden="false" targetId="59af-db5e-a69d-b9b8" type="profile">
+        <infoLink id="4cfd-bbf0-4741-7596" name="The Axe Mortalis" hidden="false" targetId="a662-325e-1bdf-351d" type="profile">
           <profiles/>
           <rules/>
           <infoLinks/>
           <modifiers/>
         </infoLink>
-        <infoLink id="98c3-f794-51e2-7313" name="And They Shall Know No Fear" hidden="false" targetId="4ea8-94d3-ba39-042f" type="rule">
+      </infoLinks>
+      <modifiers/>
+      <constraints/>
+      <categoryLinks/>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="0.0"/>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="24c2-f6fd-0c1f-dfe4" name="Blood Reaver" hidden="false" collective="false" type="upgrade">
+      <profiles/>
+      <rules/>
+      <infoLinks>
+        <infoLink id="6110-6635-e57d-8ee3" name="Blood Reaver" hidden="false" targetId="3bff-938a-ad45-efca" type="profile">
           <profiles/>
           <rules/>
           <infoLinks/>
           <modifiers/>
         </infoLink>
-        <infoLink id="4145-6687-2c69-4f4c" name="Iron Halo" hidden="false" targetId="8742-48fe-7dfc-a1c0" type="profile">
+      </infoLinks>
+      <modifiers/>
+      <constraints/>
+      <categoryLinks/>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="0.0"/>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="7be2-e824-4848-0e2a" name="Encarmine broadsword" hidden="false" collective="false" type="upgrade">
+      <profiles/>
+      <rules/>
+      <infoLinks>
+        <infoLink id="a525-490a-81ce-79d4" name="Encarmine broadsword" hidden="false" targetId="01b7-752b-4a84-fdee" type="profile">
           <profiles/>
           <rules/>
           <infoLinks/>
           <modifiers/>
         </infoLink>
-        <infoLink id="ffec-1b37-f39c-1dc1" name="Rites of Battle" hidden="false" targetId="cf04-2c83-f5e1-9fb4" type="profile">
+      </infoLinks>
+      <modifiers/>
+      <constraints/>
+      <categoryLinks/>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="0.0"/>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="5045-016e-62bb-80ee" name="Heaven&apos;s Teeth" hidden="false" collective="false" type="upgrade">
+      <profiles/>
+      <rules/>
+      <infoLinks>
+        <infoLink id="6e84-01bc-80fa-6698" name="New InfoLink" hidden="false" targetId="1e86-60cc-27f7-4b48" type="profile">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a327-328d-c275-78b3" type="min"/>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bc00-8da3-3b8e-7548" type="max"/>
+      </constraints>
+      <categoryLinks/>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="0.0"/>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="7800-6ae0-8f4e-4330" name="The Sanguine Sword" hidden="false" collective="false" type="upgrade">
+      <profiles/>
+      <rules/>
+      <infoLinks>
+        <infoLink id="f61f-18dc-62d8-e488" name="The Sanguine Sword" hidden="false" targetId="d858-97ac-1795-e4a0" type="profile">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints/>
+      <categoryLinks/>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="0.0"/>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="fec3-9185-e75c-d57d" name="The Executioner&apos;s Axe" hidden="false" collective="false" type="upgrade">
+      <profiles/>
+      <rules/>
+      <infoLinks>
+        <infoLink id="253a-4005-29bc-7f95" name="The Executioner&apos;s Axe" hidden="false" targetId="e42a-8c10-b370-1325" type="profile">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints/>
+      <categoryLinks/>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="0.0"/>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="f243-591a-5d01-f20f" name="The Blood Crozius" hidden="false" collective="false" type="upgrade">
+      <profiles/>
+      <rules/>
+      <infoLinks>
+        <infoLink id="2327-5b1d-f8b4-7f92" name="The Blood Crozius" hidden="false" targetId="800f-fd1d-4eaf-8b88" type="profile">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints/>
+      <categoryLinks/>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="0.0"/>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="9637-a28b-ff2e-9950" name="Blood Song" hidden="false" collective="false" type="upgrade">
+      <profiles/>
+      <rules/>
+      <infoLinks>
+        <infoLink id="5d20-8a66-8295-2c15" name="New InfoLink" hidden="false" targetId="d6e5-a8cf-4602-28e0" type="profile">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="90a6-e303-837a-3d33" name="Meltagun" hidden="false" targetId="ec4c-1132-ddaf-db8e" type="profile">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints/>
+      <categoryLinks/>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="0.0"/>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="28f8-4358-519b-58d2" name="Dead Man&apos;s Hand" hidden="false" collective="false" type="upgrade">
+      <profiles/>
+      <rules/>
+      <infoLinks>
+        <infoLink id="6dc1-e2b8-f515-69c8" name="Dead Man&apos;s Hand" hidden="false" targetId="8eed-79b9-bf3e-6fe3" type="profile">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints/>
+      <categoryLinks/>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="0.0"/>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="e6a5-f069-14a3-b6a1" name="Captain in Cataphractii Armour" hidden="false" collective="false" type="model">
+      <profiles/>
+      <rules/>
+      <infoLinks>
+        <infoLink id="6714-c23e-46ff-e71c" name="Captain in Cataphractii Armour" hidden="false" targetId="5bf8-9a47-a69f-6ade" type="profile">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="f531-4135-b982-4ad9" name="And They Shall Know No Fear" hidden="false" targetId="4ea8-94d3-ba39-042f" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="2828-d3af-9959-f008" name="Rites of Battle" hidden="false" targetId="cf04-2c83-f5e1-9fb4" type="profile">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="b5a2-3e97-8d97-a340" name="Teleport Strike" hidden="false" targetId="4243-5016-c4d9-2b6b" type="profile">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -23825,84 +22497,1668 @@
       <modifiers/>
       <constraints/>
       <categoryLinks>
-        <categoryLink id="ac83-bfda-3b77-905d" name="New CategoryLink" hidden="false" targetId="c7b7-edbc-bc14-6238" primary="false">
+        <categoryLink id="2894-54a4-8d6a-7781" name="New CategoryLink" hidden="false" targetId="c7b7-edbc-bc14-6238" primary="false">
           <profiles/>
           <rules/>
           <infoLinks/>
           <modifiers/>
           <constraints/>
         </categoryLink>
-        <categoryLink id="0f96-cb10-8526-dc86" name="New CategoryLink" hidden="false" targetId="ef18-746a-369f-43a4" primary="false">
+        <categoryLink id="2c72-8701-b2a7-3e13" name="New CategoryLink" hidden="false" targetId="6fd7-9e10-d37c-5056" primary="false">
           <profiles/>
           <rules/>
           <infoLinks/>
           <modifiers/>
           <constraints/>
         </categoryLink>
-        <categoryLink id="e625-bc06-cbe8-a30e" name="New CategoryLink" hidden="false" targetId="eb9d-2b67-64b0-800f" primary="false">
+        <categoryLink id="b1c1-e606-ee97-9289" name="New CategoryLink" hidden="false" targetId="84e2-9fa9-ebe6-1d18" primary="false">
           <profiles/>
           <rules/>
           <infoLinks/>
           <modifiers/>
           <constraints/>
         </categoryLink>
-        <categoryLink id="be92-aba1-4166-3b3a" name="New CategoryLink" hidden="false" targetId="b44c-e966-5868-c970" primary="false">
+        <categoryLink id="2ded-2a0b-49a2-83bb" name="New CategoryLink" hidden="false" targetId="9956-5c97-2c81-da80" primary="false">
           <profiles/>
           <rules/>
           <infoLinks/>
           <modifiers/>
           <constraints/>
         </categoryLink>
-        <categoryLink id="79af-39d4-b318-05be" name="New CategoryLink" hidden="false" targetId="6fd7-9e10-d37c-5056" primary="false">
+        <categoryLink id="ad6e-64e0-7e60-2e79" name="New CategoryLink" hidden="false" targetId="ef18-746a-369f-43a4" primary="false">
           <profiles/>
           <rules/>
           <infoLinks/>
           <modifiers/>
           <constraints/>
         </categoryLink>
-        <categoryLink id="3d0b-3f72-0003-46c3" name="New CategoryLink" hidden="false" targetId="2c4a-3ec9-a1f6-a1ee" primary="false">
+        <categoryLink id="9039-3756-bf93-7166" name="New CategoryLink" hidden="false" targetId="848a6ff2-0def-4c72-8433-ff7da70e6bc7" primary="true">
           <profiles/>
           <rules/>
           <infoLinks/>
           <modifiers/>
           <constraints/>
         </categoryLink>
-        <categoryLink id="e422-dd5e-197b-d850" name="New CategoryLink" hidden="false" targetId="50f1-c3ea-9d66-6446" primary="false">
+        <categoryLink id="7a91-655e-6be8-77cc" name="New CategoryLink" hidden="false" targetId="3d52-fccf-10c0-3fae" primary="false">
           <profiles/>
           <rules/>
           <infoLinks/>
           <modifiers/>
           <constraints/>
         </categoryLink>
-        <categoryLink id="7057-93f8-8774-cd17" name="New CategoryLink" hidden="false" targetId="848a6ff2-0def-4c72-8433-ff7da70e6bc7" primary="true">
+        <categoryLink id="ab6d-be1e-b7e3-ad74" name="New CategoryLink" hidden="false" targetId="2378-fd9b-5213-6a6c" primary="false">
           <profiles/>
           <rules/>
           <infoLinks/>
           <modifiers/>
           <constraints/>
         </categoryLink>
-        <categoryLink id="82cd-f7c8-ab43-5691" name="New CategoryLink" hidden="false" targetId="84e2-9fa9-ebe6-1d18" primary="false">
+      </categoryLinks>
+      <selectionEntries/>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="30b0-5501-d658-86a4" name="Ranged/melee weapon" hidden="false" collective="false" defaultSelectionEntryId="0502-e584-499c-11d4">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f2c7-6087-51cc-ee03" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1432-c4df-7b99-4ec8" type="max"/>
+          </constraints>
+          <categoryLinks/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="0502-e584-499c-11d4" name="Combi-bolter" hidden="false" targetId="eba0-9fc6-5334-a390" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="cee8-090d-90bb-a7c6" type="max"/>
+              </constraints>
+              <categoryLinks/>
+            </entryLink>
+            <entryLink id="555d-5dbc-d21b-424d" name="Terminator combi-weapons" hidden="false" targetId="c713-8c0d-64b9-ce2f" type="selectionEntryGroup">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7ddf-83e8-5105-ce4a" type="max"/>
+              </constraints>
+              <categoryLinks/>
+            </entryLink>
+            <entryLink id="5c99-55d7-fc20-35c4" name="Terminator melee weapons" hidden="false" targetId="4071-f5e2-ec86-a309" type="selectionEntryGroup">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="cc2d-9716-adf4-fd74" type="max"/>
+              </constraints>
+              <categoryLinks/>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="1857-e823-38d5-2321" name="Melee weapon" hidden="false" collective="false" defaultSelectionEntryId="4267-3963-dd8d-1d47">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1cc5-c433-85c6-cf78" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d1cc-7694-3505-4288" type="max"/>
+          </constraints>
+          <categoryLinks/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="4267-3963-dd8d-1d47" name="Chainfist" hidden="false" targetId="e464-77c1-12bb-e52f" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3fce-011c-77bf-3f13" type="max"/>
+              </constraints>
+              <categoryLinks/>
+            </entryLink>
+            <entryLink id="b310-5927-ba0b-06a7" name="Terminator melee weapons" hidden="false" targetId="4071-f5e2-ec86-a309" type="selectionEntryGroup">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c2e4-d520-edef-4af7" type="max"/>
+              </constraints>
+              <categoryLinks/>
+            </entryLink>
+            <entryLink id="de08-7c0e-962a-3809" name="Power sword" hidden="false" targetId="bc9e-551d-9afb-78d5" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d6bf-bcd5-56ca-1864" type="max"/>
+              </constraints>
+              <categoryLinks/>
+            </entryLink>
+            <entryLink id="4ea9-816c-d43e-fba4" name="Relic blade" hidden="false" targetId="0140-c9f2-0524-34cc" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f7bf-1f96-75fc-6df1" type="max"/>
+              </constraints>
+              <categoryLinks/>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <entryLinks>
+        <entryLink id="8030-8a7d-c673-e023" name="Warlord" hidden="false" targetId="33f6-60da-7b70-5fee" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1813-74ed-8e39-e7a0" type="max"/>
+          </constraints>
+          <categoryLinks/>
+        </entryLink>
+        <entryLink id="af84-bab5-8d38-e794" name="Warlord Traits" hidden="false" targetId="c25d-2fbc-47b3-9e39" type="selectionEntryGroup">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+          <categoryLinks/>
+        </entryLink>
+        <entryLink id="b01a-c8cb-4408-2aac" name="Relics of Baal" hidden="false" targetId="441f-1714-0777-c202" type="selectionEntryGroup">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+          <categoryLinks/>
+        </entryLink>
+      </entryLinks>
+      <costs>
+        <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="8.0"/>
+        <cost name="pts" costTypeId="points" value="126.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="5a04-c03d-3ac5-2c78" name="Lieutenants" hidden="false" collective="false" type="unit">
+      <profiles/>
+      <rules/>
+      <infoLinks>
+        <infoLink id="372b-9c58-5a6c-a85f" name="Company Heroes" hidden="false" targetId="0ebd-45e5-3eb6-d9e0" type="profile">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="c86b-cb09-8a86-0f0a" name="Tactical Precision" hidden="false" targetId="a8e2-0267-b144-14fc" type="profile">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="f9fb-3fde-63bc-3a4d" name="And They Shall Know No Fear" hidden="false" targetId="4ea8-94d3-ba39-042f" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints/>
+      <categoryLinks>
+        <categoryLink id="170d-7932-4770-aa31" name="New CategoryLink" hidden="false" targetId="c7b7-edbc-bc14-6238" primary="false">
           <profiles/>
           <rules/>
           <infoLinks/>
           <modifiers/>
           <constraints/>
         </categoryLink>
-        <categoryLink id="aab2-7492-af1e-353e" name="New CategoryLink" hidden="false" targetId="3d52-fccf-10c0-3fae" primary="false">
+        <categoryLink id="c6b0-ed1a-073d-8761" name="New CategoryLink" hidden="false" targetId="ef18-746a-369f-43a4" primary="false">
           <profiles/>
           <rules/>
           <infoLinks/>
           <modifiers/>
           <constraints/>
         </categoryLink>
-        <categoryLink id="d564-dc70-76b2-eebf" name="New CategoryLink" hidden="false" targetId="df09-a39a-dd33-89f7" primary="false">
+        <categoryLink id="db45-ace3-49fa-1363" name="New CategoryLink" hidden="false" targetId="6fd7-9e10-d37c-5056" primary="false">
           <profiles/>
           <rules/>
           <infoLinks/>
           <modifiers/>
           <constraints/>
         </categoryLink>
-        <categoryLink id="b763-5ff2-131d-8782" name="New CategoryLink" hidden="false" targetId="9956-5c97-2c81-da80" primary="false">
+        <categoryLink id="80f9-7949-0ec5-cffc" name="New CategoryLink" hidden="false" targetId="848a6ff2-0def-4c72-8433-ff7da70e6bc7" primary="true">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
+        <categoryLink id="485c-be1c-daef-82b1" name="New CategoryLink" hidden="false" targetId="84e2-9fa9-ebe6-1d18" primary="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
+        <categoryLink id="0ede-5fae-50c8-0f84" name="New CategoryLink" hidden="false" targetId="3d52-fccf-10c0-3fae" primary="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
+        <categoryLink id="d0c2-3621-be6c-0fb0" name="New CategoryLink" hidden="false" targetId="f4a5-3ad5-3ec4-9e7b" primary="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="c16a-af24-1b18-f9d0" name="Lieutenant" hidden="false" collective="false" type="model">
+          <profiles/>
+          <rules/>
+          <infoLinks>
+            <infoLink id="4aff-3215-aeb6-2072" name="Lieutenant" hidden="false" targetId="30ec-37fb-8737-4b5e" type="profile">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers>
+                <modifier type="set" field="0bdf-a96e-9e38-7779" value="12&quot;">
+                  <repeats/>
+                  <conditions>
+                    <condition field="selections" scope="c16a-af24-1b18-f9d0" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8eda-5cb2-0c31-56da" type="equalTo"/>
+                  </conditions>
+                  <conditionGroups/>
+                </modifier>
+              </modifiers>
+            </infoLink>
+          </infoLinks>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="05f7-4881-27df-8dae" type="min"/>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c5e1-d67a-b2d3-80ba" type="max"/>
+          </constraints>
+          <categoryLinks/>
+          <selectionEntries/>
+          <selectionEntryGroups>
+            <selectionEntryGroup id="149e-e92c-71a9-fe45" name="Melee weapon" hidden="false" collective="false" defaultSelectionEntryId="9af5-10ce-94aa-8b13">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8628-7a45-f861-9388" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1ba3-f16d-842d-b2de" type="max"/>
+              </constraints>
+              <categoryLinks/>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks>
+                <entryLink id="9af5-10ce-94aa-8b13" name="Chainsword" hidden="false" targetId="0dd1-2e2b-7dd1-5495" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e136-7c6c-8a5c-a169" type="max"/>
+                  </constraints>
+                  <categoryLinks/>
+                </entryLink>
+                <entryLink id="a0ae-fefd-135f-314f" name="Melee weapons" hidden="false" targetId="ed23-9d40-c441-5d0d" type="selectionEntryGroup">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7f52-bf35-4a53-2249" type="max"/>
+                  </constraints>
+                  <categoryLinks/>
+                </entryLink>
+              </entryLinks>
+            </selectionEntryGroup>
+            <selectionEntryGroup id="fd59-db26-2ac8-a40b" name="Ranged/melee weapon" hidden="false" collective="false" defaultSelectionEntryId="9a21-888f-8a24-d7ba">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f926-8627-9fee-e333" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1bc9-d762-6c6f-2a08" type="max"/>
+              </constraints>
+              <categoryLinks/>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks>
+                <entryLink id="9a21-888f-8a24-d7ba" name="Master-crafted boltgun" hidden="false" targetId="c215-aaf9-77ef-27fb" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0821-9eb6-f55e-d0ea" type="max"/>
+                  </constraints>
+                  <categoryLinks/>
+                </entryLink>
+                <entryLink id="2886-57e2-7661-c4c4" name="Melee weapons" hidden="false" targetId="ed23-9d40-c441-5d0d" type="selectionEntryGroup">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b97c-50c2-3ca8-ee92" type="max"/>
+                  </constraints>
+                  <categoryLinks/>
+                </entryLink>
+                <entryLink id="f041-0ab7-9e9c-e2c9" name="Pistols" hidden="false" targetId="fd01-4d17-a6ee-a344" type="selectionEntryGroup">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="39af-45d2-2e2b-b45a" type="max"/>
+                  </constraints>
+                  <categoryLinks/>
+                </entryLink>
+                <entryLink id="a545-d117-731d-01d5" name="Combi-weapons" hidden="false" targetId="eb30-a0c9-788b-eda1" type="selectionEntryGroup">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3a6d-e671-e77c-a5d3" type="max"/>
+                  </constraints>
+                  <categoryLinks/>
+                </entryLink>
+              </entryLinks>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
+          <entryLinks>
+            <entryLink id="37f7-f90c-b506-4495" name="Frag &amp; Krak grenades" book="" hidden="false" targetId="cddf-945e-1335-e681" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fd11-92eb-daae-f671" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b6dd-91a1-040d-e82f" type="max"/>
+              </constraints>
+              <categoryLinks/>
+            </entryLink>
+            <entryLink id="1eba-14c6-7515-319d" name="Bolt pistol" book="" hidden="false" targetId="0334-f487-8229-0c1a" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8d4b-6acc-5d70-8ff5" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f6a8-a58a-9b8a-2f35" type="max"/>
+              </constraints>
+              <categoryLinks/>
+            </entryLink>
+            <entryLink id="626a-c78e-e8b5-90ea" name="Jump Pack" book="" hidden="false" targetId="8eda-5cb2-0c31-56da" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers>
+                <modifier type="set" field="points" value="18">
+                  <repeats/>
+                  <conditions/>
+                  <conditionGroups/>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="27cc-6702-3869-dbd7" type="max"/>
+              </constraints>
+              <categoryLinks/>
+            </entryLink>
+            <entryLink id="87af-eedc-ed8e-a856" name="Warlord" hidden="false" targetId="33f6-60da-7b70-5fee" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d322-9d48-5af3-d5fb" type="max"/>
+              </constraints>
+              <categoryLinks/>
+            </entryLink>
+            <entryLink id="111b-4584-5d3b-fdf0" name="Warlord Traits" hidden="false" targetId="c25d-2fbc-47b3-9e39" type="selectionEntryGroup">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+              <categoryLinks/>
+            </entryLink>
+            <entryLink id="793a-1a0e-1515-f676" name="Relics of Baal" hidden="false" targetId="441f-1714-0777-c202" type="selectionEntryGroup">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+              <categoryLinks/>
+            </entryLink>
+          </entryLinks>
+          <costs>
+            <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="4.0"/>
+            <cost name="pts" costTypeId="points" value="60.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="0.0"/>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="eef8-6558-5bca-4db1" name="Cataphractii Terminator Squad" hidden="false" collective="false" type="unit">
+      <profiles>
+        <profile id="781d-80ac-a4b1-3fd4" name="Combat Squads" hidden="false" profileTypeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" profileTypeName="Abilities">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Description" characteristicTypeId="21befb24-fc85-4f52-a745-64b2e48f8228" value="Before deployment at the start of the game, a Cataphractii Terminator Squad containing 10 models may be split into two units, each containing 5 models."/>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules/>
+      <infoLinks>
+        <infoLink id="1c00-25ff-4832-ca4d" name="And They Shall Know No Fear" hidden="false" targetId="4ea8-94d3-ba39-042f" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="2458-68d8-f192-5b98" name="Cataphractii Armour" hidden="false" targetId="513c-7a02-27a5-7f86" type="profile">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="d76e-a190-79f0-cce7" name="Teleport Strike" hidden="false" targetId="4243-5016-c4d9-2b6b" type="profile">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers>
+        <modifier type="increment" field="e356-c769-5920-6e14" value="12">
+          <repeats/>
+          <conditions>
+            <condition field="selections" scope="eef8-6558-5bca-4db1" value="4.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b539-c8a3-f3a4-2f8a" type="greaterThan"/>
+          </conditions>
+          <conditionGroups/>
+        </modifier>
+      </modifiers>
+      <constraints/>
+      <categoryLinks>
+        <categoryLink id="a2ca-6ca3-198e-42b8" name="New CategoryLink" hidden="false" targetId="c7b7-edbc-bc14-6238" primary="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
+        <categoryLink id="882b-8f5f-5ee2-5c2b" name="New CategoryLink" hidden="false" targetId="6fd7-9e10-d37c-5056" primary="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
+        <categoryLink id="51b2-df02-fd26-1363" name="New CategoryLink" hidden="false" targetId="b44c-e966-5868-c970" primary="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
+        <categoryLink id="2317-0e6f-fa94-c843" name="New CategoryLink" hidden="false" targetId="2c4a-3ec9-a1f6-a1ee" primary="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
+        <categoryLink id="a64f-8857-9310-e8dc" name="New CategoryLink" hidden="false" targetId="84e2-9fa9-ebe6-1d18" primary="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
+        <categoryLink id="5a2c-245e-562a-a000" name="New CategoryLink" hidden="false" targetId="638d74c6-bd97-4de5-b65a-6aaa24e9f4b2" primary="true">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
+        <categoryLink id="59a6-903c-0826-3060" name="New CategoryLink" hidden="false" targetId="3d52-fccf-10c0-3fae" primary="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
+        <categoryLink id="0b0d-14a8-ba0a-5e85" name="New CategoryLink" hidden="false" targetId="2378-fd9b-5213-6a6c" primary="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
+        <categoryLink id="f03c-15f6-ebc9-139a" name="New CategoryLink" hidden="false" targetId="2ddb-c542-6db7-d30f" primary="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="3053-e242-db69-c41a" name="Cataphractii Sergeant" hidden="false" collective="false" type="model">
+          <profiles/>
+          <rules/>
+          <infoLinks>
+            <infoLink id="4865-1815-9887-d0b8" name="Cataphractii Sergeant" hidden="false" targetId="8dd8-1119-4c11-dfbd" type="profile">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+          </infoLinks>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fb31-62de-7758-d24f" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fadd-b8ea-c886-b314" type="max"/>
+          </constraints>
+          <categoryLinks/>
+          <selectionEntries/>
+          <selectionEntryGroups>
+            <selectionEntryGroup id="2182-cdb1-4d4f-c637" name="Combi-bolter arm" hidden="false" collective="false" defaultSelectionEntryId="2b4f-a8d3-7b49-ee6c">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1027-52d8-586c-b8e3" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7485-7cd8-799b-aa77" type="max"/>
+              </constraints>
+              <categoryLinks/>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks>
+                <entryLink id="2b4f-a8d3-7b49-ee6c" name="Combi-bolter" hidden="false" targetId="eba0-9fc6-5334-a390" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7566-a43d-d0bb-a029" type="max"/>
+                  </constraints>
+                  <categoryLinks/>
+                </entryLink>
+                <entryLink id="52a3-5de1-8360-98af" name="Lightning Claw" hidden="false" targetId="90de-7b01-e401-888b" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="54e5-d813-66f9-a107" type="max"/>
+                  </constraints>
+                  <categoryLinks/>
+                </entryLink>
+              </entryLinks>
+            </selectionEntryGroup>
+            <selectionEntryGroup id="35dd-4c9e-ed77-7824" name="Power sword arm" hidden="false" collective="false" defaultSelectionEntryId="dfef-f841-b807-5de0">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5bd8-329b-55f4-40ca" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b9f3-6c5e-b1e0-5bf9" type="max"/>
+              </constraints>
+              <categoryLinks/>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks>
+                <entryLink id="dfef-f841-b807-5de0" name="Power sword" hidden="false" targetId="bc9e-551d-9afb-78d5" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b364-4a0e-9edf-6a75" type="max"/>
+                  </constraints>
+                  <categoryLinks/>
+                </entryLink>
+                <entryLink id="3912-147a-02d2-a41c" name="Lightning Claw" hidden="false" targetId="90de-7b01-e401-888b" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="aa43-ead3-d51b-7507" type="max"/>
+                  </constraints>
+                  <categoryLinks/>
+                </entryLink>
+                <entryLink id="45b5-2f03-0bcc-40c2" name="Chainfist" hidden="false" targetId="e464-77c1-12bb-e52f" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="65b1-279a-1693-819b" type="max"/>
+                  </constraints>
+                  <categoryLinks/>
+                </entryLink>
+                <entryLink id="43b6-90b7-3582-eb01" name="Power fist" hidden="false" targetId="f122-3720-fa32-4215" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e658-3a0c-aa3c-f11c" type="max"/>
+                  </constraints>
+                  <categoryLinks/>
+                </entryLink>
+              </entryLinks>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
+          <entryLinks>
+            <entryLink id="749d-7ee5-088d-5711" name="Grenade harness" hidden="false" targetId="c300-04a5-d4eb-3f53" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c983-a0e9-51a6-ea3a" type="max"/>
+              </constraints>
+              <categoryLinks/>
+            </entryLink>
+          </entryLinks>
+          <costs>
+            <cost name="pts" costTypeId="points" value="30.0"/>
+            <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="b539-c8a3-f3a4-2f8a" name="Cataphractii Terminator" hidden="false" collective="false" type="model">
+          <profiles/>
+          <rules/>
+          <infoLinks>
+            <infoLink id="af15-e73d-b8f8-d23a" name="Cataphractii Terminator" hidden="false" targetId="e834-3e76-82c6-77fa" type="profile">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+          </infoLinks>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e15e-31b9-ec53-7ab5" type="min"/>
+            <constraint field="selections" scope="parent" value="9.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ed16-0ba6-e59f-24d4" type="max"/>
+          </constraints>
+          <categoryLinks/>
+          <selectionEntries/>
+          <selectionEntryGroups>
+            <selectionEntryGroup id="183f-4ca0-962c-c32d" name="Combi-bolter arm" hidden="false" collective="false" defaultSelectionEntryId="5db1-8075-56f7-ae5d">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="dfaf-e78f-81cd-3c39" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1176-0a71-cf33-e3e5" type="max"/>
+              </constraints>
+              <categoryLinks/>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks>
+                <entryLink id="5db1-8075-56f7-ae5d" name="Combi-bolter" hidden="false" targetId="eba0-9fc6-5334-a390" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="660f-2284-adec-9e11" type="max"/>
+                  </constraints>
+                  <categoryLinks/>
+                </entryLink>
+                <entryLink id="89ef-a3df-1fb7-a977" name="Lightning Claw" hidden="false" targetId="90de-7b01-e401-888b" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="1af5-fe45-e96e-328b" type="max"/>
+                  </constraints>
+                  <categoryLinks/>
+                </entryLink>
+                <entryLink id="d40b-8ffc-0b8a-4223" name="Heavy flamer" hidden="false" targetId="18bc-b335-29c2-2ae2" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers>
+                    <modifier type="increment" field="129c-5219-6309-c521" value="1">
+                      <repeats>
+                        <repeat field="selections" scope="eef8-6558-5bca-4db1" value="5.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="model" repeats="1" roundUp="false"/>
+                      </repeats>
+                      <conditions/>
+                      <conditionGroups/>
+                    </modifier>
+                  </modifiers>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7fcf-d643-40a3-8996" type="max"/>
+                    <constraint field="selections" scope="eef8-6558-5bca-4db1" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="129c-5219-6309-c521" type="max"/>
+                  </constraints>
+                  <categoryLinks/>
+                </entryLink>
+              </entryLinks>
+            </selectionEntryGroup>
+            <selectionEntryGroup id="fd66-2255-f497-7db5" name="Power fist arm" hidden="false" collective="false" defaultSelectionEntryId="e89c-ded6-d2e5-83e3">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7df4-9ae5-0032-94c7" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f519-442d-eb51-0858" type="max"/>
+              </constraints>
+              <categoryLinks/>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks>
+                <entryLink id="eb02-ad75-965e-99e4" name="Lightning Claw" hidden="false" targetId="90de-7b01-e401-888b" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="d011-e47c-63aa-8098" type="max"/>
+                  </constraints>
+                  <categoryLinks/>
+                </entryLink>
+                <entryLink id="a49a-36c4-3f94-9959" name="Chainfist" hidden="false" targetId="e464-77c1-12bb-e52f" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2c1b-0633-090f-7083" type="max"/>
+                  </constraints>
+                  <categoryLinks/>
+                </entryLink>
+                <entryLink id="e89c-ded6-d2e5-83e3" name="Power fist" hidden="false" targetId="f122-3720-fa32-4215" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e669-54b3-2f1f-00da" type="max"/>
+                  </constraints>
+                  <categoryLinks/>
+                </entryLink>
+              </entryLinks>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="30.0"/>
+            <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="0.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="12.0"/>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="e044-89c5-b266-854b" name="Tartaros Terminator Squad" hidden="false" collective="false" type="unit">
+      <profiles>
+        <profile id="d39d-b52b-c78e-46fe" name="Combat Squads" hidden="false" profileTypeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" profileTypeName="Abilities">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Description" characteristicTypeId="21befb24-fc85-4f52-a745-64b2e48f8228" value="Before deployment at the start of the game, a Tartaros Terminator Squad containing 10 models may be split into two units, each containing 5 models."/>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules/>
+      <infoLinks>
+        <infoLink id="90b5-1d50-945d-4f1b" name="And They Shall Know No Fear" hidden="false" targetId="4ea8-94d3-ba39-042f" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="100e-1874-1071-2db1" name="Tartaros Armour" hidden="false" targetId="e28b-6386-03ab-ad31" type="profile">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="9eae-6564-2560-6a5a" name="Teleport Strike" hidden="false" targetId="4243-5016-c4d9-2b6b" type="profile">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers>
+        <modifier type="increment" field="e356-c769-5920-6e14" value="12">
+          <repeats/>
+          <conditions>
+            <condition field="selections" scope="e044-89c5-b266-854b" value="4.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f00e-3664-264a-f090" type="greaterThan"/>
+          </conditions>
+          <conditionGroups/>
+        </modifier>
+      </modifiers>
+      <constraints/>
+      <categoryLinks>
+        <categoryLink id="b90a-8cac-13d3-27c2" name="New CategoryLink" hidden="false" targetId="c7b7-edbc-bc14-6238" primary="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
+        <categoryLink id="637c-e40b-1024-bee9" name="New CategoryLink" hidden="false" targetId="6fd7-9e10-d37c-5056" primary="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
+        <categoryLink id="cd58-8d42-af94-2369" name="New CategoryLink" hidden="false" targetId="b44c-e966-5868-c970" primary="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
+        <categoryLink id="b4ea-7815-46d5-e7f3" name="New CategoryLink" hidden="false" targetId="2c4a-3ec9-a1f6-a1ee" primary="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
+        <categoryLink id="2ea6-e583-6da2-bcd2" name="New CategoryLink" hidden="false" targetId="84e2-9fa9-ebe6-1d18" primary="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
+        <categoryLink id="be45-9c54-783a-70b3" name="New CategoryLink" hidden="false" targetId="638d74c6-bd97-4de5-b65a-6aaa24e9f4b2" primary="true">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
+        <categoryLink id="4e96-6515-92bc-a7bf" name="New CategoryLink" hidden="false" targetId="3d52-fccf-10c0-3fae" primary="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
+        <categoryLink id="898d-39e6-ea4f-5cd5" name="New CategoryLink" hidden="false" targetId="2378-fd9b-5213-6a6c" primary="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
+        <categoryLink id="5097-2150-2e52-1e6e" name="New CategoryLink" hidden="false" targetId="5730-2cee-102d-c71f" primary="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="8b62-c762-5241-b4cd" name="Tartaros Sergeant" hidden="false" collective="false" type="model">
+          <profiles/>
+          <rules/>
+          <infoLinks>
+            <infoLink id="6e2d-4f04-6751-01bc" name="Tartaros Sergeant" hidden="false" targetId="a6c0-d093-2681-5674" type="profile">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+          </infoLinks>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9951-fb39-792f-d493" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5e68-3e84-f888-ba6d" type="max"/>
+          </constraints>
+          <categoryLinks/>
+          <selectionEntries/>
+          <selectionEntryGroups>
+            <selectionEntryGroup id="b134-bdea-0b72-df78" name="Weapons" hidden="false" collective="false" defaultSelectionEntryId="b1df-07ed-4397-0741">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3187-241a-2372-1927" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5409-26f0-b76f-88c9" type="max"/>
+              </constraints>
+              <categoryLinks/>
+              <selectionEntries>
+                <selectionEntry id="b1df-07ed-4397-0741" name="Ranged/melee weapons" hidden="false" collective="false" type="upgrade">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8d98-cae5-1c3a-4499" type="max"/>
+                  </constraints>
+                  <categoryLinks/>
+                  <selectionEntries/>
+                  <selectionEntryGroups>
+                    <selectionEntryGroup id="9740-18fb-5509-7554" name="Combi-bolter arm" hidden="false" collective="false" defaultSelectionEntryId="f715-4630-24b3-cf7f">
+                      <profiles/>
+                      <rules/>
+                      <infoLinks/>
+                      <modifiers/>
+                      <constraints>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3a48-2052-4133-4eaa" type="min"/>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c550-72b9-8466-ed76" type="max"/>
+                      </constraints>
+                      <categoryLinks/>
+                      <selectionEntries/>
+                      <selectionEntryGroups/>
+                      <entryLinks>
+                        <entryLink id="f715-4630-24b3-cf7f" name="Combi-bolter" hidden="false" targetId="eba0-9fc6-5334-a390" type="selectionEntry">
+                          <profiles/>
+                          <rules/>
+                          <infoLinks/>
+                          <modifiers/>
+                          <constraints>
+                            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0ed1-e853-7110-f3f5" type="max"/>
+                          </constraints>
+                          <categoryLinks/>
+                        </entryLink>
+                        <entryLink id="51c2-1555-551c-4ace" name="Plasma blaster" hidden="false" targetId="5aaf-d2e4-ec59-0407" type="selectionEntry">
+                          <profiles/>
+                          <rules/>
+                          <infoLinks/>
+                          <modifiers/>
+                          <constraints>
+                            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="68dc-cf84-8e7e-b61b" type="max"/>
+                          </constraints>
+                          <categoryLinks/>
+                        </entryLink>
+                        <entryLink id="db71-9fb4-3bd5-8a1e" name="Volkite charger" hidden="false" targetId="250a-10f2-a1c6-36ff" type="selectionEntry">
+                          <profiles/>
+                          <rules/>
+                          <infoLinks/>
+                          <modifiers/>
+                          <constraints>
+                            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="cc51-4825-9b94-8c75" type="max"/>
+                          </constraints>
+                          <categoryLinks/>
+                        </entryLink>
+                      </entryLinks>
+                    </selectionEntryGroup>
+                    <selectionEntryGroup id="4932-7398-e5dc-0965" name="Power sword arm" hidden="false" collective="false" defaultSelectionEntryId="df78-eb36-dd2d-38b9">
+                      <profiles/>
+                      <rules/>
+                      <infoLinks/>
+                      <modifiers/>
+                      <constraints>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4770-07da-44c1-4d37" type="min"/>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="686a-9ee3-9311-eba4" type="max"/>
+                      </constraints>
+                      <categoryLinks/>
+                      <selectionEntries/>
+                      <selectionEntryGroups/>
+                      <entryLinks>
+                        <entryLink id="df78-eb36-dd2d-38b9" name="Power sword" hidden="false" targetId="bc9e-551d-9afb-78d5" type="selectionEntry">
+                          <profiles/>
+                          <rules/>
+                          <infoLinks/>
+                          <modifiers/>
+                          <constraints>
+                            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3469-62ff-fec2-5517" type="max"/>
+                          </constraints>
+                          <categoryLinks/>
+                        </entryLink>
+                        <entryLink id="0a7d-d532-fa6e-9078" name="Chainfist" hidden="false" targetId="e464-77c1-12bb-e52f" type="selectionEntry">
+                          <profiles/>
+                          <rules/>
+                          <infoLinks/>
+                          <modifiers/>
+                          <constraints>
+                            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0d87-85db-e7e0-a78a" type="max"/>
+                          </constraints>
+                          <categoryLinks/>
+                        </entryLink>
+                        <entryLink id="c310-1732-cbd4-411d" name="Power fist" hidden="false" targetId="f122-3720-fa32-4215" type="selectionEntry">
+                          <profiles/>
+                          <rules/>
+                          <infoLinks/>
+                          <modifiers/>
+                          <constraints>
+                            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f9bf-8f51-1bd6-07c4" type="max"/>
+                          </constraints>
+                          <categoryLinks/>
+                        </entryLink>
+                      </entryLinks>
+                    </selectionEntryGroup>
+                  </selectionEntryGroups>
+                  <entryLinks/>
+                  <costs>
+                    <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="0.0"/>
+                    <cost name="pts" costTypeId="points" value="0.0"/>
+                  </costs>
+                </selectionEntry>
+              </selectionEntries>
+              <selectionEntryGroups/>
+              <entryLinks>
+                <entryLink id="5060-7441-9455-bcf6" name="Lightning Claw (Pair)" hidden="false" targetId="1f50-1645-5312-885a" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7d59-9ff9-c320-36e1" type="max"/>
+                  </constraints>
+                  <categoryLinks/>
+                </entryLink>
+              </entryLinks>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
+          <entryLinks>
+            <entryLink id="da6e-c398-3417-328d" name="Grenade harness" hidden="false" targetId="c300-04a5-d4eb-3f53" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers>
+                <modifier type="increment" field="b73b-3105-af3a-542e" value="1">
+                  <repeats>
+                    <repeat field="selections" scope="e044-89c5-b266-854b" value="5.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="model" repeats="1" roundUp="false"/>
+                  </repeats>
+                  <conditions/>
+                  <conditionGroups/>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f293-770f-1a8b-d5ed" type="max"/>
+                <constraint field="selections" scope="e044-89c5-b266-854b" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="b73b-3105-af3a-542e" type="max"/>
+              </constraints>
+              <categoryLinks/>
+            </entryLink>
+          </entryLinks>
+          <costs>
+            <cost name="pts" costTypeId="points" value="26.0"/>
+            <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="f00e-3664-264a-f090" name="Tartaros Terminator" hidden="false" collective="false" type="model">
+          <profiles/>
+          <rules/>
+          <infoLinks>
+            <infoLink id="65df-18e2-dda2-644b" name="Tartaros Terminator" hidden="false" targetId="7830-200d-5dc6-9209" type="profile">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+          </infoLinks>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e547-e0a5-9284-fdbb" type="min"/>
+            <constraint field="selections" scope="parent" value="9.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d959-db73-f0d6-b12c" type="max"/>
+          </constraints>
+          <categoryLinks/>
+          <selectionEntries/>
+          <selectionEntryGroups>
+            <selectionEntryGroup id="93cd-5749-a8b1-ff76" name="Weapons" hidden="false" collective="false" defaultSelectionEntryId="dafd-cb43-5c60-b149">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="faa2-95bc-4a9d-c777" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c69d-029a-d02b-52c8" type="max"/>
+              </constraints>
+              <categoryLinks/>
+              <selectionEntries>
+                <selectionEntry id="dafd-cb43-5c60-b149" name="Ranged/melee weapons" hidden="false" collective="false" type="upgrade">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8586-dbf1-3ca9-9589" type="max"/>
+                  </constraints>
+                  <categoryLinks/>
+                  <selectionEntries/>
+                  <selectionEntryGroups>
+                    <selectionEntryGroup id="b94b-97cf-5d27-66d9" name="Combi-bolter arm" hidden="false" collective="false" defaultSelectionEntryId="be7a-d109-939e-3ff5">
+                      <profiles/>
+                      <rules/>
+                      <infoLinks/>
+                      <modifiers/>
+                      <constraints>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5203-85f3-b383-7e00" type="min"/>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f33b-60eb-d4e8-59c9" type="max"/>
+                      </constraints>
+                      <categoryLinks/>
+                      <selectionEntries/>
+                      <selectionEntryGroups/>
+                      <entryLinks>
+                        <entryLink id="be7a-d109-939e-3ff5" name="Combi-bolter" hidden="false" targetId="eba0-9fc6-5334-a390" type="selectionEntry">
+                          <profiles/>
+                          <rules/>
+                          <infoLinks/>
+                          <modifiers/>
+                          <constraints>
+                            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d81c-4a36-fba9-7039" type="max"/>
+                          </constraints>
+                          <categoryLinks/>
+                        </entryLink>
+                        <entryLink id="3ec7-824e-9089-aa43" name="Heavy flamer" hidden="false" targetId="18bc-b335-29c2-2ae2" type="selectionEntry">
+                          <profiles/>
+                          <rules/>
+                          <infoLinks/>
+                          <modifiers>
+                            <modifier type="increment" field="765f-f623-5a83-b7e6" value="1">
+                              <repeats>
+                                <repeat field="selections" scope="e044-89c5-b266-854b" value="5.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="model" repeats="1" roundUp="false"/>
+                              </repeats>
+                              <conditions/>
+                              <conditionGroups/>
+                            </modifier>
+                            <modifier type="decrement" field="765f-f623-5a83-b7e6" value="1">
+                              <repeats>
+                                <repeat field="selections" scope="e044-89c5-b266-854b" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="5ab4-1ee7-95ad-7e15" repeats="1" roundUp="false"/>
+                              </repeats>
+                              <conditions/>
+                              <conditionGroups/>
+                            </modifier>
+                          </modifiers>
+                          <constraints>
+                            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d6a4-dc9d-f2d9-88de" type="max"/>
+                            <constraint field="selections" scope="e044-89c5-b266-854b" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="765f-f623-5a83-b7e6" type="max"/>
+                          </constraints>
+                          <categoryLinks/>
+                        </entryLink>
+                        <entryLink id="7721-feea-1e63-3006" name="Reaper autocannon" hidden="false" targetId="5ab4-1ee7-95ad-7e15" type="selectionEntry">
+                          <profiles/>
+                          <rules/>
+                          <infoLinks/>
+                          <modifiers>
+                            <modifier type="increment" field="1fb8-43b9-dc34-3408" value="1">
+                              <repeats>
+                                <repeat field="selections" scope="e044-89c5-b266-854b" value="5.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="model" repeats="1" roundUp="false"/>
+                              </repeats>
+                              <conditions/>
+                              <conditionGroups/>
+                            </modifier>
+                            <modifier type="decrement" field="1fb8-43b9-dc34-3408" value="1">
+                              <repeats>
+                                <repeat field="selections" scope="e044-89c5-b266-854b" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="18bc-b335-29c2-2ae2" repeats="1" roundUp="false"/>
+                              </repeats>
+                              <conditions/>
+                              <conditionGroups/>
+                            </modifier>
+                          </modifiers>
+                          <constraints>
+                            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e7af-5b0b-7f94-0f03" type="max"/>
+                            <constraint field="selections" scope="e044-89c5-b266-854b" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="1fb8-43b9-dc34-3408" type="max"/>
+                          </constraints>
+                          <categoryLinks/>
+                        </entryLink>
+                      </entryLinks>
+                    </selectionEntryGroup>
+                    <selectionEntryGroup id="01e6-dce4-c79b-1ac5" name="Power fist arm" hidden="false" collective="false" defaultSelectionEntryId="e63a-9fed-aa81-f2df">
+                      <profiles/>
+                      <rules/>
+                      <infoLinks/>
+                      <modifiers/>
+                      <constraints>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e9f4-a5d1-bc0c-1b8f" type="min"/>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="966a-a343-c9cd-46f5" type="max"/>
+                      </constraints>
+                      <categoryLinks/>
+                      <selectionEntries/>
+                      <selectionEntryGroups/>
+                      <entryLinks>
+                        <entryLink id="10bd-306d-f41b-205b" name="Chainfist" hidden="false" targetId="e464-77c1-12bb-e52f" type="selectionEntry">
+                          <profiles/>
+                          <rules/>
+                          <infoLinks/>
+                          <modifiers/>
+                          <constraints>
+                            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8902-98ad-62c8-c91b" type="max"/>
+                          </constraints>
+                          <categoryLinks/>
+                        </entryLink>
+                        <entryLink id="e63a-9fed-aa81-f2df" name="Power fist" hidden="false" targetId="f122-3720-fa32-4215" type="selectionEntry">
+                          <profiles/>
+                          <rules/>
+                          <infoLinks/>
+                          <modifiers/>
+                          <constraints>
+                            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0d5d-c33c-b3ec-46c9" type="max"/>
+                          </constraints>
+                          <categoryLinks/>
+                        </entryLink>
+                      </entryLinks>
+                    </selectionEntryGroup>
+                  </selectionEntryGroups>
+                  <entryLinks/>
+                  <costs>
+                    <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="0.0"/>
+                    <cost name="pts" costTypeId="points" value="0.0"/>
+                  </costs>
+                </selectionEntry>
+              </selectionEntries>
+              <selectionEntryGroups/>
+              <entryLinks>
+                <entryLink id="3add-ca3c-faa8-5c91" name="Lightning Claw (Pair)" hidden="false" targetId="1f50-1645-5312-885a" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1dc7-9493-5345-2e53" type="max"/>
+                  </constraints>
+                  <categoryLinks/>
+                </entryLink>
+              </entryLinks>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
+          <entryLinks>
+            <entryLink id="1fd8-6515-36de-3d23" name="Grenade harness" hidden="false" targetId="c300-04a5-d4eb-3f53" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers>
+                <modifier type="increment" field="0c5d-a0a8-e418-3003" value="1">
+                  <repeats>
+                    <repeat field="selections" scope="e044-89c5-b266-854b" value="5.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="model" repeats="1" roundUp="false"/>
+                  </repeats>
+                  <conditions/>
+                  <conditionGroups/>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1042-0fe1-3cf5-c52f" type="max"/>
+                <constraint field="selections" scope="e044-89c5-b266-854b" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="0c5d-a0a8-e418-3003" type="max"/>
+              </constraints>
+              <categoryLinks/>
+            </entryLink>
+          </entryLinks>
+          <costs>
+            <cost name="pts" costTypeId="points" value="26.0"/>
+            <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="0.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="12.0"/>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="0fa8-7fd2-34bb-b556" name="Contemptor Dreadought" hidden="false" collective="false" type="model">
+      <profiles>
+        <profile id="83a8-61c7-2dbf-d20d" name="Contemptor Dreadought" hidden="false" profileTypeId="5f4f-ea74-0630-4afe" profileTypeName="Wound Track">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Remaining W" characteristicTypeId="8e45-c866-b2d4-c9ab" value=""/>
+            <characteristic name="Characteristic 1" characteristicTypeId="bf41-c860-50bc-2a7e" value="M"/>
+            <characteristic name="Characteristic 2" characteristicTypeId="dc18-e51f-309b-8efa" value="WS"/>
+            <characteristic name="Characteristic 3" characteristicTypeId="df06-8eca-150f-90ba" value="BS"/>
+          </characteristics>
+        </profile>
+        <profile id="97df-b7a7-fcc8-3f23" name="Contemptor Dreadought 1" book="" hidden="false" profileTypeId="5f4f-ea74-0630-4afe" profileTypeName="Wound Track">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Remaining W" characteristicTypeId="8e45-c866-b2d4-c9ab" value="6-10+"/>
+            <characteristic name="Characteristic 1" characteristicTypeId="bf41-c860-50bc-2a7e" value="9&quot;"/>
+            <characteristic name="Characteristic 2" characteristicTypeId="dc18-e51f-309b-8efa" value="2+"/>
+            <characteristic name="Characteristic 3" characteristicTypeId="df06-8eca-150f-90ba" value="2+"/>
+          </characteristics>
+        </profile>
+        <profile id="1be9-d3d6-715a-7581" name="Contemptor Dreadought 2" hidden="false" profileTypeId="5f4f-ea74-0630-4afe" profileTypeName="Wound Track">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Remaining W" characteristicTypeId="8e45-c866-b2d4-c9ab" value="3-5"/>
+            <characteristic name="Characteristic 1" characteristicTypeId="bf41-c860-50bc-2a7e" value="6&quot;"/>
+            <characteristic name="Characteristic 2" characteristicTypeId="dc18-e51f-309b-8efa" value="3+"/>
+            <characteristic name="Characteristic 3" characteristicTypeId="df06-8eca-150f-90ba" value="3+"/>
+          </characteristics>
+        </profile>
+        <profile id="5324-7349-8d71-6e03" name="Contemptor Dreadought 3" hidden="false" profileTypeId="5f4f-ea74-0630-4afe" profileTypeName="Wound Track">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Remaining W" characteristicTypeId="8e45-c866-b2d4-c9ab" value="1-2"/>
+            <characteristic name="Characteristic 1" characteristicTypeId="bf41-c860-50bc-2a7e" value="4&quot;"/>
+            <characteristic name="Characteristic 2" characteristicTypeId="dc18-e51f-309b-8efa" value="4+"/>
+            <characteristic name="Characteristic 3" characteristicTypeId="df06-8eca-150f-90ba" value="4+"/>
+          </characteristics>
+        </profile>
+        <profile id="9c1a-7455-3b4c-ff20" name="Explodes" hidden="false" profileTypeId="818c-0db1-36f0-462a" profileTypeName="Explosion">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Dice roll" characteristicTypeId="f21d-8f6d-180d-36ff" value="6"/>
+            <characteristic name="Distance" characteristicTypeId="d69e-be07-1682-ebcc" value="6&quot;"/>
+            <characteristic name="Mortal wounds" characteristicTypeId="29f1-65a1-2c5d-8c7d" value="D3"/>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules/>
+      <infoLinks>
+        <infoLink id="ef19-96d7-aa52-62d6" name="Contemptor Dreadnought" hidden="false" targetId="bde6-3c93-9492-da0e" type="profile">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="0169-3ce4-e638-b7c5" name="Atomantic Shielding" hidden="false" targetId="b469-e56f-6da0-9dbe" type="profile">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints/>
+      <categoryLinks>
+        <categoryLink id="71d4-6eb6-1316-2204" name="New CategoryLink" hidden="false" targetId="c7b7-edbc-bc14-6238" primary="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
+        <categoryLink id="f804-b4e3-dba3-c586" name="New CategoryLink" hidden="false" targetId="638d74c6-bd97-4de5-b65a-6aaa24e9f4b2" primary="true">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
+        <categoryLink id="e659-f0dd-f7d7-f6bf" name="New CategoryLink" hidden="false" targetId="b44c-e966-5868-c970" primary="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
+        <categoryLink id="d81c-35a1-b978-f8f8" name="New CategoryLink" hidden="false" targetId="6fd7-9e10-d37c-5056" primary="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
+        <categoryLink id="b3f8-d4db-43d3-cd3c" name="New CategoryLink" hidden="false" targetId="2c4a-3ec9-a1f6-a1ee" primary="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
+        <categoryLink id="56fc-c348-57bb-8345" name="New CategoryLink" hidden="false" targetId="84e2-9fa9-ebe6-1d18" primary="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
+        <categoryLink id="3ec1-f6bc-9f20-677d" name="New CategoryLink" hidden="false" targetId="c8fd-783f-3230-493e" primary="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
+        <categoryLink id="1fff-7dc7-ff06-2c79" name="New CategoryLink" hidden="false" targetId="5b5a-6b60-b356-d2ec" primary="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
+        <categoryLink id="554a-8d84-e611-949a" name="New CategoryLink" hidden="false" targetId="9c7b-4573-3321-2def" primary="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
+      </categoryLinks>
+      <selectionEntries/>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="d5aa-8ebb-07bd-abc6" name="Main weapon" hidden="false" collective="false" defaultSelectionEntryId="6a0e-d0d1-830c-6f8f">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4b2a-b076-4389-b11a" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9e76-35b9-a79a-e6b0" type="max"/>
+          </constraints>
+          <categoryLinks/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="6a0e-d0d1-830c-6f8f" name="Multi-melta" hidden="false" targetId="2b37-65ee-9443-b4ef" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5e74-2949-b1f8-6096" type="max"/>
+              </constraints>
+              <categoryLinks/>
+            </entryLink>
+            <entryLink id="71d6-2a74-a364-5eb1" name="Kheres pattern assault cannon" hidden="false" targetId="db1d-3a08-13f2-72fa" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6281-c70e-e08b-df47" type="max"/>
+              </constraints>
+              <categoryLinks/>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <entryLinks>
+        <entryLink id="40de-1648-f2da-fe31" name="Combi-bolter" hidden="false" targetId="eba0-9fc6-5334-a390" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="376f-8d65-4aa5-0f35" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1be4-3432-4e52-a386" type="max"/>
+          </constraints>
+          <categoryLinks/>
+        </entryLink>
+        <entryLink id="54f6-09ff-9bc7-4881" name="Dreadnought combat weapon" hidden="false" targetId="a869-5624-fe55-fe95" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7ac7-2954-d309-c9c3" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8c08-59b6-bd4b-e0a6" type="max"/>
+          </constraints>
+          <categoryLinks/>
+        </entryLink>
+      </entryLinks>
+      <costs>
+        <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="8.0"/>
+        <cost name="pts" costTypeId="points" value="98.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="b92e-9a51-38e3-065d" name="Hunter" hidden="false" collective="false" type="model">
+      <profiles>
+        <profile id="ad21-52dc-cea7-02fd" name="Hunter" hidden="false" profileTypeId="5f4f-ea74-0630-4afe" profileTypeName="Wound Track">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Remaining W" characteristicTypeId="8e45-c866-b2d4-c9ab" value=""/>
+            <characteristic name="Characteristic 1" characteristicTypeId="bf41-c860-50bc-2a7e" value="M"/>
+            <characteristic name="Characteristic 2" characteristicTypeId="dc18-e51f-309b-8efa" value="BS"/>
+            <characteristic name="Characteristic 3" characteristicTypeId="df06-8eca-150f-90ba" value="A"/>
+          </characteristics>
+        </profile>
+        <profile id="6a67-4042-67bc-988f" name="Hunter 1" hidden="false" profileTypeId="5f4f-ea74-0630-4afe" profileTypeName="Wound Track">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Remaining W" characteristicTypeId="8e45-c866-b2d4-c9ab" value="6-11+"/>
+            <characteristic name="Characteristic 1" characteristicTypeId="bf41-c860-50bc-2a7e" value="10&quot;"/>
+            <characteristic name="Characteristic 2" characteristicTypeId="dc18-e51f-309b-8efa" value="3+"/>
+            <characteristic name="Characteristic 3" characteristicTypeId="df06-8eca-150f-90ba" value="3"/>
+          </characteristics>
+        </profile>
+        <profile id="6af4-43e4-91d0-a94f" name="Hunter 2" hidden="false" profileTypeId="5f4f-ea74-0630-4afe" profileTypeName="Wound Track">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Remaining W" characteristicTypeId="8e45-c866-b2d4-c9ab" value="3-5"/>
+            <characteristic name="Characteristic 1" characteristicTypeId="bf41-c860-50bc-2a7e" value="5&quot;"/>
+            <characteristic name="Characteristic 2" characteristicTypeId="dc18-e51f-309b-8efa" value="4+"/>
+            <characteristic name="Characteristic 3" characteristicTypeId="df06-8eca-150f-90ba" value="D3"/>
+          </characteristics>
+        </profile>
+        <profile id="1a96-ed5b-f287-fd5e" name="Hunter 3" hidden="false" profileTypeId="5f4f-ea74-0630-4afe" profileTypeName="Wound Track">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Remaining W" characteristicTypeId="8e45-c866-b2d4-c9ab" value="1-2"/>
+            <characteristic name="Characteristic 1" characteristicTypeId="bf41-c860-50bc-2a7e" value="3&quot;"/>
+            <characteristic name="Characteristic 2" characteristicTypeId="dc18-e51f-309b-8efa" value="5+"/>
+            <characteristic name="Characteristic 3" characteristicTypeId="df06-8eca-150f-90ba" value="1"/>
+          </characteristics>
+        </profile>
+        <profile id="32a1-94d4-bc44-2fd9" name="Explodes" hidden="false" profileTypeId="818c-0db1-36f0-462a" profileTypeName="Explosion">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Dice roll" characteristicTypeId="f21d-8f6d-180d-36ff" value="6"/>
+            <characteristic name="Distance" characteristicTypeId="d69e-be07-1682-ebcc" value="6&quot;"/>
+            <characteristic name="Mortal wounds" characteristicTypeId="29f1-65a1-2c5d-8c7d" value="D3"/>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules/>
+      <infoLinks>
+        <infoLink id="0d21-c57c-2094-dcdb" name="Hunter" hidden="false" targetId="75da-64fd-47bc-daa7" type="profile">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="0138-98ed-587f-ba52" name="Smoke Launchers" hidden="false" targetId="c883-3078-1367-cc2c" type="profile">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints/>
+      <categoryLinks>
+        <categoryLink id="b9ae-85ff-bca2-4731" name="New CategoryLink" hidden="false" targetId="b44c-e966-5868-c970" primary="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
+        <categoryLink id="5b9b-0ccb-407c-32b9" name="New CategoryLink" hidden="false" targetId="6fd7-9e10-d37c-5056" primary="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
+        <categoryLink id="4789-8ef3-753e-ff32" name="New CategoryLink" hidden="false" targetId="2c4a-3ec9-a1f6-a1ee" primary="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
+        <categoryLink id="254b-ba9e-579e-5384" name="New CategoryLink" hidden="false" targetId="abf5fd55-9ac7-4263-8bc1-a9fb0a8fa6a6" primary="true">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
+        <categoryLink id="cc48-9c1e-869e-4885" name="New CategoryLink" hidden="false" targetId="c450-41ad-d4a6-cd12" primary="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
+        <categoryLink id="e8de-2a0e-107a-94be" name="New CategoryLink" hidden="false" targetId="c8fd-783f-3230-493e" primary="false">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -23913,54 +24169,1023 @@
       <selectionEntries/>
       <selectionEntryGroups/>
       <entryLinks>
-        <entryLink id="7b20-e187-5e24-2193" name="Power fist" hidden="false" targetId="3102-2dd8-4f31-3af7" type="selectionEntry">
+        <entryLink id="9585-0a00-d20c-18b7" name="Skyspear missile launcher" hidden="false" targetId="cd63-9586-da03-ec49" type="selectionEntry">
           <profiles/>
           <rules/>
           <infoLinks/>
           <modifiers/>
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c165-79f7-cacb-4149" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9db3-b68f-dd59-89f8" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1770-57df-7bcf-929e" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6e5a-91d4-51b4-bb72" type="max"/>
           </constraints>
           <categoryLinks/>
         </entryLink>
-        <entryLink id="c7d9-69cb-c682-e312" name="Plasma pistol" hidden="false" targetId="b333-4c80-2f72-6b45" type="selectionEntry">
+        <entryLink id="4368-4a89-57b1-3a30" name="Hunter-killer missile" hidden="false" targetId="32bf-b117-4ecf-5165" type="selectionEntry">
           <profiles/>
           <rules/>
           <infoLinks/>
           <modifiers/>
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b978-d24d-8e0d-fb05" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bd67-8e33-92e4-ad29" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="05b6-ea9f-8721-247d" type="max"/>
           </constraints>
           <categoryLinks/>
         </entryLink>
-        <entryLink id="f983-ee6a-1a23-e5ed" name="Frag grenades" hidden="false" targetId="e897-c8fa-0976-e2d3" type="selectionEntry">
+        <entryLink id="68f3-4060-043c-6004" name="Storm bolter" hidden="false" targetId="2b03-8d64-3711-f300" type="selectionEntry">
           <profiles/>
           <rules/>
           <infoLinks/>
           <modifiers/>
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fda4-119b-606a-fc78" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d49c-8e2e-a2b0-4dfc" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bf1d-285d-16d5-6a94" type="max"/>
           </constraints>
           <categoryLinks/>
         </entryLink>
-        <entryLink id="66c2-21f4-2154-59d3" name="Krak grenade" hidden="false" targetId="073b-2de5-765f-a4f2" type="selectionEntry">
+      </entryLinks>
+      <costs>
+        <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="5.0"/>
+        <cost name="pts" costTypeId="points" value="90.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="74b4-a8e2-14b0-452d" name="Stalker" hidden="false" collective="false" type="model">
+      <profiles>
+        <profile id="cf7e-63e0-0e6e-4e44" name="Stalker" hidden="false" profileTypeId="5f4f-ea74-0630-4afe" profileTypeName="Wound Track">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Remaining W" characteristicTypeId="8e45-c866-b2d4-c9ab" value=""/>
+            <characteristic name="Characteristic 1" characteristicTypeId="bf41-c860-50bc-2a7e" value="M"/>
+            <characteristic name="Characteristic 2" characteristicTypeId="dc18-e51f-309b-8efa" value="BS"/>
+            <characteristic name="Characteristic 3" characteristicTypeId="df06-8eca-150f-90ba" value="A"/>
+          </characteristics>
+        </profile>
+        <profile id="3946-4852-8064-1224" name="Stalker 1" hidden="false" profileTypeId="5f4f-ea74-0630-4afe" profileTypeName="Wound Track">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Remaining W" characteristicTypeId="8e45-c866-b2d4-c9ab" value="6-11+"/>
+            <characteristic name="Characteristic 1" characteristicTypeId="bf41-c860-50bc-2a7e" value="10&quot;"/>
+            <characteristic name="Characteristic 2" characteristicTypeId="dc18-e51f-309b-8efa" value="3+"/>
+            <characteristic name="Characteristic 3" characteristicTypeId="df06-8eca-150f-90ba" value="3"/>
+          </characteristics>
+        </profile>
+        <profile id="e053-a644-3201-3207" name="Stalker 2" hidden="false" profileTypeId="5f4f-ea74-0630-4afe" profileTypeName="Wound Track">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Remaining W" characteristicTypeId="8e45-c866-b2d4-c9ab" value="3-5"/>
+            <characteristic name="Characteristic 1" characteristicTypeId="bf41-c860-50bc-2a7e" value="5&quot;"/>
+            <characteristic name="Characteristic 2" characteristicTypeId="dc18-e51f-309b-8efa" value="4+"/>
+            <characteristic name="Characteristic 3" characteristicTypeId="df06-8eca-150f-90ba" value="D3"/>
+          </characteristics>
+        </profile>
+        <profile id="a515-a93d-d50d-3a35" name="Stalker 3" hidden="false" profileTypeId="5f4f-ea74-0630-4afe" profileTypeName="Wound Track">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Remaining W" characteristicTypeId="8e45-c866-b2d4-c9ab" value="1-2"/>
+            <characteristic name="Characteristic 1" characteristicTypeId="bf41-c860-50bc-2a7e" value="3&quot;"/>
+            <characteristic name="Characteristic 2" characteristicTypeId="dc18-e51f-309b-8efa" value="5+"/>
+            <characteristic name="Characteristic 3" characteristicTypeId="df06-8eca-150f-90ba" value="1"/>
+          </characteristics>
+        </profile>
+        <profile id="b41f-7632-86b3-d59d" name="Explodes" hidden="false" profileTypeId="818c-0db1-36f0-462a" profileTypeName="Explosion">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Dice roll" characteristicTypeId="f21d-8f6d-180d-36ff" value="6"/>
+            <characteristic name="Distance" characteristicTypeId="d69e-be07-1682-ebcc" value="6&quot;"/>
+            <characteristic name="Mortal wounds" characteristicTypeId="29f1-65a1-2c5d-8c7d" value="D3"/>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules/>
+      <infoLinks>
+        <infoLink id="1b01-247f-eaf1-b120" name="Stalker" hidden="false" targetId="88bd-6f9c-3a0e-eaa3" type="profile">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="ad54-7052-14f4-be96" name="Smoke Launchers" hidden="false" targetId="c883-3078-1367-cc2c" type="profile">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints/>
+      <categoryLinks>
+        <categoryLink id="b15f-d32a-f9b2-3a71" name="New CategoryLink" hidden="false" targetId="b44c-e966-5868-c970" primary="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
+        <categoryLink id="a117-8257-3cd1-0d55" name="New CategoryLink" hidden="false" targetId="6fd7-9e10-d37c-5056" primary="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
+        <categoryLink id="541a-5a32-7494-d588" name="New CategoryLink" hidden="false" targetId="2c4a-3ec9-a1f6-a1ee" primary="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
+        <categoryLink id="54bf-4923-0cb5-4ef5" name="New CategoryLink" hidden="false" targetId="abf5fd55-9ac7-4263-8bc1-a9fb0a8fa6a6" primary="true">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
+        <categoryLink id="d8f8-ba79-e66f-8f40" name="New CategoryLink" hidden="false" targetId="c8fd-783f-3230-493e" primary="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
+        <categoryLink id="7c8d-f000-1b70-1b24" name="New CategoryLink" hidden="false" targetId="7b59-3865-4434-bd31" primary="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
+      </categoryLinks>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks>
+        <entryLink id="ece2-413a-1e1e-e374" name="Icarus stormcannon" hidden="false" targetId="98bf-0664-0b1b-3e27" type="selectionEntry">
           <profiles/>
           <rules/>
           <infoLinks/>
           <modifiers/>
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9a93-32ed-0cdc-3fda" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5e0c-8c27-084c-b251" type="max"/>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4531-78bd-ae4d-34ea" type="min"/>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0d48-3c33-b2a2-6c22" type="max"/>
+          </constraints>
+          <categoryLinks/>
+        </entryLink>
+        <entryLink id="4146-d953-bd33-867c" name="Hunter-killer missile" hidden="false" targetId="32bf-b117-4ecf-5165" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f5b5-20d0-5d23-edb7" type="max"/>
+          </constraints>
+          <categoryLinks/>
+        </entryLink>
+        <entryLink id="de86-5882-33f7-52b0" name="Storm bolter" hidden="false" targetId="2b03-8d64-3711-f300" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="65d9-6ee0-4118-f854" type="max"/>
           </constraints>
           <categoryLinks/>
         </entryLink>
       </entryLinks>
       <costs>
         <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="6.0"/>
-        <cost name="pts" costTypeId="points" value="87.0"/>
+        <cost name="pts" costTypeId="points" value="75.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="3ea3-34fc-f59c-9d17" name="Land Speeder Storm" hidden="false" collective="false" type="model">
+      <profiles>
+        <profile id="e226-5a7f-a197-941e" name="Explodes" hidden="false" profileTypeId="818c-0db1-36f0-462a" profileTypeName="Explosion">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Dice roll" characteristicTypeId="f21d-8f6d-180d-36ff" value="6"/>
+            <characteristic name="Distance" characteristicTypeId="d69e-be07-1682-ebcc" value="3&quot;"/>
+            <characteristic name="Mortal wounds" characteristicTypeId="29f1-65a1-2c5d-8c7d" value="1"/>
+          </characteristics>
+        </profile>
+        <profile id="5d75-82c5-7a83-0eec" name="Transport" hidden="false" profileTypeId="b3a8-0452-7436-44d1" profileTypeName="Transport">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Capacity" characteristicTypeId="15aa-1916-a38b-d223" value="This model can transport 5 BLOOD ANGELS SCOUT INFANTRY models."/>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules/>
+      <infoLinks>
+        <infoLink id="3a48-5afc-3541-5d76" name="Land Speeder Storm" hidden="false" targetId="35ee-b59e-db25-3f3e" type="profile">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="d9f2-e878-1f2b-4a69" name="Open-topped" hidden="false" targetId="f8f1-812d-e46a-841a" type="profile">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints/>
+      <categoryLinks>
+        <categoryLink id="331e-0899-9c64-04da" name="New CategoryLink" hidden="false" targetId="1b66-3f5f-6705-079a" primary="true">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
+        <categoryLink id="f827-0aa9-c531-47c2" name="New CategoryLink" hidden="false" targetId="b44c-e966-5868-c970" primary="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
+        <categoryLink id="e681-1b7c-5822-4069" name="New CategoryLink" hidden="false" targetId="6fd7-9e10-d37c-5056" primary="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
+        <categoryLink id="9061-c10d-7b1c-348e" name="New CategoryLink" hidden="false" targetId="2c4a-3ec9-a1f6-a1ee" primary="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
+        <categoryLink id="3202-c2f8-224a-b497" name="New CategoryLink" hidden="false" targetId="3117-16d8-fcef-4f56" primary="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
+        <categoryLink id="d5ed-5e65-9b09-74ce" name="New CategoryLink" hidden="false" targetId="d63c-e896-8db9-39dc" primary="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
+        <categoryLink id="0f14-3632-27ce-8d55" name="New CategoryLink" hidden="false" targetId="16f0-25ae-1d96-ffc4" primary="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
+        <categoryLink id="d346-8782-3fc3-e48b" name="New CategoryLink" hidden="false" targetId="3365-ed66-444c-2451" primary="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
+        <categoryLink id="11f0-6bc9-8c6a-dc06" name="New CategoryLink" hidden="false" targetId="6cc4-1b62-8e8a-05cd" primary="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
+        <categoryLink id="b6b4-0899-d6f4-b51c" name="New CategoryLink" hidden="false" targetId="c8fd-783f-3230-493e" primary="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
+      </categoryLinks>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks>
+        <entryLink id="81fb-1907-f574-adb3" name="Heavy bolter" hidden="false" targetId="05ab-e7cc-e856-c36f" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f53f-5ded-fa80-4eda" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="dfe3-e380-0f9b-1b3e" type="max"/>
+          </constraints>
+          <categoryLinks/>
+        </entryLink>
+        <entryLink id="52a1-178d-e9c2-5083" name="Cerberus launcher" hidden="false" targetId="3846-568f-f410-946e" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6d67-df80-6082-4d5a" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f354-5c33-8061-6704" type="max"/>
+          </constraints>
+          <categoryLinks/>
+        </entryLink>
+      </entryLinks>
+      <costs>
+        <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="5.0"/>
+        <cost name="pts" costTypeId="points" value="70.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="e6a8-900d-944a-f32d" name="Stormhawk Interceptor" hidden="false" collective="false" type="model">
+      <profiles>
+        <profile id="fd62-d932-6649-d196" name="Crash and Burn" hidden="false" profileTypeId="818c-0db1-36f0-462a" profileTypeName="Explosion">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Dice roll" characteristicTypeId="f21d-8f6d-180d-36ff" value="6"/>
+            <characteristic name="Distance" characteristicTypeId="d69e-be07-1682-ebcc" value="6&quot;"/>
+            <characteristic name="Mortal wounds" characteristicTypeId="29f1-65a1-2c5d-8c7d" value="D3"/>
+          </characteristics>
+        </profile>
+        <profile id="1a1a-b414-1311-9105" name="Stormhawk Interceptor" hidden="false" profileTypeId="5f4f-ea74-0630-4afe" profileTypeName="Wound Track">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Remaining W" characteristicTypeId="8e45-c866-b2d4-c9ab" value=""/>
+            <characteristic name="Characteristic 1" characteristicTypeId="bf41-c860-50bc-2a7e" value="M"/>
+            <characteristic name="Characteristic 2" characteristicTypeId="dc18-e51f-309b-8efa" value="BS"/>
+            <characteristic name="Characteristic 3" characteristicTypeId="df06-8eca-150f-90ba" value="A"/>
+          </characteristics>
+        </profile>
+        <profile id="bb29-f8cc-383d-0fce" name="Stormhawk Interceptor 1" hidden="false" profileTypeId="5f4f-ea74-0630-4afe" profileTypeName="Wound Track">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Remaining W" characteristicTypeId="8e45-c866-b2d4-c9ab" value="6-10+"/>
+            <characteristic name="Characteristic 1" characteristicTypeId="bf41-c860-50bc-2a7e" value="20-60&quot;"/>
+            <characteristic name="Characteristic 2" characteristicTypeId="dc18-e51f-309b-8efa" value="3+"/>
+            <characteristic name="Characteristic 3" characteristicTypeId="df06-8eca-150f-90ba" value="3"/>
+          </characteristics>
+        </profile>
+        <profile id="ee95-ac13-c589-5ad2" name="Stormhawk Interceptor 2" hidden="false" profileTypeId="5f4f-ea74-0630-4afe" profileTypeName="Wound Track">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Remaining W" characteristicTypeId="8e45-c866-b2d4-c9ab" value="3-5"/>
+            <characteristic name="Characteristic 1" characteristicTypeId="bf41-c860-50bc-2a7e" value="20-40&quot;"/>
+            <characteristic name="Characteristic 2" characteristicTypeId="dc18-e51f-309b-8efa" value="4+"/>
+            <characteristic name="Characteristic 3" characteristicTypeId="df06-8eca-150f-90ba" value="D3"/>
+          </characteristics>
+        </profile>
+        <profile id="45a4-085f-170b-d70e" name="Stormhawk Interceptor 3" hidden="false" profileTypeId="5f4f-ea74-0630-4afe" profileTypeName="Wound Track">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Remaining W" characteristicTypeId="8e45-c866-b2d4-c9ab" value="1-2"/>
+            <characteristic name="Characteristic 1" characteristicTypeId="bf41-c860-50bc-2a7e" value="20-25&quot;"/>
+            <characteristic name="Characteristic 2" characteristicTypeId="dc18-e51f-309b-8efa" value="5+"/>
+            <characteristic name="Characteristic 3" characteristicTypeId="df06-8eca-150f-90ba" value="1"/>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules/>
+      <infoLinks>
+        <infoLink id="ddd3-449d-d8f1-ddbc" name="Stormhawk Interceptor" hidden="false" targetId="7738-1e58-d25e-ed32" type="profile">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="be74-1367-7cf8-c98c" name="Airborne" hidden="false" targetId="5612-a7b4-ed49-63e2" type="profile">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="70a1-a2f9-6256-94d8" name="Hard to Hit" hidden="false" targetId="05fe-231e-bd86-86e4" type="profile">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="1944-e6ac-7ab1-6cc6" name="Supersonic" hidden="false" targetId="c5ca-67fb-3f1a-5a0b" type="profile">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="3fc6-b828-5ff9-4a74" name="Infernum Halo-launcher" hidden="false" targetId="c129-a8e6-9cca-e132" type="profile">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="8dc0-35a4-7101-38bc" name="Interceptor" hidden="false" targetId="e5e9-776c-a573-ec03" type="profile">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints/>
+      <categoryLinks>
+        <categoryLink id="6363-295a-b44a-70af" name="New CategoryLink" hidden="false" targetId="3117-16d8-fcef-4f56" primary="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
+        <categoryLink id="efe6-2235-633d-b462" name="New CategoryLink" hidden="false" targetId="e888-1504-aa61-95ff" primary="true">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
+        <categoryLink id="2a39-285f-4306-03c8" name="New CategoryLink" hidden="false" targetId="2c4a-3ec9-a1f6-a1ee" primary="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
+        <categoryLink id="224e-7661-2dfc-e34b" name="New CategoryLink" hidden="false" targetId="6fd7-9e10-d37c-5056" primary="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
+        <categoryLink id="9e8c-e45a-bf8a-7203" name="New CategoryLink" hidden="false" targetId="b44c-e966-5868-c970" primary="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
+        <categoryLink id="4342-d48b-274b-2af0" name="New CategoryLink" hidden="false" targetId="c8fd-783f-3230-493e" primary="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
+        <categoryLink id="7fb0-018b-e903-edf3" name="New CategoryLink" hidden="false" targetId="8104-d542-d9d5-ae7f" primary="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
+      </categoryLinks>
+      <selectionEntries/>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="d938-297c-b635-cac6" name="Hull weapon" hidden="false" collective="false" defaultSelectionEntryId="398f-19ea-1af2-8ea9">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2604-cb5b-7ef4-d71d" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c7d4-6b46-d4d2-0d06" type="max"/>
+          </constraints>
+          <categoryLinks/>
+          <selectionEntries>
+            <selectionEntry id="398f-19ea-1af2-8ea9" name="Two heavy bolters" hidden="false" collective="false" type="upgrade">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="aa78-7abd-d201-715e" type="max"/>
+              </constraints>
+              <categoryLinks/>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks>
+                <entryLink id="4f5d-e22b-a5f5-0591" name="Heavy bolter" hidden="false" targetId="05ab-e7cc-e856-c36f" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="615d-4751-c51c-396c" type="min"/>
+                    <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9659-31b7-c73a-4dee" type="max"/>
+                  </constraints>
+                  <categoryLinks/>
+                </entryLink>
+              </entryLinks>
+              <costs>
+                <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="0.0"/>
+                <cost name="pts" costTypeId="points" value="0.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="5b10-77b7-0d7a-5ad9" name="Skyhammer missile launcher" hidden="false" targetId="dc9d-4795-4788-d6e6" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2141-2e4f-defa-62a6" type="max"/>
+              </constraints>
+              <categoryLinks/>
+            </entryLink>
+            <entryLink id="a9ce-4278-8e08-38fc" name="Typhoon missile launcher" hidden="false" targetId="6027-7017-756a-600c" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7ed4-bce2-3816-52de" type="max"/>
+              </constraints>
+              <categoryLinks/>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="6b8d-d720-c6cb-4384" name="Front weapon" hidden="false" collective="false" defaultSelectionEntryId="3576-eee0-d799-b4e7">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b5ce-b9f8-b9f8-90d2" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1214-79d5-3e22-2446" type="max"/>
+          </constraints>
+          <categoryLinks/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="3576-eee0-d799-b4e7" name="Icarus stormcannon" hidden="false" targetId="98bf-0664-0b1b-3e27" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6282-0711-5e0f-e851" type="max"/>
+              </constraints>
+              <categoryLinks/>
+            </entryLink>
+            <entryLink id="494f-0c92-0c9d-29f7" name="Las-talon" hidden="false" targetId="5ca6-11eb-52e7-aad9" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="50bd-7706-f29b-b13f" type="max"/>
+              </constraints>
+              <categoryLinks/>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <entryLinks>
+        <entryLink id="3933-c9d8-009a-27bd" name="Assault cannon" hidden="false" targetId="51b0-3d46-5af4-683e" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3ad2-0ee9-96a9-93d4" type="min"/>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6fd7-ee24-e0a6-6201" type="max"/>
+          </constraints>
+          <categoryLinks/>
+        </entryLink>
+      </entryLinks>
+      <costs>
+        <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="10.0"/>
+        <cost name="pts" costTypeId="points" value="85.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="11a1-bc52-7694-8b6d" name="Stormtalon Gunship" hidden="false" collective="false" type="model">
+      <profiles>
+        <profile id="6d05-3d0f-491a-eeba" name="Crash and Burn" hidden="false" profileTypeId="818c-0db1-36f0-462a" profileTypeName="Explosion">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Dice roll" characteristicTypeId="f21d-8f6d-180d-36ff" value="6"/>
+            <characteristic name="Distance" characteristicTypeId="d69e-be07-1682-ebcc" value="6&quot;"/>
+            <characteristic name="Mortal wounds" characteristicTypeId="29f1-65a1-2c5d-8c7d" value="D3"/>
+          </characteristics>
+        </profile>
+        <profile id="a956-f88c-c76f-6622" name="Stormtalon Gunship" hidden="false" profileTypeId="5f4f-ea74-0630-4afe" profileTypeName="Wound Track">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Remaining W" characteristicTypeId="8e45-c866-b2d4-c9ab" value=""/>
+            <characteristic name="Characteristic 1" characteristicTypeId="bf41-c860-50bc-2a7e" value="M"/>
+            <characteristic name="Characteristic 2" characteristicTypeId="dc18-e51f-309b-8efa" value="BS"/>
+            <characteristic name="Characteristic 3" characteristicTypeId="df06-8eca-150f-90ba" value="A"/>
+          </characteristics>
+        </profile>
+        <profile id="3fd1-e883-37f7-bb57" name="Stormtalon Gunship 1" hidden="false" profileTypeId="5f4f-ea74-0630-4afe" profileTypeName="Wound Track">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Remaining W" characteristicTypeId="8e45-c866-b2d4-c9ab" value="6-10+"/>
+            <characteristic name="Characteristic 1" characteristicTypeId="bf41-c860-50bc-2a7e" value="20-50&quot;"/>
+            <characteristic name="Characteristic 2" characteristicTypeId="dc18-e51f-309b-8efa" value="3+"/>
+            <characteristic name="Characteristic 3" characteristicTypeId="df06-8eca-150f-90ba" value="3"/>
+          </characteristics>
+        </profile>
+        <profile id="6a48-a730-c3d1-2687" name="Stormtalon Gunship 2" hidden="false" profileTypeId="5f4f-ea74-0630-4afe" profileTypeName="Wound Track">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Remaining W" characteristicTypeId="8e45-c866-b2d4-c9ab" value="3-5"/>
+            <characteristic name="Characteristic 1" characteristicTypeId="bf41-c860-50bc-2a7e" value="20-35&quot;"/>
+            <characteristic name="Characteristic 2" characteristicTypeId="dc18-e51f-309b-8efa" value="4+"/>
+            <characteristic name="Characteristic 3" characteristicTypeId="df06-8eca-150f-90ba" value="D3"/>
+          </characteristics>
+        </profile>
+        <profile id="b03e-bec5-f785-a7ec" name="Stormtalon Gunship 3" hidden="false" profileTypeId="5f4f-ea74-0630-4afe" profileTypeName="Wound Track">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Remaining W" characteristicTypeId="8e45-c866-b2d4-c9ab" value="1-2"/>
+            <characteristic name="Characteristic 1" characteristicTypeId="bf41-c860-50bc-2a7e" value="20&quot;"/>
+            <characteristic name="Characteristic 2" characteristicTypeId="dc18-e51f-309b-8efa" value="5+"/>
+            <characteristic name="Characteristic 3" characteristicTypeId="df06-8eca-150f-90ba" value="1"/>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules/>
+      <infoLinks>
+        <infoLink id="a3aa-58f6-169d-2a70" name="Stormtalon Gunship" hidden="false" targetId="3970-342a-bea2-806f" type="profile">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="2497-3dd6-ed7b-fa60" name="Airborne" hidden="false" targetId="5612-a7b4-ed49-63e2" type="profile">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="5300-808d-1f21-040d" name="Hard to Hit" hidden="false" targetId="05fe-231e-bd86-86e4" type="profile">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="57f2-8f86-6097-4659" name="Supersonic" hidden="false" targetId="c5ca-67fb-3f1a-5a0b" type="profile">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="ca48-f202-03ed-8180" name="Strafing Run" hidden="false" targetId="78ec-3915-059d-a723" type="profile">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="7b88-7c23-656b-bd51" name="Hover Jet" hidden="false" targetId="d061-4605-a6f7-0b4c" type="profile">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints/>
+      <categoryLinks>
+        <categoryLink id="360b-0dd2-6d77-2f20" name="New CategoryLink" hidden="false" targetId="3117-16d8-fcef-4f56" primary="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
+        <categoryLink id="93b5-8779-dae9-fd6a" name="New CategoryLink" hidden="false" targetId="e888-1504-aa61-95ff" primary="true">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
+        <categoryLink id="0954-9eeb-796a-b89d" name="New CategoryLink" hidden="false" targetId="2c4a-3ec9-a1f6-a1ee" primary="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
+        <categoryLink id="4ae4-d48f-eadb-5078" name="New CategoryLink" hidden="false" targetId="6fd7-9e10-d37c-5056" primary="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
+        <categoryLink id="9c6c-88a8-859f-1a1b" name="New CategoryLink" hidden="false" targetId="b44c-e966-5868-c970" primary="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
+        <categoryLink id="366b-1bc6-7191-5a13" name="New CategoryLink" hidden="false" targetId="c8fd-783f-3230-493e" primary="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
+        <categoryLink id="3719-6adc-23d3-8734" name="New CategoryLink" hidden="false" targetId="782a-435b-d18d-09a2" primary="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
+      </categoryLinks>
+      <selectionEntries/>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="19bf-3eaf-4d2f-7cfa" name="Additional weapon" hidden="false" collective="false" defaultSelectionEntryId="6fab-53da-3763-0396">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="315f-b68c-8196-39d4" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="577c-e108-dfb7-edc6" type="max"/>
+          </constraints>
+          <categoryLinks/>
+          <selectionEntries>
+            <selectionEntry id="6fab-53da-3763-0396" name="Two heavy bolters" hidden="false" collective="false" type="upgrade">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f822-1eda-5d66-a328" type="max"/>
+              </constraints>
+              <categoryLinks/>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks>
+                <entryLink id="262f-be84-8cf6-cf95" name="Heavy bolter" hidden="false" targetId="05ab-e7cc-e856-c36f" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7981-dd10-7f83-5621" type="min"/>
+                    <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c2da-9098-e48d-68c8" type="max"/>
+                  </constraints>
+                  <categoryLinks/>
+                </entryLink>
+              </entryLinks>
+              <costs>
+                <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="0.0"/>
+                <cost name="pts" costTypeId="points" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="439b-20d6-19f5-8773" name="Two lascannons" hidden="false" collective="false" type="upgrade">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="efea-6824-2f66-d266" type="max"/>
+              </constraints>
+              <categoryLinks/>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks>
+                <entryLink id="9707-81d2-c0cc-9636" name="Lascannon" hidden="false" targetId="a908-4664-11cd-f8b2" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="94a2-e169-0ba7-263b" type="min"/>
+                    <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9e3c-e287-4c8a-e1a1" type="max"/>
+                  </constraints>
+                  <categoryLinks/>
+                </entryLink>
+              </entryLinks>
+              <costs>
+                <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="0.0"/>
+                <cost name="pts" costTypeId="points" value="0.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="4862-5f4a-4ba4-5ea8" name="Skyhammer missile launcher" hidden="false" targetId="dc9d-4795-4788-d6e6" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3bd4-6753-54d6-34d3" type="max"/>
+              </constraints>
+              <categoryLinks/>
+            </entryLink>
+            <entryLink id="2c1c-9543-d84d-d395" name="Typhoon missile launcher" hidden="false" targetId="6027-7017-756a-600c" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3ff7-7b4c-424e-daa6" type="max"/>
+              </constraints>
+              <categoryLinks/>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <entryLinks>
+        <entryLink id="ba07-ce10-62ea-2d5a" name="Twin assault cannon" hidden="false" targetId="f787-a3af-72b5-60d1" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d58f-2f39-3982-9bfa" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3739-1c1a-c0aa-56a4" type="max"/>
+          </constraints>
+          <categoryLinks/>
+        </entryLink>
+      </entryLinks>
+      <costs>
+        <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="9.0"/>
+        <cost name="pts" costTypeId="points" value="110.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="2ec6-a5f9-9dc1-93e5" name="1. Speed of the Primarch" book="" hidden="false" collective="false" type="upgrade">
+      <profiles/>
+      <rules/>
+      <infoLinks>
+        <infoLink id="dd4c-a520-a891-3013" name="1. Speed of the Primarch" hidden="false" targetId="c0e7-86ee-673c-41a7" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints/>
+      <categoryLinks/>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="0.0"/>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="73a7-1838-fbc4-b242" name="2. Artisan of War" hidden="false" collective="false" type="upgrade">
+      <profiles/>
+      <rules/>
+      <infoLinks>
+        <infoLink id="9a7e-6e84-34e2-fef2" name="2. Artisan of War" hidden="false" targetId="1c97-a0e6-03f9-74c6" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints/>
+      <categoryLinks/>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="0.0"/>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="58d2-aee8-1337-a246" name="3. Soulwarden" hidden="false" collective="false" type="upgrade">
+      <profiles/>
+      <rules/>
+      <infoLinks>
+        <infoLink id="45ea-2c2d-1705-376b" name="3. Soulwarden" hidden="false" targetId="f7ea-a747-21ef-3887" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints/>
+      <categoryLinks/>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="0.0"/>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="f000-3a97-306f-1264" name="4. Heroic Bearing" hidden="false" collective="false" type="upgrade">
+      <profiles/>
+      <rules/>
+      <infoLinks>
+        <infoLink id="9875-566b-3e2b-1fda" name="4. Heroic Bearing" hidden="false" targetId="05dd-5796-cd5d-3ecc" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints/>
+      <categoryLinks/>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="0.0"/>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="1d05-f4aa-e4ff-548f" name="5. Gift of Foresight" hidden="false" collective="false" type="upgrade">
+      <profiles/>
+      <rules/>
+      <infoLinks>
+        <infoLink id="48f9-9cf2-517b-7666" name="5. Gift of Foresight" hidden="false" targetId="aa55-79c3-d21e-5057" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints/>
+      <categoryLinks/>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="0.0"/>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="5aac-e94d-2bcf-c1d1" name="6. Selfless Valour" hidden="false" collective="false" type="upgrade">
+      <profiles/>
+      <rules/>
+      <infoLinks>
+        <infoLink id="9d78-451e-67c6-2ff0" name="6. Selfless Valour" hidden="false" targetId="c1ab-b6fb-ef36-a56d" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints/>
+      <categoryLinks/>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="0.0"/>
+        <cost name="pts" costTypeId="points" value="0.0"/>
       </costs>
     </selectionEntry>
   </sharedSelectionEntries>
@@ -23988,7 +25213,7 @@
           <selectionEntries/>
           <selectionEntryGroups/>
           <entryLinks>
-            <entryLink id="fa59-27a1-f6d8-43bc" name="New EntryLink" hidden="false" targetId="bf86-1c1b-6871-da0b" type="selectionEntry">
+            <entryLink id="fa59-27a1-f6d8-43bc" name="Bolt pistol" hidden="false" targetId="0334-f487-8229-0c1a" type="selectionEntry">
               <profiles/>
               <rules/>
               <infoLinks/>
@@ -23996,7 +25221,7 @@
               <constraints/>
               <categoryLinks/>
             </entryLink>
-            <entryLink id="4433-18e2-0d40-bf19" name="New EntryLink" hidden="false" targetId="b333-4c80-2f72-6b45" type="selectionEntry">
+            <entryLink id="4433-18e2-0d40-bf19" name="Plasma pistol" hidden="false" targetId="83be-1ba9-c326-4760" type="selectionEntry">
               <profiles/>
               <rules/>
               <infoLinks/>
@@ -24012,7 +25237,7 @@
               <constraints/>
               <categoryLinks/>
             </entryLink>
-            <entryLink id="3d10-0753-eb3c-c46c" name="New EntryLink" hidden="false" targetId="12fb-6600-667f-5922" type="selectionEntry">
+            <entryLink id="3d10-0753-eb3c-c46c" name="Inferno pistol" hidden="false" targetId="83f0-56d1-b852-f21c" type="selectionEntry">
               <profiles/>
               <rules/>
               <infoLinks/>
@@ -24020,7 +25245,7 @@
               <constraints/>
               <categoryLinks/>
             </entryLink>
-            <entryLink id="2004-bd57-fda3-44e0" name="New EntryLink" hidden="false" targetId="5f85-cddd-00b5-41f8" type="selectionEntry">
+            <entryLink id="2004-bd57-fda3-44e0" name="Chainsword" hidden="false" targetId="0dd1-2e2b-7dd1-5495" type="selectionEntry">
               <profiles/>
               <rules/>
               <infoLinks/>
@@ -24028,7 +25253,7 @@
               <constraints/>
               <categoryLinks/>
             </entryLink>
-            <entryLink id="2ca6-12ff-3e4c-6a5e" name="New EntryLink" hidden="false" targetId="c3d0-2567-35c6-3f29" type="selectionEntry">
+            <entryLink id="2ca6-12ff-3e4c-6a5e" name="Power sword" hidden="false" targetId="bc9e-551d-9afb-78d5" type="selectionEntry">
               <profiles/>
               <rules/>
               <infoLinks/>
@@ -24036,7 +25261,7 @@
               <constraints/>
               <categoryLinks/>
             </entryLink>
-            <entryLink id="2dc6-dcc9-32ef-9627" name="New EntryLink" hidden="false" targetId="8d13-0f69-a808-e300" type="selectionEntry">
+            <entryLink id="2dc6-dcc9-32ef-9627" name="Power axe" hidden="false" targetId="3292-34e6-f679-d5b9" type="selectionEntry">
               <profiles/>
               <rules/>
               <infoLinks/>
@@ -24044,7 +25269,7 @@
               <constraints/>
               <categoryLinks/>
             </entryLink>
-            <entryLink id="1dec-4782-2d39-bb14" name="New EntryLink" hidden="false" targetId="b22c-5019-c613-fb74" type="selectionEntry">
+            <entryLink id="1dec-4782-2d39-bb14" name="Power maul" hidden="false" targetId="6ea7-1195-7144-438e" type="selectionEntry">
               <profiles/>
               <rules/>
               <infoLinks/>
@@ -24060,7 +25285,7 @@
               <constraints/>
               <categoryLinks/>
             </entryLink>
-            <entryLink id="7e1d-810d-3c5c-86a7" name="New EntryLink" hidden="false" targetId="3102-2dd8-4f31-3af7" type="selectionEntry">
+            <entryLink id="7e1d-810d-3c5c-86a7" name="Power fist" hidden="false" targetId="f122-3720-fa32-4215" type="selectionEntry">
               <profiles/>
               <rules/>
               <infoLinks/>
@@ -24068,7 +25293,7 @@
               <constraints/>
               <categoryLinks/>
             </entryLink>
-            <entryLink id="3966-af1e-65c1-db35" name="New EntryLink" hidden="false" targetId="7057-ee87-f5bf-5e42" type="selectionEntry">
+            <entryLink id="3966-af1e-65c1-db35" name="Thunder hammer" hidden="false" targetId="0e57-eaf5-763f-9c45" type="selectionEntry">
               <profiles/>
               <rules/>
               <infoLinks/>
@@ -24076,7 +25301,7 @@
               <constraints/>
               <categoryLinks/>
             </entryLink>
-            <entryLink id="2a12-9615-e774-596b" name="Grav-pistol" hidden="false" targetId="9f58-3b91-fa2e-32e2" type="selectionEntry">
+            <entryLink id="2a12-9615-e774-596b" name="Grav-pistol" hidden="false" targetId="7b66-cac7-e582-a518" type="selectionEntry">
               <profiles/>
               <rules/>
               <infoLinks/>
@@ -24098,7 +25323,7 @@
           <selectionEntries/>
           <selectionEntryGroups/>
           <entryLinks>
-            <entryLink id="94f3-c3e1-4eda-5dde" name="New EntryLink" hidden="false" targetId="8e23-a2e7-23c4-cac7" type="selectionEntry">
+            <entryLink id="94f3-c3e1-4eda-5dde" name="Boltgun" hidden="false" targetId="b61f-a3c1-827d-c5b6" type="selectionEntry">
               <profiles/>
               <rules/>
               <infoLinks/>
@@ -24106,7 +25331,7 @@
               <constraints/>
               <categoryLinks/>
             </entryLink>
-            <entryLink id="a5e1-8cbd-2af7-a8e1" name="New EntryLink" hidden="false" targetId="a070-091c-f79c-7838" type="selectionEntry">
+            <entryLink id="a5e1-8cbd-2af7-a8e1" name="Combi-flamer" hidden="false" targetId="c6a1-e0c4-c1b1-dce1" type="selectionEntry">
               <profiles/>
               <rules/>
               <infoLinks/>
@@ -24114,7 +25339,7 @@
               <constraints/>
               <categoryLinks/>
             </entryLink>
-            <entryLink id="3d06-a6bb-8833-b8cf" name="New EntryLink" hidden="false" targetId="ce34-2e18-b818-b255" type="selectionEntry">
+            <entryLink id="3d06-a6bb-8833-b8cf" name="Combi-melta" hidden="false" targetId="c445-e211-f316-5d83" type="selectionEntry">
               <profiles/>
               <rules/>
               <infoLinks/>
@@ -24122,7 +25347,7 @@
               <constraints/>
               <categoryLinks/>
             </entryLink>
-            <entryLink id="8169-d054-b11f-40b6" name="New EntryLink" hidden="false" targetId="1e2d-40cf-18d3-db7f" type="selectionEntry">
+            <entryLink id="8169-d054-b11f-40b6" name="Combi-plasma" hidden="false" targetId="fdce-cdf7-21a9-f9ac" type="selectionEntry">
               <profiles/>
               <rules/>
               <infoLinks/>
@@ -24130,7 +25355,7 @@
               <constraints/>
               <categoryLinks/>
             </entryLink>
-            <entryLink id="2827-0ed9-1d1f-00cd" name="New EntryLink" hidden="false" targetId="a80a-0476-1ef9-e1cc" type="selectionEntry">
+            <entryLink id="2827-0ed9-1d1f-00cd" name="Combi-grav" hidden="false" targetId="c027-24d6-7a3d-cf12" type="selectionEntry">
               <profiles/>
               <rules/>
               <infoLinks/>
@@ -24138,7 +25363,7 @@
               <constraints/>
               <categoryLinks/>
             </entryLink>
-            <entryLink id="eb45-1a98-482d-345b" name="New EntryLink" hidden="false" targetId="d74a-2fee-abea-1b42" type="selectionEntry">
+            <entryLink id="eb45-1a98-482d-345b" name="Storm bolter" hidden="false" targetId="2b03-8d64-3711-f300" type="selectionEntry">
               <profiles/>
               <rules/>
               <infoLinks/>
@@ -24169,7 +25394,7 @@
       <selectionEntries/>
       <selectionEntryGroups/>
       <entryLinks>
-        <entryLink id="b22b-d26d-056a-181a" name="" hidden="false" targetId="bf86-1c1b-6871-da0b" type="selectionEntry">
+        <entryLink id="b22b-d26d-056a-181a" name="Bolt pistol" hidden="false" targetId="0334-f487-8229-0c1a" type="selectionEntry">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -24185,7 +25410,7 @@
           <constraints/>
           <categoryLinks/>
         </entryLink>
-        <entryLink id="f4bd-1485-8e2d-b870" name="New EntryLink" hidden="false" targetId="12fb-6600-667f-5922" type="selectionEntry">
+        <entryLink id="f4bd-1485-8e2d-b870" name="Inferno pistol" hidden="false" targetId="83f0-56d1-b852-f21c" type="selectionEntry">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -24193,7 +25418,7 @@
           <constraints/>
           <categoryLinks/>
         </entryLink>
-        <entryLink id="3896-b39b-3e59-fdd0" name="New EntryLink" hidden="false" targetId="b333-4c80-2f72-6b45" type="selectionEntry">
+        <entryLink id="3896-b39b-3e59-fdd0" name="Plasma pistol" hidden="false" targetId="83be-1ba9-c326-4760" type="selectionEntry">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -24201,7 +25426,7 @@
           <constraints/>
           <categoryLinks/>
         </entryLink>
-        <entryLink id="8505-2342-3f68-db08" name="New EntryLink" hidden="false" targetId="9f58-3b91-fa2e-32e2" type="selectionEntry">
+        <entryLink id="8505-2342-3f68-db08" name="Grav-pistol" hidden="false" targetId="7b66-cac7-e582-a518" type="selectionEntry">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -24221,7 +25446,7 @@
       <selectionEntries/>
       <selectionEntryGroups/>
       <entryLinks>
-        <entryLink id="327c-ce4d-1a13-c5c0" name="New EntryLink" hidden="false" targetId="d74a-2fee-abea-1b42" type="selectionEntry">
+        <entryLink id="327c-ce4d-1a13-c5c0" name="Storm bolter" hidden="false" targetId="2b03-8d64-3711-f300" type="selectionEntry">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -24229,7 +25454,7 @@
           <constraints/>
           <categoryLinks/>
         </entryLink>
-        <entryLink id="7495-b532-af02-b031" name="New EntryLink" hidden="false" targetId="a070-091c-f79c-7838" type="selectionEntry">
+        <entryLink id="7495-b532-af02-b031" name="Combi-flamer" hidden="false" targetId="c6a1-e0c4-c1b1-dce1" type="selectionEntry">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -24237,7 +25462,7 @@
           <constraints/>
           <categoryLinks/>
         </entryLink>
-        <entryLink id="9814-6960-3e62-5cce" name="New EntryLink" hidden="false" targetId="a80a-0476-1ef9-e1cc" type="selectionEntry">
+        <entryLink id="9814-6960-3e62-5cce" name="Combi-grav" hidden="false" targetId="c027-24d6-7a3d-cf12" type="selectionEntry">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -24245,7 +25470,7 @@
           <constraints/>
           <categoryLinks/>
         </entryLink>
-        <entryLink id="df4a-a03f-f2c5-c4e0" name="New EntryLink" hidden="false" targetId="ce34-2e18-b818-b255" type="selectionEntry">
+        <entryLink id="df4a-a03f-f2c5-c4e0" name="Combi-melta" hidden="false" targetId="c445-e211-f316-5d83" type="selectionEntry">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -24253,7 +25478,7 @@
           <constraints/>
           <categoryLinks/>
         </entryLink>
-        <entryLink id="bcc0-bff4-0c1e-a5d8" name="New EntryLink" hidden="false" targetId="1e2d-40cf-18d3-db7f" type="selectionEntry">
+        <entryLink id="bcc0-bff4-0c1e-a5d8" name="Combi-plasma" hidden="false" targetId="fdce-cdf7-21a9-f9ac" type="selectionEntry">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -24273,7 +25498,7 @@
       <selectionEntries/>
       <selectionEntryGroups/>
       <entryLinks>
-        <entryLink id="7d79-c01a-82e1-f880" name="New EntryLink" hidden="false" targetId="5f85-cddd-00b5-41f8" type="selectionEntry">
+        <entryLink id="7d79-c01a-82e1-f880" name="Chainsword" hidden="false" targetId="0dd1-2e2b-7dd1-5495" type="selectionEntry">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -24281,7 +25506,7 @@
           <constraints/>
           <categoryLinks/>
         </entryLink>
-        <entryLink id="d761-9ad4-c876-08d3" name="New EntryLink" hidden="false" targetId="c3d0-2567-35c6-3f29" type="selectionEntry">
+        <entryLink id="d761-9ad4-c876-08d3" name="Power sword" hidden="false" targetId="bc9e-551d-9afb-78d5" type="selectionEntry">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -24289,7 +25514,7 @@
           <constraints/>
           <categoryLinks/>
         </entryLink>
-        <entryLink id="8474-df28-bc07-bf2d" name="New EntryLink" hidden="false" targetId="8d13-0f69-a808-e300" type="selectionEntry">
+        <entryLink id="8474-df28-bc07-bf2d" name="Power axe" hidden="false" targetId="3292-34e6-f679-d5b9" type="selectionEntry">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -24297,7 +25522,7 @@
           <constraints/>
           <categoryLinks/>
         </entryLink>
-        <entryLink id="d367-92be-e296-d0fd" name="New EntryLink" hidden="false" targetId="b22c-5019-c613-fb74" type="selectionEntry">
+        <entryLink id="d367-92be-e296-d0fd" name="Power maul" hidden="false" targetId="6ea7-1195-7144-438e" type="selectionEntry">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -24313,7 +25538,7 @@
           <constraints/>
           <categoryLinks/>
         </entryLink>
-        <entryLink id="15d6-600d-272b-5a63" name="New EntryLink" hidden="false" targetId="3102-2dd8-4f31-3af7" type="selectionEntry">
+        <entryLink id="15d6-600d-272b-5a63" name="Power fist" hidden="false" targetId="f122-3720-fa32-4215" type="selectionEntry">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -24321,7 +25546,7 @@
           <constraints/>
           <categoryLinks/>
         </entryLink>
-        <entryLink id="cab4-841f-03e8-804c" name="New EntryLink" hidden="false" targetId="7057-ee87-f5bf-5e42" type="selectionEntry">
+        <entryLink id="cab4-841f-03e8-804c" name="Thunder hammer" hidden="false" targetId="0e57-eaf5-763f-9c45" type="selectionEntry">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -24329,7 +25554,7 @@
           <constraints/>
           <categoryLinks/>
         </entryLink>
-        <entryLink id="c3ec-0c04-4f7e-8818" name="New EntryLink" hidden="false" targetId="f2c7-e0ae-58d4-205a" type="selectionEntry">
+        <entryLink id="c3ec-0c04-4f7e-8818" name="Power lance" hidden="false" targetId="ba8d-691a-6178-1a60" type="selectionEntry">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -24349,7 +25574,7 @@
       <selectionEntries/>
       <selectionEntryGroups/>
       <entryLinks>
-        <entryLink id="7f04-b8c7-1760-a849" name="New EntryLink" hidden="false" targetId="a255-3b4c-89e4-e6b3" type="selectionEntry">
+        <entryLink id="7f04-b8c7-1760-a849" name="Flamer" hidden="false" targetId="fd22-6743-2d4c-dd62" type="selectionEntry">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -24357,7 +25582,7 @@
           <constraints/>
           <categoryLinks/>
         </entryLink>
-        <entryLink id="0bbd-77ae-8207-0831" name="New EntryLink" hidden="false" targetId="be22-4d06-c69b-5310" type="selectionEntry">
+        <entryLink id="0bbd-77ae-8207-0831" name="Plasma gun" hidden="false" targetId="8c14-22cc-93ce-b85a" type="selectionEntry">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -24365,7 +25590,7 @@
           <constraints/>
           <categoryLinks/>
         </entryLink>
-        <entryLink id="b89f-7133-b8d5-b60d" name="New EntryLink" hidden="false" targetId="9ec1-5584-a623-fdda" type="selectionEntry">
+        <entryLink id="b89f-7133-b8d5-b60d" name="Meltagun" hidden="false" targetId="efc8-c51d-5b02-a3a2" type="selectionEntry">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -24373,7 +25598,7 @@
           <constraints/>
           <categoryLinks/>
         </entryLink>
-        <entryLink id="172d-73d8-f3de-025d" name="New EntryLink" hidden="false" targetId="5043-0a0a-25d7-3c6d" type="selectionEntry">
+        <entryLink id="172d-73d8-f3de-025d" name="Grav-gun" hidden="false" targetId="538c-b8cd-b452-2685" type="selectionEntry">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -24393,7 +25618,7 @@
       <selectionEntries/>
       <selectionEntryGroups/>
       <entryLinks>
-        <entryLink id="e5c7-e7d2-f6e8-3385" name="New EntryLink" hidden="false" targetId="96f3-141e-f073-d314" type="selectionEntry">
+        <entryLink id="e5c7-e7d2-f6e8-3385" name="Missile launcher" hidden="false" targetId="1469-1964-7a91-94d4" type="selectionEntry">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -24401,7 +25626,7 @@
           <constraints/>
           <categoryLinks/>
         </entryLink>
-        <entryLink id="aaf5-cf4e-0e25-fcf7" name="New EntryLink" hidden="false" targetId="290a-8ad2-2af9-5ebc" type="selectionEntry">
+        <entryLink id="aaf5-cf4e-0e25-fcf7" name="Heavy bolter" hidden="false" targetId="05ab-e7cc-e856-c36f" type="selectionEntry">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -24409,7 +25634,7 @@
           <constraints/>
           <categoryLinks/>
         </entryLink>
-        <entryLink id="5d14-a5f9-6e78-0f74" name="New EntryLink" hidden="false" targetId="9523-8395-ca20-2849" type="selectionEntry">
+        <entryLink id="5d14-a5f9-6e78-0f74" name="Multi-melta" hidden="false" targetId="2b37-65ee-9443-b4ef" type="selectionEntry">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -24417,7 +25642,7 @@
           <constraints/>
           <categoryLinks/>
         </entryLink>
-        <entryLink id="4254-6ecb-8b07-906a" name="New EntryLink" hidden="false" targetId="7c7d-abb2-d8b9-2d9c" type="selectionEntry">
+        <entryLink id="4254-6ecb-8b07-906a" name="Lascannon" hidden="false" targetId="a908-4664-11cd-f8b2" type="selectionEntry">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -24425,7 +25650,7 @@
           <constraints/>
           <categoryLinks/>
         </entryLink>
-        <entryLink id="473e-908f-c9b3-2556" name="New EntryLink" hidden="false" targetId="68f5-b30c-1556-e4ac" type="selectionEntry">
+        <entryLink id="473e-908f-c9b3-2556" name="Grav-cannon and grav-amp" hidden="false" targetId="2f3b-2b38-8060-efc7" type="selectionEntry">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -24433,7 +25658,7 @@
           <constraints/>
           <categoryLinks/>
         </entryLink>
-        <entryLink id="027f-8a95-b2b0-6283" name="New EntryLink" hidden="false" targetId="cc33-411c-60b0-fdec" type="selectionEntry">
+        <entryLink id="027f-8a95-b2b0-6283" name="Plasma cannon" hidden="false" targetId="eb15-db61-5d4f-b65e" type="selectionEntry">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -24441,7 +25666,7 @@
           <constraints/>
           <categoryLinks/>
         </entryLink>
-        <entryLink id="3b08-1366-8f1f-d6bd" name="New EntryLink" hidden="false" targetId="7eb4-1d78-9058-f71a" type="selectionEntry">
+        <entryLink id="3b08-1366-8f1f-d6bd" name="Heavy flamer" hidden="false" targetId="18bc-b335-29c2-2ae2" type="selectionEntry">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -24469,7 +25694,7 @@
           <constraints/>
           <categoryLinks/>
         </entryLink>
-        <entryLink id="531f-9688-29d0-4f72" name="New EntryLink" hidden="false" targetId="3102-2dd8-4f31-3af7" type="selectionEntry">
+        <entryLink id="531f-9688-29d0-4f72" name="Power fist" hidden="false" targetId="f122-3720-fa32-4215" type="selectionEntry">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -24485,7 +25710,7 @@
           <constraints/>
           <categoryLinks/>
         </entryLink>
-        <entryLink id="4089-7789-e487-9693" name="New EntryLink" hidden="false" targetId="7057-ee87-f5bf-5e42" type="selectionEntry">
+        <entryLink id="4089-7789-e487-9693" name="Thunder hammer" hidden="false" targetId="0e57-eaf5-763f-9c45" type="selectionEntry">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -24505,7 +25730,7 @@
       <selectionEntries/>
       <selectionEntryGroups/>
       <entryLinks>
-        <entryLink id="2dd8-fc94-477f-db06" name="New EntryLink" hidden="false" targetId="d74a-2fee-abea-1b42" type="selectionEntry">
+        <entryLink id="2dd8-fc94-477f-db06" name="Storm bolter" hidden="false" targetId="2b03-8d64-3711-f300" type="selectionEntry">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -24513,7 +25738,7 @@
           <constraints/>
           <categoryLinks/>
         </entryLink>
-        <entryLink id="f543-cc1b-401d-781c" name="New EntryLink" hidden="false" targetId="a070-091c-f79c-7838" type="selectionEntry">
+        <entryLink id="f543-cc1b-401d-781c" name="Combi-flamer" hidden="false" targetId="c6a1-e0c4-c1b1-dce1" type="selectionEntry">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -24521,7 +25746,7 @@
           <constraints/>
           <categoryLinks/>
         </entryLink>
-        <entryLink id="fd51-9b4a-81a1-7bec" name="New EntryLink" hidden="false" targetId="ce34-2e18-b818-b255" type="selectionEntry">
+        <entryLink id="fd51-9b4a-81a1-7bec" name="Combi-melta" hidden="false" targetId="c445-e211-f316-5d83" type="selectionEntry">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -24529,7 +25754,7 @@
           <constraints/>
           <categoryLinks/>
         </entryLink>
-        <entryLink id="1309-9f79-3dee-3c52" name="New EntryLink" hidden="false" targetId="1e2d-40cf-18d3-db7f" type="selectionEntry">
+        <entryLink id="1309-9f79-3dee-3c52" name="Combi-plasma" hidden="false" targetId="fdce-cdf7-21a9-f9ac" type="selectionEntry">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -24549,7 +25774,7 @@
       <selectionEntries/>
       <selectionEntryGroups/>
       <entryLinks>
-        <entryLink id="86d6-3f09-0624-722c" name="New EntryLink" hidden="false" targetId="7eb4-1d78-9058-f71a" type="selectionEntry">
+        <entryLink id="86d6-3f09-0624-722c" name="Heavy flamer" hidden="false" targetId="18bc-b335-29c2-2ae2" type="selectionEntry">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -24557,7 +25782,7 @@
           <constraints/>
           <categoryLinks/>
         </entryLink>
-        <entryLink id="05b3-e0f6-aae6-e837" name="New EntryLink" hidden="false" targetId="640e-ce8b-bba2-ce5f" type="selectionEntry">
+        <entryLink id="05b3-e0f6-aae6-e837" name="Assault cannon" hidden="false" targetId="51b0-3d46-5af4-683e" type="selectionEntry">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -24585,7 +25810,7 @@
       <selectionEntries/>
       <selectionEntryGroups/>
       <entryLinks>
-        <entryLink id="b2c4-3e9f-8a47-2bb7" name="New EntryLink" hidden="false" targetId="256f-ce46-d4c9-02dc" type="selectionEntry">
+        <entryLink id="b2c4-3e9f-8a47-2bb7" name="Twin heavy flamer" hidden="false" targetId="8d70-a6af-cbad-f08c" type="selectionEntry">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -24593,7 +25818,7 @@
           <constraints/>
           <categoryLinks/>
         </entryLink>
-        <entryLink id="fc9d-7dcf-27d3-f92f" name="New EntryLink" hidden="false" targetId="2837-2f42-e4d7-56c6" type="selectionEntry">
+        <entryLink id="fc9d-7dcf-27d3-f92f" name="Twin autocannon" hidden="false" targetId="afe0-3771-1982-92b4" type="selectionEntry">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -24601,7 +25826,7 @@
           <constraints/>
           <categoryLinks/>
         </entryLink>
-        <entryLink id="e2de-42eb-9132-45d5" name="New EntryLink" hidden="false" targetId="b310-1fca-9564-5812" type="selectionEntry">
+        <entryLink id="e2de-42eb-9132-45d5" name="Twin heavy bolter" hidden="false" targetId="09d8-7790-ed3f-4d6d" type="selectionEntry">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -24609,7 +25834,7 @@
           <constraints/>
           <categoryLinks/>
         </entryLink>
-        <entryLink id="827b-fd10-72e5-f2e7" name="New EntryLink" hidden="false" targetId="de7a-7bba-e2c5-c37c" type="selectionEntry">
+        <entryLink id="827b-fd10-72e5-f2e7" name="Twin lascannon" hidden="false" targetId="ee18-b1cd-6b60-464d" type="selectionEntry">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -24617,7 +25842,7 @@
           <constraints/>
           <categoryLinks/>
         </entryLink>
-        <entryLink id="ec38-20d5-dd5a-672a" name="" hidden="false" targetId="640e-ce8b-bba2-ce5f" type="selectionEntry">
+        <entryLink id="ec38-20d5-dd5a-672a" name="Assault cannon" hidden="false" targetId="51b0-3d46-5af4-683e" type="selectionEntry">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -24625,7 +25850,7 @@
           <constraints/>
           <categoryLinks/>
         </entryLink>
-        <entryLink id="7bac-e09e-b9a8-e5a8" name="New EntryLink" hidden="false" targetId="82cc-cf20-dcc6-ab64" type="selectionEntry">
+        <entryLink id="7bac-e09e-b9a8-e5a8" name="Heavy plasma cannon" hidden="false" targetId="221a-6109-61df-015e" type="selectionEntry">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -24633,7 +25858,7 @@
           <constraints/>
           <categoryLinks/>
         </entryLink>
-        <entryLink id="4bb3-a7d5-5400-cd05" name="New EntryLink" hidden="false" targetId="9523-8395-ca20-2849" type="selectionEntry">
+        <entryLink id="4bb3-a7d5-5400-cd05" name="Multi-melta" hidden="false" targetId="2b37-65ee-9443-b4ef" type="selectionEntry">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -24653,7 +25878,7 @@
       <selectionEntries/>
       <selectionEntryGroups/>
       <entryLinks>
-        <entryLink id="2006-4f39-bb81-702a" name="New EntryLink" hidden="false" targetId="5f85-cddd-00b5-41f8" type="selectionEntry">
+        <entryLink id="2006-4f39-bb81-702a" name="Chainsword" hidden="false" targetId="0dd1-2e2b-7dd1-5495" type="selectionEntry">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -24661,7 +25886,7 @@
           <constraints/>
           <categoryLinks/>
         </entryLink>
-        <entryLink id="42e1-60ae-b3ae-5002" name="New EntryLink" hidden="false" targetId="c3d0-2567-35c6-3f29" type="selectionEntry">
+        <entryLink id="42e1-60ae-b3ae-5002" name="Power sword" hidden="false" targetId="bc9e-551d-9afb-78d5" type="selectionEntry">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -24669,7 +25894,7 @@
           <constraints/>
           <categoryLinks/>
         </entryLink>
-        <entryLink id="0b28-e433-df6f-38ef" name="New EntryLink" hidden="false" targetId="8d13-0f69-a808-e300" type="selectionEntry">
+        <entryLink id="0b28-e433-df6f-38ef" name="Power axe" hidden="false" targetId="3292-34e6-f679-d5b9" type="selectionEntry">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -24677,7 +25902,7 @@
           <constraints/>
           <categoryLinks/>
         </entryLink>
-        <entryLink id="e298-ae97-c752-7137" name="New EntryLink" hidden="false" targetId="b22c-5019-c613-fb74" type="selectionEntry">
+        <entryLink id="e298-ae97-c752-7137" name="Power maul" hidden="false" targetId="6ea7-1195-7144-438e" type="selectionEntry">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -24693,7 +25918,7 @@
           <constraints/>
           <categoryLinks/>
         </entryLink>
-        <entryLink id="10b8-c42b-aa19-3cc0" name="New EntryLink" hidden="false" targetId="3102-2dd8-4f31-3af7" type="selectionEntry">
+        <entryLink id="10b8-c42b-aa19-3cc0" name="Power fist" hidden="false" targetId="f122-3720-fa32-4215" type="selectionEntry">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -24701,7 +25926,7 @@
           <constraints/>
           <categoryLinks/>
         </entryLink>
-        <entryLink id="6e59-6cd6-aca2-bdf4" name="New EntryLink" hidden="false" targetId="7057-ee87-f5bf-5e42" type="selectionEntry">
+        <entryLink id="6e59-6cd6-aca2-bdf4" name="Thunder hammer" hidden="false" targetId="0e57-eaf5-763f-9c45" type="selectionEntry">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -24709,7 +25934,7 @@
           <constraints/>
           <categoryLinks/>
         </entryLink>
-        <entryLink id="63e4-a061-0010-55e8" name="New EntryLink" hidden="false" targetId="f2c7-e0ae-58d4-205a" type="selectionEntry">
+        <entryLink id="63e4-a061-0010-55e8" name="Power lance" hidden="false" targetId="ba8d-691a-6178-1a60" type="selectionEntry">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -24717,7 +25942,7 @@
           <constraints/>
           <categoryLinks/>
         </entryLink>
-        <entryLink id="3816-fe8d-9997-31fa" name="" hidden="false" targetId="bf86-1c1b-6871-da0b" type="selectionEntry">
+        <entryLink id="3816-fe8d-9997-31fa" name="Bolt pistol" hidden="false" targetId="0334-f487-8229-0c1a" type="selectionEntry">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -24725,7 +25950,7 @@
           <constraints/>
           <categoryLinks/>
         </entryLink>
-        <entryLink id="1a4f-b6d1-20e8-ca28" name="New EntryLink" hidden="false" targetId="9f58-3b91-fa2e-32e2" type="selectionEntry">
+        <entryLink id="1a4f-b6d1-20e8-ca28" name="Grav-pistol" hidden="false" targetId="7b66-cac7-e582-a518" type="selectionEntry">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -24741,7 +25966,7 @@
           <constraints/>
           <categoryLinks/>
         </entryLink>
-        <entryLink id="df0e-83c6-fec0-8930" name="New EntryLink" hidden="false" targetId="12fb-6600-667f-5922" type="selectionEntry">
+        <entryLink id="df0e-83c6-fec0-8930" name="Inferno pistol" hidden="false" targetId="83f0-56d1-b852-f21c" type="selectionEntry">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -24749,7 +25974,7 @@
           <constraints/>
           <categoryLinks/>
         </entryLink>
-        <entryLink id="d015-2bb7-65ee-5c8e" name="New EntryLink" hidden="false" targetId="d83e-4dc3-0722-4206" type="selectionEntry">
+        <entryLink id="d015-2bb7-65ee-5c8e" name="Plasma pistol" hidden="false" targetId="83be-1ba9-c326-4760" type="selectionEntry">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -24759,8 +25984,419 @@
         </entryLink>
       </entryLinks>
     </selectionEntryGroup>
+    <selectionEntryGroup id="92a9-e94b-7190-1eb3" name="Intercessor bolt rifles" hidden="false" collective="true">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints/>
+      <categoryLinks/>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks>
+        <entryLink id="2871-f247-b8e3-4ff5" name="Bolt rifle" hidden="false" targetId="5907-c64e-703e-5778" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c9fe-9b28-3307-def1" type="max"/>
+          </constraints>
+          <categoryLinks/>
+        </entryLink>
+        <entryLink id="9f61-0188-1af2-d504" name="Auto bolt rifle" hidden="false" targetId="36fb-ccc7-03d1-93c9" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6aa8-c5e2-f565-0f4f" type="max"/>
+          </constraints>
+          <categoryLinks/>
+        </entryLink>
+        <entryLink id="f99d-56e4-7f30-6f75" name="Stalker bolt rifle" hidden="false" targetId="1840-b6e5-27f2-3436" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="13cf-8509-0fe6-07f9" type="max"/>
+          </constraints>
+          <categoryLinks/>
+        </entryLink>
+      </entryLinks>
+    </selectionEntryGroup>
+    <selectionEntryGroup id="c25d-2fbc-47b3-9e39" name="Warlord Traits" hidden="true" collective="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <repeats/>
+          <conditions>
+            <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="33f6-60da-7b70-5fee" type="equalTo"/>
+          </conditions>
+          <conditionGroups/>
+        </modifier>
+      </modifiers>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0a76-fcf3-06d4-36b9" type="max"/>
+      </constraints>
+      <categoryLinks/>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks>
+        <entryLink id="4a4f-e6be-820a-4224" name="Warlord Traits  (Codex: Blood Angels)" hidden="false" targetId="f754-c641-2e0a-5e90" type="selectionEntryGroup">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+          <categoryLinks/>
+        </entryLink>
+        <entryLink id="f555-334d-e671-64ba" name="Warlord Traits (BRB)" hidden="false" targetId="d442-1f03-d9da-e77f" type="selectionEntryGroup">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+          <categoryLinks/>
+        </entryLink>
+        <entryLink id="90d5-800c-7adb-c99b" name="Warlord Traits (CA)" hidden="false" targetId="f673-3d9b-bb1b-377f" type="selectionEntryGroup">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+          <categoryLinks/>
+        </entryLink>
+      </entryLinks>
+    </selectionEntryGroup>
+    <selectionEntryGroup id="f754-c641-2e0a-5e90" name="Warlord Traits  (Codex: Blood Angels)" hidden="true" collective="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <repeats/>
+          <conditions>
+            <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="33f6-60da-7b70-5fee" type="equalTo"/>
+          </conditions>
+          <conditionGroups/>
+        </modifier>
+      </modifiers>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a57e-2b6c-ea27-791b" type="max"/>
+      </constraints>
+      <categoryLinks/>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks>
+        <entryLink id="adfd-adc7-f21e-b462" name="1. Speed of the Primarch" hidden="false" targetId="2ec6-a5f9-9dc1-93e5" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+          <categoryLinks/>
+        </entryLink>
+        <entryLink id="0197-b805-4623-c2aa" name="2. Artisan of War" hidden="false" targetId="73a7-1838-fbc4-b242" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+          <categoryLinks/>
+        </entryLink>
+        <entryLink id="b95f-82e6-0367-e166" name="3. Soulwarden" hidden="false" targetId="58d2-aee8-1337-a246" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+          <categoryLinks/>
+        </entryLink>
+        <entryLink id="782e-7ed6-d187-62d4" name="4. Heroic Bearing" hidden="false" targetId="f000-3a97-306f-1264" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+          <categoryLinks/>
+        </entryLink>
+        <entryLink id="a91f-5a72-77eb-6547" name="5. Gift of Foresight" hidden="false" targetId="1d05-f4aa-e4ff-548f" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+          <categoryLinks/>
+        </entryLink>
+        <entryLink id="5c74-7a9a-96d0-a897" name="6. Selfless Valour" hidden="false" targetId="5aac-e94d-2bcf-c1d1" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+          <categoryLinks/>
+        </entryLink>
+      </entryLinks>
+    </selectionEntryGroup>
+    <selectionEntryGroup id="441f-1714-0777-c202" name="Relics of Baal" hidden="true" collective="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <repeats/>
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="33f6-60da-7b70-5fee" type="equalTo"/>
+          </conditions>
+          <conditionGroups/>
+        </modifier>
+      </modifiers>
+      <constraints>
+        <constraint field="selections" scope="roster" value="3.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="8bb7-fa05-a838-8230" type="max"/>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="56bb-38d8-5ef0-d1ed" type="max"/>
+      </constraints>
+      <categoryLinks/>
+      <selectionEntries>
+        <selectionEntry id="a550-1344-b83e-80d1" name="The Veritas Vitae" hidden="false" collective="false" type="upgrade">
+          <profiles/>
+          <rules/>
+          <infoLinks>
+            <infoLink id="0304-aa41-3714-0893" name="The Veritas Vitae" hidden="false" targetId="da00-db89-76b1-8fd0" type="profile">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+          </infoLinks>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="f7e5-0d27-4ffc-1c0f" type="max"/>
+          </constraints>
+          <categoryLinks/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks/>
+          <costs>
+            <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="0.0"/>
+            <cost name="pts" costTypeId="points" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="6a97-fdbf-7751-f19d" name="The Hammer of Baal (replaces thunder hammer)" hidden="false" collective="false" type="upgrade">
+          <profiles/>
+          <rules/>
+          <infoLinks>
+            <infoLink id="d69d-5693-1b42-b87a" name="The Hammer of Baal" hidden="false" targetId="46f2-9ac2-a4df-4508" type="profile">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+          </infoLinks>
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <repeats/>
+              <conditions>
+                <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9c7b-4573-3321-2def" type="instanceOf"/>
+              </conditions>
+              <conditionGroups/>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="4069-e64a-fc86-0b62" type="max"/>
+          </constraints>
+          <categoryLinks/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks/>
+          <costs>
+            <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="dde0-9f1f-6381-2a4d" name="The Angel&apos;s Wing (replaces jump pack)" hidden="true" collective="false" type="upgrade">
+          <profiles/>
+          <rules/>
+          <infoLinks>
+            <infoLink id="19a4-4228-e216-1b90" name="The Angel&apos;s Wing" hidden="false" targetId="ddb3-ec71-ab5d-9c29" type="profile">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+          </infoLinks>
+          <modifiers>
+            <modifier type="set" field="hidden" value="false">
+              <repeats/>
+              <conditions>
+                <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f627-f23e-a3b4-dc2c" type="equalTo"/>
+              </conditions>
+              <conditionGroups/>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="1a40-fbc1-58e4-85f3" type="max"/>
+          </constraints>
+          <categoryLinks/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks/>
+          <costs>
+            <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="0.0"/>
+            <cost name="pts" costTypeId="points" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="c5b3-a269-a122-64ba" name="Standard of Sacrifice" hidden="true" collective="false" type="upgrade">
+          <profiles/>
+          <rules/>
+          <infoLinks>
+            <infoLink id="ee9c-2e20-dbec-3786" name="Standard of Sacrifice" hidden="false" targetId="bd64-21ad-57a1-4fad" type="profile">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+          </infoLinks>
+          <modifiers>
+            <modifier type="set" field="hidden" value="false">
+              <repeats/>
+              <conditions>
+                <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="86bf-b026-f6e2-a949" type="instanceOf"/>
+              </conditions>
+              <conditionGroups/>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="1454-d608-4303-cb3a" type="max"/>
+          </constraints>
+          <categoryLinks/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks/>
+          <costs>
+            <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="0.0"/>
+            <cost name="pts" costTypeId="points" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="f77f-cb20-544a-4fc2" name="Gallian&apos;s Staff (replaces force stave)" hidden="true" collective="false" type="upgrade">
+          <profiles/>
+          <rules/>
+          <infoLinks>
+            <infoLink id="d220-cf6a-f850-9b7b" name="Gallian&apos;s Staff" hidden="false" targetId="5830-68e3-f762-f066" type="profile">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+          </infoLinks>
+          <modifiers>
+            <modifier type="set" field="hidden" value="false">
+              <repeats/>
+              <conditions/>
+              <conditionGroups>
+                <conditionGroup type="and">
+                  <conditions>
+                    <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3d10-0420-b210-b091" type="instanceOf"/>
+                    <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="c150-13fe-d2ff-141d" type="notInstanceOf"/>
+                  </conditions>
+                  <conditionGroups/>
+                </conditionGroup>
+              </conditionGroups>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="c093-6559-7ee9-5bd6" type="max"/>
+          </constraints>
+          <categoryLinks/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks/>
+          <costs>
+            <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="70cc-8870-b790-c4de" name="Archangel&apos;s Shard (replaces power sword or master-crafted power sword)" hidden="false" collective="false" type="upgrade">
+          <profiles/>
+          <rules/>
+          <infoLinks>
+            <infoLink id="addf-d829-7f3f-9ebc" name="Archangel&apos;s Shard" hidden="false" targetId="2bb8-1f87-1d4b-59de" type="profile">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+          </infoLinks>
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <repeats/>
+              <conditions>
+                <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9c7b-4573-3321-2def" type="instanceOf"/>
+              </conditions>
+              <conditionGroups/>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="88af-5a3f-e25f-f6a5" type="max"/>
+          </constraints>
+          <categoryLinks/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks/>
+          <costs>
+            <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="0.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups/>
+      <entryLinks/>
+    </selectionEntryGroup>
   </sharedSelectionEntryGroups>
-  <sharedRules/>
+  <sharedRules>
+    <rule id="c0e7-86ee-673c-41a7" name="1. Speed of the Primarch" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <description>You can always choose your Warlord to fight first in the Fight phase even if he didn&apos;t charge. If the enemy has units that have charged, or that have a similar ability, then alternate choosing units to fight with, starting with the player whose turn is taking place.</description>
+    </rule>
+    <rule id="1c97-a0e6-03f9-74c6" name="2. Artisan of War" page="" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <description>Add 1 to the Damage characteristic of one weapon carried by your Warlord. Note that this cannot be a Relic of Baal.</description>
+    </rule>
+    <rule id="f7ea-a747-21ef-3887" name="3. Soulwarden" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <description>You can attempt to resist one psychic power with your Warlord (or attempt to resist one additional psychic power if he is already able to do so) in each of your opponent&apos;s Psychic phases.</description>
+    </rule>
+    <rule id="05dd-5796-cd5d-3ecc" name="4. Heroic Bearing" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <description>Friendly BLOOD ANGELS units automatically pass Morale tests whilst they are within 6&quot; of your Warlord.</description>
+    </rule>
+    <rule id="aa55-79c3-d21e-5057" name="5. Gift of Foresight" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <description>Roll aD6 each time your Warlord loses a wound, re-rolling rolls of 1; on a 6, that wound is ignored and has no effect. If your Warlord also has the Black Rage ability, they instead ignore wounds on rolls of 5 or 6, but the similar ability to ignore wounds from the Black Rage has no effect.</description>
+    </rule>
+    <rule id="c1ab-b6fb-ef36-a56d" name="6. Selfless Valour" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <description>Your Warlord can perform a Heroic Intervention if he is within 6&quot; of an enemy unit instead of only 3&quot;, and if he does so he can move up to 6&quot; rather than 3&quot;.</description>
+    </rule>
+  </sharedRules>
   <sharedProfiles>
     <profile id="4c6e-5f3b-8fe7-13a6" name="Hand Flamer" book="Index: Imperium 1" page="213" hidden="false" profileTypeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" profileTypeName="Weapon">
       <profiles/>
@@ -25103,7 +26739,7 @@
       <infoLinks/>
       <modifiers/>
       <characteristics>
-        <characteristic name="Description" characteristicTypeId="21befb24-fc85-4f52-a745-64b2e48f8228" value="You can add 1 to this unit&apos;s Attacks characteristic in the Fight phase if it charged in the preceding Charge phase. In addition, roll a D6 each time this unit loses a wound. On a roll of 6 the damage is ignored."/>
+        <characteristic name="Description" characteristicTypeId="21befb24-fc85-4f52-a745-64b2e48f8228" value="You can add 1 to this unit&apos;s Attacks characteristic in the Fight phase if it charged in the preceding Charge phase. In addition, roll a D6 each time this unit loses a wound. On a 6 the wound is ignored and has no effect."/>
       </characteristics>
     </profile>
     <profile id="5d04-8767-d93e-f7fd" name="Honour or Death" hidden="false" profileTypeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" profileTypeName="Abilities">
@@ -25139,7 +26775,7 @@
       <infoLinks/>
       <modifiers/>
       <characteristics>
-        <characteristic name="Description" characteristicTypeId="21befb24-fc85-4f52-a745-64b2e48f8228" value="You can re-roll failed hit rolls in the Fight phase for friendly &lt;CHAPTER&gt; units within 6&quot; of this model."/>
+        <characteristic name="Description" characteristicTypeId="21befb24-fc85-4f52-a745-64b2e48f8228" value="You can re-roll failed hit rolls in the Fight phase for friendly BLOOD ANGELS units within 6&quot; of this model."/>
       </characteristics>
     </profile>
     <profile id="cf04-2c83-f5e1-9fb4" name="Rites of Battle" hidden="false" profileTypeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" profileTypeName="Abilities">
@@ -25148,7 +26784,7 @@
       <infoLinks/>
       <modifiers/>
       <characteristics>
-        <characteristic name="Description" characteristicTypeId="21befb24-fc85-4f52-a745-64b2e48f8228" value="You can re-roll hit rolls of 1 made for friendly &lt;CHAPTER&gt; units within 6&quot; of this model."/>
+        <characteristic name="Description" characteristicTypeId="21befb24-fc85-4f52-a745-64b2e48f8228" value="You can re-roll hit rolls of 1 made for friendly BLOOD ANGELS units within 6&quot; of this model."/>
       </characteristics>
     </profile>
     <profile id="1291-2924-8f8a-105c" name="Rosarius" hidden="false" profileTypeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" profileTypeName="Abilities">
@@ -25175,7 +26811,7 @@
       <infoLinks/>
       <modifiers/>
       <characteristics>
-        <characteristic name="Description" characteristicTypeId="21befb24-fc85-4f52-a745-64b2e48f8228" value="All friendly &lt;CHAPTER&gt; units within 6&quot; of this model can use the Chaplain&apos;s Leadership instead of their own."/>
+        <characteristic name="Description" characteristicTypeId="21befb24-fc85-4f52-a745-64b2e48f8228" value="All friendly BLOOD ANGELS units within 6&quot; of this model can use the Chaplain&apos;s Leadership instead of their own."/>
       </characteristics>
     </profile>
     <profile id="4243-5016-c4d9-2b6b" name="Teleport Strike" hidden="false" profileTypeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" profileTypeName="Abilities">
@@ -25605,7 +27241,7 @@
       <infoLinks/>
       <modifiers/>
       <characteristics>
-        <characteristic name="Description" characteristicTypeId="21befb24-fc85-4f52-a745-64b2e48f8228" value="You can re-roll wound rolls of 1 for friendly &lt;CHAPTER&gt; units that are within 6&quot; of this model."/>
+        <characteristic name="Description" characteristicTypeId="21befb24-fc85-4f52-a745-64b2e48f8228" value="You can re-roll wound rolls of 1 for friendly CLOOD ANGELS units that are within 6&quot; of a friendly BLOOD ANGELS LIEUTENANT."/>
       </characteristics>
     </profile>
     <profile id="6e55-5deb-c20c-ae39" name="Razorback" hidden="false" profileTypeId="800f-21d0-4387-c943" profileTypeName="Unit">
@@ -25691,7 +27327,7 @@
       <infoLinks/>
       <modifiers/>
       <characteristics>
-        <characteristic name="Description" characteristicTypeId="21befb24-fc85-4f52-a745-64b2e48f8228" value="At the end of any of your Movement phases, the Apothecary can attempt to heal or revive a single model. Select a friendly &lt;CHAPTER&gt; INFANTRY or BIKER unit within 3&quot; of the Apothecary. If that unit contains a wounded model, it immediately regains D3 lost wounds. If the chosen unit contains no wounded models but one or more of its models have been slain during the battle, roll a D6. On a 4+ a single slain model is returned to the unit with 1 wound remaining. If the Apothecary fails to revive a model he can do nothing else for the remainder of the turn (shoot, charge, fight, etc.) as he recovers the gene-seed of the fallen warrior. A unit can only be the target of the Narthecium ability once in each turn."/>
+        <characteristic name="Description" characteristicTypeId="21befb24-fc85-4f52-a745-64b2e48f8228" value="At the end of any of your Movement phases, this model can attempt to heal or revive a single model. Select a friendly BLOOD ANGELS INFANTRY or BIKER unit within 3&quot; of the Apothecary. If that unit contains a wounded model, it immediately regains D3 lost wounds. If the chosen unit contains no wounded models but one or more of its models have been slain during the battle, roll a D6. On a 4+ a single slain model is returned to the unit with 1 wound remaining. If this model fails to revive a model he can do nothing else for the remainder of the turn (shoot, charge, fight, etc.) as he recovers the gene-seed of the fallen warrior. A unit can only be the target of the Narthecium ability once in each turn."/>
       </characteristics>
     </profile>
     <profile id="c4a1-ef2a-655c-23a6" name="Scout Biker" hidden="false" profileTypeId="800f-21d0-4387-c943" profileTypeName="Unit">
@@ -25828,7 +27464,7 @@
       <infoLinks/>
       <modifiers/>
       <characteristics>
-        <characteristic name="Description" characteristicTypeId="21befb24-fc85-4f52-a745-64b2e48f8228" value="At the end of your Movement phase this model can repair a single &lt;CHAPTER&gt; VEHICLE within 1&quot;. That model regains D3 lost wounds. A model can only be repaired once per turn."/>
+        <characteristic name="Description" characteristicTypeId="21befb24-fc85-4f52-a745-64b2e48f8228" value="At the end of your Movement phase this model can repair a single BLOOD ANGELS VEHICLE within 1&quot;. That model regains D3 lost wounds. A model can only be repaired once per turn."/>
       </characteristics>
     </profile>
     <profile id="be94-de20-55b3-5e4b" name="Techmarine on Bike" hidden="false" profileTypeId="800f-21d0-4387-c943" profileTypeName="Unit">
@@ -25999,9 +27635,9 @@
         <characteristic name="Range" characteristicTypeId="6fa97fa8-ea74-4a27-a0fb-bc4e5f367464" value="Melee"/>
         <characteristic name="Type" characteristicTypeId="077c342f-d7b9-45c6-b8af-88e97cafd3a2" value="Melee"/>
         <characteristic name="S" characteristicTypeId="59b1-319e-ec13-d466" value="x2"/>
-        <characteristic name="AP" characteristicTypeId="75aa-a838-b675-6484" value="-1"/>
+        <characteristic name="AP" characteristicTypeId="75aa-a838-b675-6484" value="-2"/>
         <characteristic name="D" characteristicTypeId="ae8a-3137-d65b-4ca7" value="3"/>
-        <characteristic name="Abilities" characteristicTypeId="837d-5e63-aeb7-1410" value="Each time you roll a hit roll of 6+ for this weapon, inflict 1 additional hit on the target."/>
+        <characteristic name="Abilities" characteristicTypeId="837d-5e63-aeb7-1410" value="-"/>
       </characteristics>
     </profile>
     <profile id="253c-72cd-66db-4a37" name="Blood talons" hidden="false" profileTypeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" profileTypeName="Weapon">
@@ -26012,10 +27648,10 @@
       <characteristics>
         <characteristic name="Range" characteristicTypeId="6fa97fa8-ea74-4a27-a0fb-bc4e5f367464" value="Melee"/>
         <characteristic name="Type" characteristicTypeId="077c342f-d7b9-45c6-b8af-88e97cafd3a2" value="Melee"/>
-        <characteristic name="S" characteristicTypeId="59b1-319e-ec13-d466" value="x2"/>
-        <characteristic name="AP" characteristicTypeId="75aa-a838-b675-6484" value="-3"/>
-        <characteristic name="D" characteristicTypeId="ae8a-3137-d65b-4ca7" value="D6"/>
-        <characteristic name="Abilities" characteristicTypeId="837d-5e63-aeb7-1410" value="-"/>
+        <characteristic name="S" characteristicTypeId="59b1-319e-ec13-d466" value="+4"/>
+        <characteristic name="AP" characteristicTypeId="75aa-a838-b675-6484" value="-2"/>
+        <characteristic name="D" characteristicTypeId="ae8a-3137-d65b-4ca7" value="3"/>
+        <characteristic name="Abilities" characteristicTypeId="837d-5e63-aeb7-1410" value="You can re-roll failed hit and wound rolls for this weapon."/>
       </characteristics>
     </profile>
     <profile id="f2a8-1401-3823-c28f" name="Encarmine axe" hidden="false" profileTypeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" profileTypeName="Weapon">
@@ -26068,7 +27704,7 @@
       <characteristics>
         <characteristic name="Range" characteristicTypeId="6fa97fa8-ea74-4a27-a0fb-bc4e5f367464" value="Melee"/>
         <characteristic name="Type" characteristicTypeId="077c342f-d7b9-45c6-b8af-88e97cafd3a2" value="Melee"/>
-        <characteristic name="S" characteristicTypeId="59b1-319e-ec13-d466" value="+1"/>
+        <characteristic name="S" characteristicTypeId="59b1-319e-ec13-d466" value="+2"/>
         <characteristic name="AP" characteristicTypeId="75aa-a838-b675-6484" value="-3"/>
         <characteristic name="D" characteristicTypeId="ae8a-3137-d65b-4ca7" value="D3"/>
         <characteristic name="Abilities" characteristicTypeId="837d-5e63-aeb7-1410" value="Each time you roll a wound roll of 6+ for this weapon it causes 3 damage instead of D3."/>
@@ -26281,7 +27917,7 @@
       <infoLinks/>
       <modifiers/>
       <characteristics>
-        <characteristic name="Description" characteristicTypeId="21befb24-fc85-4f52-a745-64b2e48f8228" value="Friendly &lt;CHAPTER&gt; INFANTRY and BIKER units increase their Strength characteristic by 1 whilst they are within 6&quot; of any SANGUINARY PRIESTS."/>
+        <characteristic name="Description" characteristicTypeId="21befb24-fc85-4f52-a745-64b2e48f8228" value="Friendly BLOOD ANGELS INFANTRY and BIKER units increase their Strength characteristic by 1 whilst they are within 6&quot; of any SANGUINARY PRIESTS."/>
       </characteristics>
     </profile>
     <profile id="88e8-08cf-db87-aa86" name="Sanguinary Priest on Bike" hidden="false" profileTypeId="800f-21d0-4387-c943" profileTypeName="Unit">
@@ -26318,7 +27954,7 @@
         <characteristic name="Save" characteristicTypeId="c0df-df94-abd7-e8d3" value="3+"/>
       </characteristics>
     </profile>
-    <profile id="e5c4-93dc-1669-9916" name="Sanguinary Guard Ancient" hidden="false" profileTypeId="800f-21d0-4387-c943" profileTypeName="Unit">
+    <profile id="e5c4-93dc-1669-9916" name="Sanguinary Ancient" hidden="false" profileTypeId="800f-21d0-4387-c943" profileTypeName="Unit">
       <profiles/>
       <rules/>
       <infoLinks/>
@@ -26341,7 +27977,7 @@
       <infoLinks/>
       <modifiers/>
       <characteristics>
-        <characteristic name="Description" characteristicTypeId="21befb24-fc85-4f52-a745-64b2e48f8228" value="You can re-roll failed hit rolls for this model if it is within 6&quot; of a &lt;CHAPTER&gt; Warlord."/>
+        <characteristic name="Description" characteristicTypeId="21befb24-fc85-4f52-a745-64b2e48f8228" value="You can re-roll failed hit rolls for models from this unit if they are within 6&quot; of a friendly BLOOD ANGELS Warlord."/>
       </characteristics>
     </profile>
     <profile id="eb92-1b6d-b645-12ad" name="Terminator Ancient" hidden="false" profileTypeId="800f-21d0-4387-c943" profileTypeName="Unit">
@@ -26435,7 +28071,7 @@
       <infoLinks/>
       <modifiers/>
       <characteristics>
-        <characteristic name="Description" characteristicTypeId="21befb24-fc85-4f52-a745-64b2e48f8228" value="If a model with a magna-grapple targets a VEHICLE in the Charge phase, you can add 2 to its charge roll."/>
+        <characteristic name="Description" characteristicTypeId="21befb24-fc85-4f52-a745-64b2e48f8228" value="If a model with a magna-grapple only targets a single VEHICLE unit in the Charge phase, add 2 to its charge roll."/>
       </characteristics>
     </profile>
     <profile id="79b1-6a5e-70fc-d572" name="Furioso Dreadnought" hidden="false" profileTypeId="800f-21d0-4387-c943" profileTypeName="Unit">
@@ -27118,31 +28754,597 @@
         <characteristic name="Description" characteristicTypeId="21befb24-fc85-4f52-a745-64b2e48f8228" value="Instead of shooting any weapons in the Shooting phase, this model can use its auto launchers; until your next Shooting phase your opponent must subtract 1 from all hit rolls for ranged weapons that target this vehicle."/>
       </characteristics>
     </profile>
-    <profile id="8d29-f390-ff57-d858" name="Rites of Battle (Blood Angels)" hidden="false" profileTypeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" profileTypeName="Abilities">
+    <profile id="cb8d-e1e4-3ca6-9d20" name="Chapter Master (Blood Angels)" hidden="false" profileTypeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" profileTypeName="Abilities">
       <profiles/>
       <rules/>
       <infoLinks/>
       <modifiers/>
       <characteristics>
-        <characteristic name="Description" characteristicTypeId="21befb24-fc85-4f52-a745-64b2e48f8228" value="You can re-roll hit rolls of 1 made for friendly BLOOD ANGELS units within 6&quot; of this model."/>
+        <characteristic name="Description" characteristicTypeId="21befb24-fc85-4f52-a745-64b2e48f8228" value="You can re-roll failed hit rolls for friendly BLOOD ANGELS units within 6&quot; of Commander Dante."/>
       </characteristics>
     </profile>
-    <profile id="8697-90ba-a77e-22ab" name="Litanies of Hate (Blood Angels)" hidden="false" profileTypeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" profileTypeName="Abilities">
+    <profile id="46cc-edf3-5fd4-4a8b" name="Chapter Master (Flesh Tearers)" hidden="false" profileTypeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" profileTypeName="Abilities">
       <profiles/>
       <rules/>
       <infoLinks/>
       <modifiers/>
       <characteristics>
-        <characteristic name="Description" characteristicTypeId="21befb24-fc85-4f52-a745-64b2e48f8228" value="You can re-roll failed hit rolls in the Fight phase for friendly BLOOD ANGELS units within 6&quot; of this model."/>
+        <characteristic name="Description" characteristicTypeId="21befb24-fc85-4f52-a745-64b2e48f8228" value="You can re-roll failed hit rolls for friendly FLESH TEARERS units within 6&quot; of Gabriel Seth."/>
       </characteristics>
     </profile>
-    <profile id="009e-0690-8de7-0d28" name="Narthecium (Blood Angels)" hidden="false" profileTypeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" profileTypeName="Abilities">
+    <profile id="3f03-d1d8-e276-7953" name="Lord of Slaughter" hidden="false" profileTypeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" profileTypeName="Abilities">
       <profiles/>
       <rules/>
       <infoLinks/>
       <modifiers/>
       <characteristics>
-        <characteristic name="Description" characteristicTypeId="21befb24-fc85-4f52-a745-64b2e48f8228" value="At the end of any of your Movement phases, the Apothecary can attempt to heal or revive a single model. Select a friendly BLOOD ANGELS INFANTRY or BIKER unit within 3&quot; of the Apothecary. If that unit contains a wounded model, it immediately regains D3 lost wounds. If the chosen unit contains no wounded models but one or more of its models have been slain during the battle, roll a D6. On a 4+ a single slain model is returned to the unit with 1 wound remaining. If the Apothecary fails to revive a model he can do nothing else for the remainder of the turn (shoot, charge, fight, etc.) as he recovers the gene-seed of the fallen warrior. A unit can only be the target of the Narthecium ability once in each turn."/>
+        <characteristic name="Description" characteristicTypeId="21befb24-fc85-4f52-a745-64b2e48f8228" value="Roll a D6 each time a friendly FLESH TEARERS unit finishes its move within 6&quot; of Gabriel Seth when it consolidates; on a 6 that unit can immediately fight for a second and final time."/>
+      </characteristics>
+    </profile>
+    <profile id="7de1-49cc-8dad-c0b8" name="Whirlwind of Gore" hidden="false" profileTypeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" profileTypeName="Abilities">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <characteristics>
+        <characteristic name="Description" characteristicTypeId="21befb24-fc85-4f52-a745-64b2e48f8228" value="Each time you roll a hit roll of 6+ in the Fight phase, inflict 1 additional hit on the target."/>
+      </characteristics>
+    </profile>
+    <profile id="864f-d20b-8a6f-68a2" name="Aura of Fervour" hidden="false" profileTypeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" profileTypeName="Abilities">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <characteristics>
+        <characteristic name="Description" characteristicTypeId="21befb24-fc85-4f52-a745-64b2e48f8228" value="You can add 1 to the Attacks characteristic of friendly BLOOD ANGELS INFANTRY units within 6&quot; of the Sanguinor."/>
+      </characteristics>
+    </profile>
+    <profile id="14a9-adb9-2854-d505" name="Avenging Angel" hidden="false" profileTypeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" profileTypeName="Abilities">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <characteristics>
+        <characteristic name="Description" characteristicTypeId="21befb24-fc85-4f52-a745-64b2e48f8228" value="The Sanguinor can charge even if he Fell Back in the preceding Movement phase."/>
+      </characteristics>
+    </profile>
+    <profile id="7d74-8891-217b-ed7c" name="Far-Seeing Eye" hidden="false" profileTypeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" profileTypeName="Abilities">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <characteristics>
+        <characteristic name="Description" characteristicTypeId="21befb24-fc85-4f52-a745-64b2e48f8228" value="Once per turn you can re-roll a single dice roll made for Brother Corbulo."/>
+      </characteristics>
+    </profile>
+    <profile id="d7cf-f036-a3b4-1551" name="The Red Grail" hidden="false" profileTypeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" profileTypeName="Abilities">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <characteristics>
+        <characteristic name="Description" characteristicTypeId="21befb24-fc85-4f52-a745-64b2e48f8228" value="Friendly BLOOD ANGELS INFANTRY and BIKER units increase their Strength characteristic by 1 whilst they are within 6&quot; of any SANGUINARY PRIESTS. In addition, each time you make a hit roll of 6+ in the Fight phase for a model in a friendly BLOOD ANGELS unit that is within 6&quot; of Brother Corbulo, that model may immediately make another close combat attack using the same weapons. These bonus attacks cannot themselves generate any additional close combat attacks."/>
+      </characteristics>
+    </profile>
+    <profile id="c892-d4ec-19b0-7c7c" name="Lord of Death" hidden="false" profileTypeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" profileTypeName="Abilities">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <characteristics>
+        <characteristic name="Description" characteristicTypeId="21befb24-fc85-4f52-a745-64b2e48f8228" value="Roll a D6 each time Chief Libraian Mephiston loses a wound. On a 5+ the wound is ignored and has no effect."/>
+      </characteristics>
+    </profile>
+    <profile id="a67d-7d3e-07a2-fdd1" name="Redeemer of the Lost" hidden="false" profileTypeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" profileTypeName="Abilities">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <characteristics>
+        <characteristic name="Description" characteristicTypeId="21befb24-fc85-4f52-a745-64b2e48f8228" value="All friendly BLOOD ANGELS units within 6&quot; of Astorath can use his Leadership instead of their own. In addition, friendly DEATH COMPANY units automatically pass Morale tests if they are within 6&quot; of Astorath."/>
+      </characteristics>
+    </profile>
+    <profile id="f290-bf22-5e14-e8c1" name="Mass of Doom" hidden="false" profileTypeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" profileTypeName="Abilities">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <characteristics>
+        <characteristic name="Description" characteristicTypeId="21befb24-fc85-4f52-a745-64b2e48f8228" value="Once per battle, at the start of your Movement phase, Astorath may chant the Mass of Doom. Roll a D6 for each friendly BLOOD ANGELS INFANTRY unit within 6&quot; of Astorath and apply the result below:  1 - Frenzied Death Throes: The unit suffers a mortal wound. 2-5 - Dark Wrath: You can add 1 to hit rolls made for this unit in the Fight phase until the end of your turn. 6 - Vessel of Sanguinius: You can add 1 to hit rolls made for this unit in the Fight phase until the end of your turn. In addition, the unit has a 4+ invulnerable save until the end of your turn."/>
+      </characteristics>
+    </profile>
+    <profile id="a051-8cfb-aa05-8a9c" name="Fury Unbound" hidden="false" profileTypeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" profileTypeName="Abilities">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <characteristics>
+        <characteristic name="Description" characteristicTypeId="21befb24-fc85-4f52-a745-64b2e48f8228" value="You can re-roll failed charge rolls and failed hit rolls in the Fight phase for friendly DEATH COMPANY units within 6&quot; of Lemartes."/>
+      </characteristics>
+    </profile>
+    <profile id="b8bb-e7b3-5df7-690e" name="Guardian of the Lost" hidden="false" profileTypeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" profileTypeName="Abilities">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <characteristics>
+        <characteristic name="Description" characteristicTypeId="21befb24-fc85-4f52-a745-64b2e48f8228" value="All friendly DEATH COMPANY units within 6&quot; of Lemartes can use his Leadership instead of their own."/>
+      </characteristics>
+    </profile>
+    <profile id="8eed-79b9-bf3e-6fe3" name="Dead Man&apos;s Hand" hidden="false" profileTypeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" profileTypeName="Weapon">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <characteristics>
+        <characteristic name="Range" characteristicTypeId="6fa97fa8-ea74-4a27-a0fb-bc4e5f367464" value="Melee"/>
+        <characteristic name="Type" characteristicTypeId="077c342f-d7b9-45c6-b8af-88e97cafd3a2" value="Melee"/>
+        <characteristic name="S" characteristicTypeId="59b1-319e-ec13-d466" value="User"/>
+        <characteristic name="AP" characteristicTypeId="75aa-a838-b675-6484" value="-2"/>
+        <characteristic name="D" characteristicTypeId="ae8a-3137-d65b-4ca7" value="1"/>
+        <characteristic name="Abilities" characteristicTypeId="837d-5e63-aeb7-1410" value="-"/>
+      </characteristics>
+    </profile>
+    <profile id="7609-c5ba-3a3b-94ec" name="Abhor the Beast" hidden="false" profileTypeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" profileTypeName="Abilities">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <characteristics>
+        <characteristic name="Description" characteristicTypeId="21befb24-fc85-4f52-a745-64b2e48f8228" value="This model may make D3 additional close combat attacks if he is within 1&quot; of any enemy ORKS after he has piled in during the Fight phase."/>
+      </characteristics>
+    </profile>
+    <profile id="5bf8-9a47-a69f-6ade" name="Captain in Cataphractii Armour" hidden="false" profileTypeId="800f-21d0-4387-c943" profileTypeName="Unit">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <characteristics>
+        <characteristic name="M" characteristicTypeId="0bdf-a96e-9e38-7779" value="4&quot;"/>
+        <characteristic name="WS" characteristicTypeId="e7f0-1278-0250-df0c" value="2+"/>
+        <characteristic name="BS" characteristicTypeId="381b-eb28-74c3-df5f" value="2+"/>
+        <characteristic name="S" characteristicTypeId="2218-aa3c-265f-2939" value="4"/>
+        <characteristic name="T" characteristicTypeId="9c9f-9774-a358-3a39" value="4"/>
+        <characteristic name="W" characteristicTypeId="f330-5e6e-4110-0978" value="6"/>
+        <characteristic name="A" characteristicTypeId="13fc-b29b-31f2-ab9f" value="4"/>
+        <characteristic name="Ld" characteristicTypeId="00ca-f8b8-876d-b705" value="9"/>
+        <characteristic name="Save" characteristicTypeId="c0df-df94-abd7-e8d3" value="2+"/>
+      </characteristics>
+    </profile>
+    <profile id="7b98-a493-7bcb-08a9" name="Cataphractii Armour and Iron Halo" hidden="false" profileTypeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" profileTypeName="Abilities">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <characteristics>
+        <characteristic name="Description" characteristicTypeId="21befb24-fc85-4f52-a745-64b2e48f8228" value="This model has a 3+ invulnerable save, but you must halve the result of the dice rolled when determining how far this model Advances."/>
+      </characteristics>
+    </profile>
+    <profile id="0ebd-45e5-3eb6-d9e0" name="Company Heroes" hidden="false" profileTypeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" profileTypeName="Abilities">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <characteristics>
+        <characteristic name="Description" characteristicTypeId="21befb24-fc85-4f52-a745-64b2e48f8228" value="During deployment, all models in this unit must be set up in unit coherency. From that point onwards, each Primaris Lieutenant is treated as a separate unit."/>
+      </characteristics>
+    </profile>
+    <profile id="30ec-37fb-8737-4b5e" name="Lieutenant" hidden="false" profileTypeId="800f-21d0-4387-c943" profileTypeName="Unit">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <characteristics>
+        <characteristic name="M" characteristicTypeId="0bdf-a96e-9e38-7779" value="6&quot;"/>
+        <characteristic name="WS" characteristicTypeId="e7f0-1278-0250-df0c" value="2+"/>
+        <characteristic name="BS" characteristicTypeId="381b-eb28-74c3-df5f" value="3+"/>
+        <characteristic name="S" characteristicTypeId="2218-aa3c-265f-2939" value="4"/>
+        <characteristic name="T" characteristicTypeId="9c9f-9774-a358-3a39" value="4"/>
+        <characteristic name="W" characteristicTypeId="f330-5e6e-4110-0978" value="4"/>
+        <characteristic name="A" characteristicTypeId="13fc-b29b-31f2-ab9f" value="3"/>
+        <characteristic name="Ld" characteristicTypeId="00ca-f8b8-876d-b705" value="8"/>
+        <characteristic name="Save" characteristicTypeId="c0df-df94-abd7-e8d3" value="3+"/>
+      </characteristics>
+    </profile>
+    <profile id="7d16-8f31-c8ac-339b" name="Concealed Positions" hidden="false" profileTypeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" profileTypeName="Abilities">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <characteristics>
+        <characteristic name="Description" characteristicTypeId="21befb24-fc85-4f52-a745-64b2e48f8228" value="When you set up this unit during deployment, it can be set up anywhere on the battlefield that is more than 9&quot; from the enemy deployment zone and any enemy models."/>
+      </characteristics>
+    </profile>
+    <profile id="f604-9de6-748d-422c" name="Blood Angels Chapter Banner" hidden="false" profileTypeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" profileTypeName="Abilities">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <characteristics>
+        <characteristic name="Description" characteristicTypeId="21befb24-fc85-4f52-a745-64b2e48f8228" value="BLOOD ANGELS units within 6&quot; of any friendly BLOOD ANGELS ANCIENTS add 1 to their Leadership. In addition, you can re-roll wound rolls of 1 in the Fight phase for friendly BLOOD ANGELS units within 6&quot; of this model."/>
+      </characteristics>
+    </profile>
+    <profile id="4a79-e8eb-c017-08c5" name="Insatiable" hidden="false" profileTypeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" profileTypeName="Abilities">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <characteristics>
+        <characteristic name="Description" characteristicTypeId="21befb24-fc85-4f52-a745-64b2e48f8228" value="This model may move up to 6&quot; when consolidating at the end of the Fight phase."/>
+      </characteristics>
+    </profile>
+    <profile id="2cb8-428d-9a50-6b53" name="Mindlock" hidden="false" profileTypeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" profileTypeName="Abilities">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <characteristics>
+        <characteristic name="Description" characteristicTypeId="21befb24-fc85-4f52-a745-64b2e48f8228" value="Servitors improve both their Weapon Skill and Ballistic Skill to 4+, and their Leadership to 9, whilst they are within 6&quot; of any friendly TECHMARINES."/>
+      </characteristics>
+    </profile>
+    <profile id="7936-65c7-1887-2388" name="Archangel Standard" hidden="false" profileTypeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" profileTypeName="Abilities">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <characteristics>
+        <characteristic name="Description" characteristicTypeId="21befb24-fc85-4f52-a745-64b2e48f8228" value="BLOOD ANGELS units within 6&quot; of any friendly BLOOD ANGELS ANCIENTS add 1 to their Leadership characteristic. In addition, you can re-roll any failed hit rolls in the Fight phase for friendly BLOOD ANGELS units within 6&quot; of this model."/>
+      </characteristics>
+    </profile>
+    <profile id="e834-3e76-82c6-77fa" name="Cataphractii Terminator" hidden="false" profileTypeId="800f-21d0-4387-c943" profileTypeName="Unit">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <characteristics>
+        <characteristic name="M" characteristicTypeId="0bdf-a96e-9e38-7779" value="4&quot;"/>
+        <characteristic name="WS" characteristicTypeId="e7f0-1278-0250-df0c" value="3+"/>
+        <characteristic name="BS" characteristicTypeId="381b-eb28-74c3-df5f" value="3+"/>
+        <characteristic name="S" characteristicTypeId="2218-aa3c-265f-2939" value="4"/>
+        <characteristic name="T" characteristicTypeId="9c9f-9774-a358-3a39" value="4"/>
+        <characteristic name="W" characteristicTypeId="f330-5e6e-4110-0978" value="2"/>
+        <characteristic name="A" characteristicTypeId="13fc-b29b-31f2-ab9f" value="2"/>
+        <characteristic name="Ld" characteristicTypeId="00ca-f8b8-876d-b705" value="8"/>
+        <characteristic name="Save" characteristicTypeId="c0df-df94-abd7-e8d3" value="2+"/>
+      </characteristics>
+    </profile>
+    <profile id="8dd8-1119-4c11-dfbd" name="Cataphractii Sergeant" hidden="false" profileTypeId="800f-21d0-4387-c943" profileTypeName="Unit">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <characteristics>
+        <characteristic name="M" characteristicTypeId="0bdf-a96e-9e38-7779" value="4&quot;"/>
+        <characteristic name="WS" characteristicTypeId="e7f0-1278-0250-df0c" value="3+"/>
+        <characteristic name="BS" characteristicTypeId="381b-eb28-74c3-df5f" value="3+"/>
+        <characteristic name="S" characteristicTypeId="2218-aa3c-265f-2939" value="4"/>
+        <characteristic name="T" characteristicTypeId="9c9f-9774-a358-3a39" value="4"/>
+        <characteristic name="W" characteristicTypeId="f330-5e6e-4110-0978" value="2"/>
+        <characteristic name="A" characteristicTypeId="13fc-b29b-31f2-ab9f" value="3"/>
+        <characteristic name="Ld" characteristicTypeId="00ca-f8b8-876d-b705" value="9"/>
+        <characteristic name="Save" characteristicTypeId="c0df-df94-abd7-e8d3" value="2+"/>
+      </characteristics>
+    </profile>
+    <profile id="513c-7a02-27a5-7f86" name="Cataphractii Armour" hidden="false" profileTypeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" profileTypeName="Abilities">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <characteristics>
+        <characteristic name="Description" characteristicTypeId="21befb24-fc85-4f52-a745-64b2e48f8228" value="Models in this unit have a 4+ invulnerable save, but you must halve the result of the dice rolled when determining how far this unit Advances."/>
+      </characteristics>
+    </profile>
+    <profile id="7830-200d-5dc6-9209" name="Tartaros Terminator" hidden="false" profileTypeId="800f-21d0-4387-c943" profileTypeName="Unit">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <characteristics>
+        <characteristic name="M" characteristicTypeId="0bdf-a96e-9e38-7779" value="6&quot;"/>
+        <characteristic name="WS" characteristicTypeId="e7f0-1278-0250-df0c" value="3+"/>
+        <characteristic name="BS" characteristicTypeId="381b-eb28-74c3-df5f" value="3+"/>
+        <characteristic name="S" characteristicTypeId="2218-aa3c-265f-2939" value="4"/>
+        <characteristic name="T" characteristicTypeId="9c9f-9774-a358-3a39" value="4"/>
+        <characteristic name="W" characteristicTypeId="f330-5e6e-4110-0978" value="2"/>
+        <characteristic name="A" characteristicTypeId="13fc-b29b-31f2-ab9f" value="2"/>
+        <characteristic name="Ld" characteristicTypeId="00ca-f8b8-876d-b705" value="8"/>
+        <characteristic name="Save" characteristicTypeId="c0df-df94-abd7-e8d3" value="2+"/>
+      </characteristics>
+    </profile>
+    <profile id="a6c0-d093-2681-5674" name="Tartaros Sergeant" hidden="false" profileTypeId="800f-21d0-4387-c943" profileTypeName="Unit">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <characteristics>
+        <characteristic name="M" characteristicTypeId="0bdf-a96e-9e38-7779" value="6&quot;"/>
+        <characteristic name="WS" characteristicTypeId="e7f0-1278-0250-df0c" value="3+"/>
+        <characteristic name="BS" characteristicTypeId="381b-eb28-74c3-df5f" value="3+"/>
+        <characteristic name="S" characteristicTypeId="2218-aa3c-265f-2939" value="4"/>
+        <characteristic name="T" characteristicTypeId="9c9f-9774-a358-3a39" value="4"/>
+        <characteristic name="W" characteristicTypeId="f330-5e6e-4110-0978" value="2"/>
+        <characteristic name="A" characteristicTypeId="13fc-b29b-31f2-ab9f" value="3"/>
+        <characteristic name="Ld" characteristicTypeId="00ca-f8b8-876d-b705" value="9"/>
+        <characteristic name="Save" characteristicTypeId="c0df-df94-abd7-e8d3" value="2+"/>
+      </characteristics>
+    </profile>
+    <profile id="e28b-6386-03ab-ad31" name="Tartaros Armour" hidden="false" profileTypeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" profileTypeName="Abilities">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <characteristics>
+        <characteristic name="Description" characteristicTypeId="21befb24-fc85-4f52-a745-64b2e48f8228" value="Models in this unit have a 5+ invulnerable save."/>
+      </characteristics>
+    </profile>
+    <profile id="bde6-3c93-9492-da0e" name="Contemptor Dreadnought" hidden="false" profileTypeId="800f-21d0-4387-c943" profileTypeName="Unit">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <characteristics>
+        <characteristic name="M" characteristicTypeId="0bdf-a96e-9e38-7779" value="*"/>
+        <characteristic name="WS" characteristicTypeId="e7f0-1278-0250-df0c" value="*"/>
+        <characteristic name="BS" characteristicTypeId="381b-eb28-74c3-df5f" value="*"/>
+        <characteristic name="S" characteristicTypeId="2218-aa3c-265f-2939" value="7"/>
+        <characteristic name="T" characteristicTypeId="9c9f-9774-a358-3a39" value="7"/>
+        <characteristic name="W" characteristicTypeId="f330-5e6e-4110-0978" value="10"/>
+        <characteristic name="A" characteristicTypeId="13fc-b29b-31f2-ab9f" value="4"/>
+        <characteristic name="Ld" characteristicTypeId="00ca-f8b8-876d-b705" value="8"/>
+        <characteristic name="Save" characteristicTypeId="c0df-df94-abd7-e8d3" value="3+"/>
+      </characteristics>
+    </profile>
+    <profile id="b469-e56f-6da0-9dbe" name="Atomantic Shielding" hidden="false" profileTypeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" profileTypeName="Abilities">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <characteristics>
+        <characteristic name="Description" characteristicTypeId="21befb24-fc85-4f52-a745-64b2e48f8228" value="This model has a 5+ invulnerable save."/>
+      </characteristics>
+    </profile>
+    <profile id="444f-1f1f-a9a6-f302" name="Armorium Cherub" hidden="false" profileTypeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" profileTypeName="Abilities">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <characteristics>
+        <characteristic name="Description" characteristicTypeId="21befb24-fc85-4f52-a745-64b2e48f8228" value="Once per game, after a model in a Devastator Squad that is accompanied by an Armorium Cherub has fired, the Armorium Cherub can reload that model&apos;s weapons. When it does so, remove the Armorium Cherub and that model can immediately shoot again. The removal of an Armorium Cherub (for any reason) is ignored for the purposes of morale. The Armorium Cherub does not count as a model for the purposes of Combat Squads ability. If a Devastator Squad is split using the Combat Squads ability, the Armorium Cherub must accompany one of the units."/>
+      </characteristics>
+    </profile>
+    <profile id="7864-15b6-247d-2bed" name="Overcharged Engines" hidden="false" profileTypeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" profileTypeName="Abilities">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <characteristics>
+        <characteristic name="Description" characteristicTypeId="21befb24-fc85-4f52-a745-64b2e48f8228" value="When this model Advances roll 2 dice and pick the highest result."/>
+      </characteristics>
+    </profile>
+    <profile id="75da-64fd-47bc-daa7" name="Hunter" hidden="false" profileTypeId="800f-21d0-4387-c943" profileTypeName="Unit">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <characteristics>
+        <characteristic name="M" characteristicTypeId="0bdf-a96e-9e38-7779" value="*"/>
+        <characteristic name="WS" characteristicTypeId="e7f0-1278-0250-df0c" value="6+"/>
+        <characteristic name="BS" characteristicTypeId="381b-eb28-74c3-df5f" value="*"/>
+        <characteristic name="S" characteristicTypeId="2218-aa3c-265f-2939" value="6"/>
+        <characteristic name="T" characteristicTypeId="9c9f-9774-a358-3a39" value="8"/>
+        <characteristic name="W" characteristicTypeId="f330-5e6e-4110-0978" value="11"/>
+        <characteristic name="A" characteristicTypeId="13fc-b29b-31f2-ab9f" value="*"/>
+        <characteristic name="Ld" characteristicTypeId="00ca-f8b8-876d-b705" value="8"/>
+        <characteristic name="Save" characteristicTypeId="c0df-df94-abd7-e8d3" value="3+"/>
+      </characteristics>
+    </profile>
+    <profile id="88bd-6f9c-3a0e-eaa3" name="Stalker" hidden="false" profileTypeId="800f-21d0-4387-c943" profileTypeName="Unit">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <characteristics>
+        <characteristic name="M" characteristicTypeId="0bdf-a96e-9e38-7779" value="*"/>
+        <characteristic name="WS" characteristicTypeId="e7f0-1278-0250-df0c" value="6+"/>
+        <characteristic name="BS" characteristicTypeId="381b-eb28-74c3-df5f" value="*"/>
+        <characteristic name="S" characteristicTypeId="2218-aa3c-265f-2939" value="6"/>
+        <characteristic name="T" characteristicTypeId="9c9f-9774-a358-3a39" value="8"/>
+        <characteristic name="W" characteristicTypeId="f330-5e6e-4110-0978" value="11"/>
+        <characteristic name="A" characteristicTypeId="13fc-b29b-31f2-ab9f" value="*"/>
+        <characteristic name="Ld" characteristicTypeId="00ca-f8b8-876d-b705" value="8"/>
+        <characteristic name="Save" characteristicTypeId="c0df-df94-abd7-e8d3" value="3+"/>
+      </characteristics>
+    </profile>
+    <profile id="35ee-b59e-db25-3f3e" name="Land Speeder Storm" hidden="false" profileTypeId="800f-21d0-4387-c943" profileTypeName="Unit">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <characteristics>
+        <characteristic name="M" characteristicTypeId="0bdf-a96e-9e38-7779" value="18&quot;"/>
+        <characteristic name="WS" characteristicTypeId="e7f0-1278-0250-df0c" value="3+"/>
+        <characteristic name="BS" characteristicTypeId="381b-eb28-74c3-df5f" value="3+"/>
+        <characteristic name="S" characteristicTypeId="2218-aa3c-265f-2939" value="4"/>
+        <characteristic name="T" characteristicTypeId="9c9f-9774-a358-3a39" value="5"/>
+        <characteristic name="W" characteristicTypeId="f330-5e6e-4110-0978" value="7"/>
+        <characteristic name="A" characteristicTypeId="13fc-b29b-31f2-ab9f" value="2"/>
+        <characteristic name="Ld" characteristicTypeId="00ca-f8b8-876d-b705" value="7"/>
+        <characteristic name="Save" characteristicTypeId="c0df-df94-abd7-e8d3" value="4+"/>
+      </characteristics>
+    </profile>
+    <profile id="f8f1-812d-e46a-841a" name="Open-topped" hidden="false" profileTypeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" profileTypeName="Abilities">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <characteristics>
+        <characteristic name="Description" characteristicTypeId="21befb24-fc85-4f52-a745-64b2e48f8228" value="Models embarked on this vehicle can shoot in their Shooting phase. They measure range and draw line of sight from any point on the vehicle. When they do so, any restrictions or modifiers that apply to this model also apply to its passengers; for example, the passengers cannot shoot if this model has Fallen back in the same turn, cannot shoot (except with Pistols) if this model is within 1&quot; of an enemy unit, and so on. Note that the passengers cannot shoot if this model Falls Back, even though the Land Speeder Storm itself can."/>
+      </characteristics>
+    </profile>
+    <profile id="7738-1e58-d25e-ed32" name="Stormhawk Interceptor" hidden="false" profileTypeId="800f-21d0-4387-c943" profileTypeName="Unit">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <characteristics>
+        <characteristic name="M" characteristicTypeId="0bdf-a96e-9e38-7779" value="*"/>
+        <characteristic name="WS" characteristicTypeId="e7f0-1278-0250-df0c" value="6+"/>
+        <characteristic name="BS" characteristicTypeId="381b-eb28-74c3-df5f" value="*"/>
+        <characteristic name="S" characteristicTypeId="2218-aa3c-265f-2939" value="6"/>
+        <characteristic name="T" characteristicTypeId="9c9f-9774-a358-3a39" value="7"/>
+        <characteristic name="W" characteristicTypeId="f330-5e6e-4110-0978" value="10"/>
+        <characteristic name="A" characteristicTypeId="13fc-b29b-31f2-ab9f" value="*"/>
+        <characteristic name="Ld" characteristicTypeId="00ca-f8b8-876d-b705" value="8"/>
+        <characteristic name="Save" characteristicTypeId="c0df-df94-abd7-e8d3" value="3+"/>
+      </characteristics>
+    </profile>
+    <profile id="3970-342a-bea2-806f" name="Stormtalon Gunship" hidden="false" profileTypeId="800f-21d0-4387-c943" profileTypeName="Unit">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <characteristics>
+        <characteristic name="M" characteristicTypeId="0bdf-a96e-9e38-7779" value="*"/>
+        <characteristic name="WS" characteristicTypeId="e7f0-1278-0250-df0c" value="6+"/>
+        <characteristic name="BS" characteristicTypeId="381b-eb28-74c3-df5f" value="*"/>
+        <characteristic name="S" characteristicTypeId="2218-aa3c-265f-2939" value="6"/>
+        <characteristic name="T" characteristicTypeId="9c9f-9774-a358-3a39" value="6"/>
+        <characteristic name="W" characteristicTypeId="f330-5e6e-4110-0978" value="10"/>
+        <characteristic name="A" characteristicTypeId="13fc-b29b-31f2-ab9f" value="*"/>
+        <characteristic name="Ld" characteristicTypeId="00ca-f8b8-876d-b705" value="8"/>
+        <characteristic name="Save" characteristicTypeId="c0df-df94-abd7-e8d3" value="3+"/>
+      </characteristics>
+    </profile>
+    <profile id="5612-a7b4-ed49-63e2" name="Airborne" hidden="false" profileTypeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" profileTypeName="Abilities">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <characteristics>
+        <characteristic name="Description" characteristicTypeId="21befb24-fc85-4f52-a745-64b2e48f8228" value="This model cannot charge, can only be charged by units that can FLY, and can only attack or be attacked in the Fight phase by units that can FLY."/>
+      </characteristics>
+    </profile>
+    <profile id="05fe-231e-bd86-86e4" name="Hard to Hit" hidden="false" profileTypeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" profileTypeName="Abilities">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <characteristics>
+        <characteristic name="Description" characteristicTypeId="21befb24-fc85-4f52-a745-64b2e48f8228" value="Your opponent must subtract 1 from hit rolls for attacks that target this model in the Shooting phase."/>
+      </characteristics>
+    </profile>
+    <profile id="d061-4605-a6f7-0b4c" name="Hover Jet" hidden="false" profileTypeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" profileTypeName="Abilities">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <characteristics>
+        <characteristic name="Description" characteristicTypeId="21befb24-fc85-4f52-a745-64b2e48f8228" value="Before this model moves in your Movement phase, you can declare it will hover. Its Move characteristic becomes 20&quot; until the end of the phase, and it loses the Airborne, Hard to Hit and Supersonic abilities until the beginning of your next Movement phase."/>
+      </characteristics>
+    </profile>
+    <profile id="c5ca-67fb-3f1a-5a0b" name="Supersonic" hidden="false" profileTypeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" profileTypeName="Abilities">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <characteristics>
+        <characteristic name="Description" characteristicTypeId="21befb24-fc85-4f52-a745-64b2e48f8228" value="Each time this model moves, first pivot it on the spot up to 90° (this does not contribute to how far the model moves), and then move the model straight forwards. Note that it cannot pivot again after the initial pivot. When this model Advances, increase its Move characteristic by 20&quot; until the end of the phase - do not roll a dice."/>
+      </characteristics>
+    </profile>
+    <profile id="c129-a8e6-9cca-e132" name="Infernum Halo-launcher" hidden="false" profileTypeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" profileTypeName="Abilities">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <characteristics>
+        <characteristic name="Description" characteristicTypeId="21befb24-fc85-4f52-a745-64b2e48f8228" value="You can re-roll save rolls of 1 for this model."/>
+      </characteristics>
+    </profile>
+    <profile id="e5e9-776c-a573-ec03" name="Interceptor" hidden="false" profileTypeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" profileTypeName="Abilities">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <characteristics>
+        <characteristic name="Description" characteristicTypeId="21befb24-fc85-4f52-a745-64b2e48f8228" value="You can add 1 to hit rolls for this model when targeting an enemy in the Shooting phase that can FLY."/>
+      </characteristics>
+    </profile>
+    <profile id="78ec-3915-059d-a723" name="Strafing Run" hidden="false" profileTypeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" profileTypeName="Abilities">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <characteristics>
+        <characteristic name="Description" characteristicTypeId="21befb24-fc85-4f52-a745-64b2e48f8228" value="You can add 1 to hit rolls for this model when targeting an enemy in the Shooting phase that cannot FLY."/>
+      </characteristics>
+    </profile>
+    <profile id="46f2-9ac2-a4df-4508" name="The Hammer of Baal" hidden="false" profileTypeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" profileTypeName="Weapon">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <characteristics>
+        <characteristic name="Range" characteristicTypeId="6fa97fa8-ea74-4a27-a0fb-bc4e5f367464" value="Melee"/>
+        <characteristic name="Type" characteristicTypeId="077c342f-d7b9-45c6-b8af-88e97cafd3a2" value="Melee"/>
+        <characteristic name="S" characteristicTypeId="59b1-319e-ec13-d466" value="x2"/>
+        <characteristic name="AP" characteristicTypeId="75aa-a838-b675-6484" value="-3"/>
+        <characteristic name="D" characteristicTypeId="ae8a-3137-d65b-4ca7" value="3"/>
+        <characteristic name="Abilities" characteristicTypeId="837d-5e63-aeb7-1410" value="-"/>
+      </characteristics>
+    </profile>
+    <profile id="ddb3-ec71-ab5d-9c29" name="The Angel&apos;s Wing" hidden="false" profileTypeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" profileTypeName="Abilities">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <characteristics>
+        <characteristic name="Description" characteristicTypeId="21befb24-fc85-4f52-a745-64b2e48f8228" value="You can re-roll failed charge rolls for a model equipped with the Angel&apos;s Wing, and your opponent cannot fire Overwatch against them."/>
+      </characteristics>
+    </profile>
+    <profile id="da00-db89-76b1-8fd0" name="The Veritas Vitae" hidden="false" profileTypeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" profileTypeName="Abilities">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <characteristics>
+        <characteristic name="Description" characteristicTypeId="21befb24-fc85-4f52-a745-64b2e48f8228" value="If your army is Battle-forged and the bearer is on the battlefield, roll a D6 each time you use a Stratagem; on a 5+, you gain a Command Point."/>
+      </characteristics>
+    </profile>
+    <profile id="5830-68e3-f762-f066" name="Gallian&apos;s Staff" hidden="false" profileTypeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" profileTypeName="Weapon">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <characteristics>
+        <characteristic name="Range" characteristicTypeId="6fa97fa8-ea74-4a27-a0fb-bc4e5f367464" value="Melee"/>
+        <characteristic name="Type" characteristicTypeId="077c342f-d7b9-45c6-b8af-88e97cafd3a2" value="Melee"/>
+        <characteristic name="S" characteristicTypeId="59b1-319e-ec13-d466" value="+2"/>
+        <characteristic name="AP" characteristicTypeId="75aa-a838-b675-6484" value="-1"/>
+        <characteristic name="D" characteristicTypeId="ae8a-3137-d65b-4ca7" value="D3"/>
+        <characteristic name="Abilities" characteristicTypeId="837d-5e63-aeb7-1410" value="You can add 1 to the bearer&apos;s Psychic test when attempting to manifest the Smite psychic power."/>
+      </characteristics>
+    </profile>
+    <profile id="2bb8-1f87-1d4b-59de" name="Archangel&apos;s Shard" hidden="false" profileTypeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" profileTypeName="Weapon">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <characteristics>
+        <characteristic name="Range" characteristicTypeId="6fa97fa8-ea74-4a27-a0fb-bc4e5f367464" value="Melee"/>
+        <characteristic name="Type" characteristicTypeId="077c342f-d7b9-45c6-b8af-88e97cafd3a2" value="Melee"/>
+        <characteristic name="S" characteristicTypeId="59b1-319e-ec13-d466" value="User"/>
+        <characteristic name="AP" characteristicTypeId="75aa-a838-b675-6484" value="-3"/>
+        <characteristic name="D" characteristicTypeId="ae8a-3137-d65b-4ca7" value="1"/>
+        <characteristic name="Abilities" characteristicTypeId="837d-5e63-aeb7-1410" value="If the target is a MONSTER, this weapon has a Damage characteristic of D3. If the target is a DAEMON MONSTER, this weapon has a Damage characteristic of D6 instead."/>
+      </characteristics>
+    </profile>
+    <profile id="bd64-21ad-57a1-4fad" name="Standard of Sacrifice" hidden="false" profileTypeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" profileTypeName="Abilities">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <characteristics>
+        <characteristic name="Description" characteristicTypeId="21befb24-fc85-4f52-a745-64b2e48f8228" value="The bearer of the Standard of Sacrifice gains the following ability in addition to those described on their datasheet: Roll a D6 each time a friendly BLOOD ANGELS INFANTRY or BLOOD ANGELS BIKER model within 6&quot; of the bearer loses a wound; on a 5+, the wound is ignored and has no effect. Models with the Black Rage ability are not affected."/>
       </characteristics>
     </profile>
   </sharedProfiles>


### PR DESCRIPTION
Replaced all wargear entries with links from GST (where appropriate and available).
Updated all datasheets (including points) according to Codex.
New datasheets added.
Warlord traits added.
Psychic powers added.
Relics added.