### PR TITLE
Chaos - Death Guard - Keyword Updates via Categories - Elites, Fast Attack, Heavy Support, Dedicated Transport, and Lord of War  -- also add smoke launchers to Predator

### DIFF
--- a/Chaos - Death Guard.cat
+++ b/Chaos - Death Guard.cat
@@ -205,6 +205,146 @@
       <modifiers/>
       <constraints/>
     </categoryEntry>
+    <categoryEntry id="6f8e-4937-f16f-d32b" name="Noxious Blightbringer" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints/>
+    </categoryEntry>
+    <categoryEntry id="af22-997e-da42-e651" name="Foul Blightspawn" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints/>
+    </categoryEntry>
+    <categoryEntry id="ecd7-299f-e997-1548" name="Biologus Putrifier" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints/>
+    </categoryEntry>
+    <categoryEntry id="8d6d-3d6a-dcc9-5731" name="Plague Surgeon" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints/>
+    </categoryEntry>
+    <categoryEntry id="e936-731d-fadb-a113" name="Tallyman" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints/>
+    </categoryEntry>
+    <categoryEntry id="2110-97af-25b6-2eb8" name="Deathshroud" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints/>
+    </categoryEntry>
+    <categoryEntry id="1e74-2c48-7179-152e" name="Blightlord Terminators" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints/>
+    </categoryEntry>
+    <categoryEntry id="5356-a75a-02b3-49e3" name="Helbrute" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints/>
+    </categoryEntry>
+    <categoryEntry id="1d9c-2ef0-0695-e179" name="Beasts of Nurgle" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints/>
+    </categoryEntry>
+    <categoryEntry id="acd7-5577-5a74-bfef" name="Possessed" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints/>
+    </categoryEntry>
+    <categoryEntry id="0472-13fb-7016-2059" name="Foetid Bloat-drone" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints/>
+    </categoryEntry>
+    <categoryEntry id="0053-39d8-9506-8bc8" name="Myphitic Blight-haulers" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints/>
+    </categoryEntry>
+    <categoryEntry id="8a15-9612-41c6-2e02" name="Chaos Spawn" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints/>
+    </categoryEntry>
+    <categoryEntry id="4baf-bddb-d1d6-e66d" name="Plague Drones" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints/>
+    </categoryEntry>
+    <categoryEntry id="d86f-a7f9-e09a-3ab3" name="Chaos Land Raider" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints/>
+    </categoryEntry>
+    <categoryEntry id="b865-e6f2-4c59-ccb8" name="Plagueburst Crawler" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints/>
+    </categoryEntry>
+    <categoryEntry id="5dbc-e607-0dce-b9f0" name="Defiler" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints/>
+    </categoryEntry>
+    <categoryEntry id="ce96-2f80-a7fa-5630" name="Chaos Predator" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints/>
+    </categoryEntry>
+    <categoryEntry id="7627-d7ef-6d16-fc76" name="Chaos Rhino" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints/>
+    </categoryEntry>
+    <categoryEntry id="c940-6653-e034-772f" name="Mortarion" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints/>
+    </categoryEntry>
   </categoryEntries>
   <forceEntries/>
   <selectionEntries/>
@@ -241,7 +381,7 @@
       <constraints/>
       <categoryLinks/>
     </entryLink>
-    <entryLink id="8d04-1842-4c3f-0d5f" name="New EntryLink" hidden="false" targetId="6c90-74d4-6e66-cb10" type="selectionEntry">
+    <entryLink id="8d04-1842-4c3f-0d5f" name="Chaos Land Raider" hidden="false" targetId="6c90-74d4-6e66-cb10" type="selectionEntry">
       <profiles/>
       <rules/>
       <infoLinks/>
@@ -774,6 +914,13 @@
           <modifiers/>
           <constraints/>
         </categoryLink>
+        <categoryLink id="470f-b087-39e3-b1d4" name="New CategoryLink" hidden="false" targetId="ce96-2f80-a7fa-5630" primary="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
       </categoryLinks>
       <selectionEntries/>
       <selectionEntryGroups>
@@ -901,7 +1048,7 @@
         </selectionEntryGroup>
       </selectionEntryGroups>
       <entryLinks>
-        <entryLink id="1f14-3677-3768-e2d3" name="New EntryLink" hidden="false" targetId="f668-0ff7-69d5-be65" type="selectionEntry">
+        <entryLink id="1f14-3677-3768-e2d3" name="Havoc launcher" hidden="false" targetId="f668-0ff7-69d5-be65" type="selectionEntry">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -915,6 +1062,17 @@
           <infoLinks/>
           <modifiers/>
           <constraints/>
+          <categoryLinks/>
+        </entryLink>
+        <entryLink id="bd00-8391-5c20-ac65" name="Smoke launchers" hidden="false" targetId="a8f6-49e7-ea35-aca5" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="aa91-3ddc-6ae9-2188" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e874-ec40-b283-bf40" type="max"/>
+          </constraints>
           <categoryLinks/>
         </entryLink>
       </entryLinks>
@@ -985,6 +1143,13 @@
           <constraints/>
         </categoryLink>
         <categoryLink id="80ad-e0d3-d78a-d0a8" name="New CategoryLink" hidden="false" targetId="5cf1-acf2-ca3b-c2e5" primary="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
+        <categoryLink id="e62e-8de0-c398-4b1c" name="New CategoryLink" hidden="false" targetId="8a15-9612-41c6-2e02" primary="false">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -1475,6 +1640,13 @@
           <modifiers/>
           <constraints/>
         </categoryLink>
+        <categoryLink id="6155-ff21-ce0d-5024" name="New CategoryLink" hidden="false" targetId="5dbc-e607-0dce-b9f0" primary="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="a065-6733-00d0-cdf5" name="Defiler claws" hidden="false" collective="false" type="upgrade">
@@ -1652,7 +1824,7 @@
           <constraints/>
           <categoryLinks/>
         </entryLink>
-        <entryLink id="1f5f-6312-4edd-d675" name="New EntryLink" hidden="false" targetId="a8f6-49e7-ea35-aca5" type="selectionEntry">
+        <entryLink id="1f5f-6312-4edd-d675" name="Smoke launchers" hidden="false" targetId="a8f6-49e7-ea35-aca5" type="selectionEntry">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -2180,6 +2352,13 @@
           <constraints/>
         </categoryLink>
         <categoryLink id="7b3a-30b8-d9a9-d284" name="New CategoryLink" hidden="false" targetId="5cf1-acf2-ca3b-c2e5" primary="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
+        <categoryLink id="beaa-13d8-a91e-e37a" name="New CategoryLink" hidden="false" targetId="0472-13fb-7016-2059" primary="false">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -3809,6 +3988,13 @@
           <modifiers/>
           <constraints/>
         </categoryLink>
+        <categoryLink id="a1d4-e074-4c78-17c3" name="New CategoryLink" hidden="false" targetId="acd7-5577-5a74-bfef" primary="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="b970-b66d-897d-3182" name="Possessed" page="" hidden="false" collective="false" type="model">
@@ -4040,6 +4226,13 @@
           <constraints/>
         </categoryLink>
         <categoryLink id="ed80-e9e9-dfa0-0b62" name="New CategoryLink" hidden="false" targetId="5cf1-acf2-ca3b-c2e5" primary="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
+        <categoryLink id="1998-6dc8-5b2f-822c" name="New CategoryLink" hidden="false" targetId="5356-a75a-02b3-49e3" primary="false">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -4421,6 +4614,13 @@
           <constraints/>
         </categoryLink>
         <categoryLink id="e5f9-9626-5b58-cc0d" name="New CategoryLink" hidden="false" targetId="5cf1-acf2-ca3b-c2e5" primary="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
+        <categoryLink id="e870-4e5e-ebb0-efab" name="New CategoryLink" hidden="false" targetId="7627-d7ef-6d16-fc76" primary="false">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -5666,13 +5866,6 @@
           <modifiers/>
           <constraints/>
         </categoryLink>
-        <categoryLink id="f5ac-7234-05b6-f6b7" name="New CategoryLink" hidden="false" targetId="e691-aad7-d21c-1023" primary="false">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints/>
-        </categoryLink>
         <categoryLink id="1e6b-d42d-1994-6a94" name="New CategoryLink" hidden="false" targetId="638d74c6-bd97-4de5-b65a-6aaa24e9f4b2" primary="true">
           <profiles/>
           <rules/>
@@ -5681,6 +5874,13 @@
           <constraints/>
         </categoryLink>
         <categoryLink id="5886-b5df-0c09-19f8" name="New CategoryLink" hidden="false" targetId="5cf1-acf2-ca3b-c2e5" primary="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
+        <categoryLink id="b91e-04c8-71f3-e441" name="New CategoryLink" hidden="false" targetId="6f8e-4937-f16f-d32b" primary="false">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -5919,6 +6119,13 @@
           <modifiers/>
           <constraints/>
         </categoryLink>
+        <categoryLink id="63ab-e234-b4f9-a003" name="New CategoryLink" hidden="false" targetId="d86f-a7f9-e09a-3ab3" primary="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="9ce6-e5bc-09c6-6546" name="Twin lascannon" hidden="false" collective="false" type="upgrade">
@@ -5970,7 +6177,7 @@
           </constraints>
           <categoryLinks/>
         </entryLink>
-        <entryLink id="5b9f-f78d-1928-f97b" name="New EntryLink" hidden="false" targetId="a8f6-49e7-ea35-aca5" type="selectionEntry">
+        <entryLink id="5b9f-f78d-1928-f97b" name="Smoke launchers" hidden="false" targetId="a8f6-49e7-ea35-aca5" type="selectionEntry">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -6729,6 +6936,13 @@
           <modifiers/>
           <constraints/>
         </categoryLink>
+        <categoryLink id="0ca5-36d1-689d-7479" name="New CategoryLink" hidden="false" targetId="c940-6653-e034-772f" primary="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="32e8-7356-020c-796c" name="Silence" hidden="false" collective="false" type="upgrade">
@@ -7043,6 +7257,13 @@
           <constraints/>
         </categoryLink>
         <categoryLink id="41c9-d4f5-5f9a-cd78" name="New CategoryLink" hidden="false" targetId="36b8-cf23-7648-ece9" primary="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
+        <categoryLink id="83cf-233e-f4ad-6702" name="New CategoryLink" hidden="false" targetId="2110-97af-25b6-2eb8" primary="false">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -8597,6 +8818,27 @@
           <modifiers/>
           <constraints/>
         </categoryLink>
+        <categoryLink id="4811-a261-8436-dd90" name="New CategoryLink" hidden="false" targetId="3d52-fccf-10c0-3fae" primary="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
+        <categoryLink id="bd88-6282-f3d5-8272" name="New CategoryLink" hidden="false" targetId="36b8-cf23-7648-ece9" primary="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
+        <categoryLink id="328b-d6b4-cbb7-e22c" name="New CategoryLink" hidden="false" targetId="1e74-2c48-7179-152e" primary="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="dd27-cdde-3a05-090b" name="Blightlord Terminator Champion" hidden="false" collective="false" type="model">
@@ -9053,6 +9295,13 @@
           <modifiers/>
           <constraints/>
         </categoryLink>
+        <categoryLink id="9c63-b335-6626-3a44" name="New CategoryLink" hidden="false" targetId="0053-39d8-9506-8bc8" primary="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="326d-bb03-d303-5d91" name="Myphitic Blight-hauler" hidden="false" collective="false" type="model">
@@ -9330,6 +9579,13 @@
           <constraints/>
         </categoryLink>
         <categoryLink id="2681-ae9f-2f2a-7fc8" name="New CategoryLink" hidden="false" targetId="c35d-97e7-5b2a-0a70" primary="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
+        <categoryLink id="a3bd-5e91-a681-d20d" name="New CategoryLink" hidden="false" targetId="b865-e6f2-4c59-ccb8" primary="false">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -9808,6 +10064,13 @@
           <modifiers/>
           <constraints/>
         </categoryLink>
+        <categoryLink id="5227-1bec-523b-b049" name="New CategoryLink" hidden="false" targetId="ecd7-299f-e997-1548" primary="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="ebe9-f34d-71f1-387c" name="Injector pistol" hidden="false" collective="false" type="upgrade">
@@ -10075,6 +10338,13 @@
           <modifiers/>
           <constraints/>
         </categoryLink>
+        <categoryLink id="fbbb-8d46-b5e6-8bb5" name="New CategoryLink" hidden="false" targetId="8d6d-3d6a-dcc9-5731" primary="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
       </categoryLinks>
       <selectionEntries/>
       <selectionEntryGroups>
@@ -10265,6 +10535,13 @@
           <constraints/>
         </categoryLink>
         <categoryLink id="aeb0-4b9d-ba89-3d7e" name="New CategoryLink" hidden="false" targetId="0fb6-fcaf-b180-5dda" primary="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
+        <categoryLink id="2445-3ec0-1065-d56b" name="New CategoryLink" hidden="false" targetId="e936-731d-fadb-a113" primary="false">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -10639,6 +10916,13 @@
           <modifiers/>
           <constraints/>
         </categoryLink>
+        <categoryLink id="3f3c-5c5c-8ec8-4b77" name="New CategoryLink" hidden="false" targetId="af22-997e-da42-e651" primary="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="8b00-b075-0cef-ba4d" name="Plague sprayer" hidden="false" collective="false" type="upgrade">
@@ -10787,6 +11071,13 @@
           <constraints/>
         </categoryLink>
         <categoryLink id="2bca-7442-1b61-6a42" name="New CategoryLink" hidden="false" targetId="0fb6-fcaf-b180-5dda" primary="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
+        <categoryLink id="867f-5c91-cb72-c846" name="New CategoryLink" hidden="false" targetId="1d9c-2ef0-0695-e179" primary="false">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -10950,6 +11241,13 @@
           <constraints/>
         </categoryLink>
         <categoryLink id="6662-92af-999c-3f14" name="New CategoryLink" hidden="false" targetId="5cf1-acf2-ca3b-c2e5" primary="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
+        <categoryLink id="8e6e-841d-70d2-731b" name="New CategoryLink" hidden="false" targetId="4baf-bddb-d1d6-e66d" primary="false">
           <profiles/>
           <rules/>
           <infoLinks/>


### PR DESCRIPTION
Addresses Issue #2025

Updated from Chaos - Death Guard.cat v25

Updated Categories (otherwise known as Keywords)  and adds smoke launchers to Predator

# -----------------
# Elites
# -----------------
# Category Entries
* ### Added
    * Noxious Blightbringer
    * Foul Blightspawn
    * Biologus Putrifier
    * Plague Surgeon
    * Tallyman
    * Deathshroud
    * Blightlord Terminators
    * Helbrute
    * Beasts of Nurgle
    * Possessed

# 
# Shared Selection Entries

- ### Noxious Blightbringer
  - **Categories**
    - Added - Noxious Blightbringer
    - Removed - Psyker

- ### Foul Blightspawn
  - **Categories**
    - Added - Foul Blightspawn

- ### Biologus Putrifier
  - **Categories**
    - Added - Biologus Putrifier

- ### Plague Surgeon
  - **Categories**
    - Added - Plague Surgeon

- ### Tallyman
  - **Categories**
    - Added - Tallyman

- ### Deathshroud Terminators
  - **Categories**
    - Added - Deathshroud

- ### Blightlord Terminators
  - **Categories**
    - Added - Infantry
    - Added - Terminator
    - Added - Blightlord Terminators

- ### Helbrute
  - **Categories**
    - Added - Helbrute

- ### Beasts of Nurgle
  - **Categories**
    - Added - Beasts of Nurgle

- ### Possessed
  - **Categories**
    - Added - Possessed


# -----------------
# Fast Attack
# -----------------
# Category Entries
* ### Added
    * Foetid Bloat-drone
    * Myphitic Blight-haulers
    * Chaos Spawn
    * Plague Drones

# 
# Shared Selection Entries

- ### Foetid Bloat-drone
  - **Categories**
    - Added - Foetid Bloat-drone

- ### Myphitic Blight-haulers
  - **Categories**
    - Added - Myphitic Blight-haulers

- ### Chaos Spawn
  - **Categories**
    - Added - Chaos Spawn

- ### Plague Drones
  - **Categories**
    - Added - Plague Drones


# -----------------
# Heavy Support
# -----------------
# Category Entries
* ### Added
    * Chaos Land Raider
    * Plagueburst Crawler
    * Defiler
    * Chaos Predator

# 
# Shared Selection Entries

- ### Chaos Land Raider
  - **Categories**
    - Added - Chaos Land Raider

- ### Plagueburst Crawler
  - **Categories**
    - Added - Plagueburst Crawler

- ### Defiler
  - **Categories**
    - Added - Defiler

- ### Chaos Predator
  - **Categories**
    - Added - Chaos Predator
  - **Entry Link**
    - Added - Smoke Launchers
      - Added Constraint - Min 1 in parent
      - Added Constraint - Max 1 in parent



# -----------------
# Dedicated Transport
# -----------------
# Category Entries
* ### Added
    * Chaos Rhino

# 
# Shared Selection Entries

- ### Chaos Rhino
  - **Categories**
    - Added - Chaos Rhino


# -----------------
# Lord of War
# -----------------
# Category Entries
* ### Added
    * Mortarion

# 
# Shared Selection Entries

- ### Mortarion
  - **Categories**
    - Added - Mortarion
