### PR TITLE
Drukhari Update

### DIFF
--- a/Aeldari - Drukhari.cat
+++ b/Aeldari - Drukhari.cat
@@ -8251,6 +8251,41 @@
           <modifiers/>
           <constraints/>
         </categoryLink>
+        <categoryLink id="f1c2-b2b2-97e4-8185" name="New CategoryLink" hidden="false" targetId="ef18-746a-369f-43a4" primary="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
+        <categoryLink id="4b6a-828b-6256-322e" name="New CategoryLink" hidden="false" targetId="6a01-e1fc-d03d-8390" primary="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
+        <categoryLink id="501a-5191-580f-0b59" name="New CategoryLink" hidden="false" targetId="bd42-0139-0789-e05b" primary="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
+        <categoryLink id="1e8b-7c08-91d3-d2bb" name="New CategoryLink" hidden="false" targetId="4c47-af86-571d-3176" primary="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
+        <categoryLink id="e62f-addb-b3f6-5713" name="New CategoryLink" hidden="false" targetId="3d52-fccf-10c0-3fae" primary="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="66fd-4c8a-214b-5bb3" name="Mane of barbs and hooks" hidden="false" collective="false" type="upgrade">

--- a/Aeldari - Drukhari.cat
+++ b/Aeldari - Drukhari.cat
@@ -1266,6 +1266,14 @@
           <constraints/>
           <categoryLinks/>
         </entryLink>
+        <entryLink id="050f-a8e8-8f93-54fa" name="Relic" hidden="false" targetId="e852-3a50-d3ca-9934" type="selectionEntryGroup">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+          <categoryLinks/>
+        </entryLink>
       </entryLinks>
       <costs>
         <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="4.0"/>
@@ -1512,6 +1520,14 @@
           <categoryLinks/>
         </entryLink>
         <entryLink id="4edd-96e2-43eb-7870" name="Warlord Trait" hidden="true" targetId="7de1-3715-26ec-4ef8" type="selectionEntryGroup">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+          <categoryLinks/>
+        </entryLink>
+        <entryLink id="f3e2-4e5f-371c-b105" name="Relic" hidden="false" targetId="e852-3a50-d3ca-9934" type="selectionEntryGroup">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -3750,6 +3766,14 @@
           <categoryLinks/>
         </entryLink>
         <entryLink id="544a-f2b1-b95a-24ce" name="Warlord Trait" hidden="true" targetId="7de1-3715-26ec-4ef8" type="selectionEntryGroup">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+          <categoryLinks/>
+        </entryLink>
+        <entryLink id="0c0f-6fb8-723c-43d8" name="Relic" hidden="false" targetId="e852-3a50-d3ca-9934" type="selectionEntryGroup">
           <profiles/>
           <rules/>
           <infoLinks/>

--- a/Aeldari - Drukhari.cat
+++ b/Aeldari - Drukhari.cat
@@ -1253,7 +1253,9 @@
           <rules/>
           <infoLinks/>
           <modifiers/>
-          <constraints/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f4b5-61db-b32b-48a9" type="max"/>
+          </constraints>
           <categoryLinks/>
         </entryLink>
         <entryLink id="def2-d828-ea97-c397" name="Warlord Trait" hidden="true" targetId="7de1-3715-26ec-4ef8" type="selectionEntryGroup">
@@ -1504,7 +1506,9 @@
           <rules/>
           <infoLinks/>
           <modifiers/>
-          <constraints/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b66b-a423-3330-89a9" type="max"/>
+          </constraints>
           <categoryLinks/>
         </entryLink>
         <entryLink id="4edd-96e2-43eb-7870" name="Warlord Trait" hidden="true" targetId="7de1-3715-26ec-4ef8" type="selectionEntryGroup">
@@ -3705,7 +3709,9 @@
           <rules/>
           <infoLinks/>
           <modifiers/>
-          <constraints/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a6b8-de15-d285-4a5f" type="max"/>
+          </constraints>
           <categoryLinks/>
         </entryLink>
         <entryLink id="544a-f2b1-b95a-24ce" name="Warlord Trait" hidden="true" targetId="7de1-3715-26ec-4ef8" type="selectionEntryGroup">
@@ -7022,7 +7028,9 @@
           <rules/>
           <infoLinks/>
           <modifiers/>
-          <constraints/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6d09-5335-d81a-4fa6" type="max"/>
+          </constraints>
           <categoryLinks/>
         </entryLink>
         <entryLink id="6642-6614-10fe-8930" name="Warlord Trait" hidden="true" targetId="7de1-3715-26ec-4ef8" type="selectionEntryGroup">
@@ -8372,7 +8380,9 @@
           <rules/>
           <infoLinks/>
           <modifiers/>
-          <constraints/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="76dc-3ba8-123e-817f" type="max"/>
+          </constraints>
           <categoryLinks/>
         </entryLink>
       </entryLinks>
@@ -9661,7 +9671,9 @@
           <rules/>
           <infoLinks/>
           <modifiers/>
-          <constraints/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6a42-90d5-ca04-fc1e" type="max"/>
+          </constraints>
           <categoryLinks/>
         </entryLink>
       </entryLinks>
@@ -12123,7 +12135,10 @@
       <selectionEntries/>
       <selectionEntryGroups/>
       <entryLinks/>
-      <costs/>
+      <costs>
+        <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="0.0"/>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
     </selectionEntry>
     <selectionEntry id="853b-9d19-704f-6757" name="Blood Dancer" hidden="true" collective="false" type="upgrade">
       <profiles/>
@@ -12153,7 +12168,10 @@
       <selectionEntries/>
       <selectionEntryGroups/>
       <entryLinks/>
-      <costs/>
+      <costs>
+        <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="0.0"/>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
     </selectionEntry>
     <selectionEntry id="4f49-c843-12ee-07f2" name="Master Regenerist" hidden="true" collective="false" type="upgrade">
       <profiles/>
@@ -12183,7 +12201,10 @@
       <selectionEntries/>
       <selectionEntryGroups/>
       <entryLinks/>
-      <costs/>
+      <costs>
+        <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="0.0"/>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
     </selectionEntry>
   </sharedSelectionEntries>
   <sharedSelectionEntryGroups>

--- a/Aeldari - Drukhari.cat
+++ b/Aeldari - Drukhari.cat
@@ -3601,6 +3601,41 @@
           <modifiers/>
           <constraints/>
         </categoryLink>
+        <categoryLink id="a240-2cba-b0d6-717e" name="New CategoryLink" hidden="false" targetId="ef18-746a-369f-43a4" primary="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
+        <categoryLink id="ec88-6042-c7ba-3d89" name="New CategoryLink" hidden="false" targetId="99c9-6127-f78b-1f66" primary="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
+        <categoryLink id="b23a-3abf-dea6-21cb" name="New CategoryLink" hidden="false" targetId="6a01-e1fc-d03d-8390" primary="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
+        <categoryLink id="c62b-767e-72c6-4380" name="New CategoryLink" hidden="false" targetId="bd42-0139-0789-e05b" primary="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
+        <categoryLink id="e8d7-96e0-c64b-32c0" name="New CategoryLink" hidden="false" targetId="3d52-fccf-10c0-3fae" primary="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="fea6-ffc2-cc13-da62" name="Archite Glaive" hidden="false" collective="false" type="upgrade">

--- a/Aeldari - Drukhari.cat
+++ b/Aeldari - Drukhari.cat
@@ -12249,7 +12249,7 @@
         <cost name="pts" costTypeId="points" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="4f49-c843-12ee-07f2" name="Master Regenerist" hidden="true" collective="false" type="upgrade">
+    <selectionEntry id="4f49-c843-12ee-07f2" name="Master Regenerist" hidden="false" collective="false" type="upgrade">
       <profiles/>
       <rules>
         <rule id="4f1e-7c5b-38d9-bc47" name="Master Regenerist" hidden="false">
@@ -12262,12 +12262,18 @@
       </rules>
       <infoLinks/>
       <modifiers>
-        <modifier type="set" field="hidden" value="false">
+        <modifier type="set" field="hidden" value="true">
           <repeats/>
           <conditions>
-            <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="c3cc-22d9-1014-b496" type="instanceOf"/>
+            <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="c3cc-22d9-1014-b496" type="notInstanceOf"/>
+            <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="f16a-5e3b-9a49-2b42" type="notInstanceOf"/>
           </conditions>
-          <conditionGroups/>
+          <conditionGroups>
+            <conditionGroup type="and">
+              <conditions/>
+              <conditionGroups/>
+            </conditionGroup>
+          </conditionGroups>
         </modifier>
       </modifiers>
       <constraints>

--- a/Aeldari - Drukhari.cat
+++ b/Aeldari - Drukhari.cat
@@ -12093,7 +12093,7 @@
       </entryLinks>
       <costs>
         <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="18.0"/>
-        <cost name="pts" costTypeId="points" value="350.0"/>
+        <cost name="pts" costTypeId="points" value="400.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="922c-5981-23f9-a644" name="Faction Keyword Filter" hidden="false" collective="false" type="upgrade">

--- a/Aeldari - Drukhari.cat
+++ b/Aeldari - Drukhari.cat
@@ -12288,6 +12288,36 @@
         <cost name="pts" costTypeId="points" value="0.0"/>
       </costs>
     </selectionEntry>
+    <selectionEntry id="efec-7b09-1a63-e41f" name="The Parasite&apos;s Kiss" hidden="false" collective="false" type="upgrade">
+      <profiles>
+        <profile id="e97c-2815-8042-03b2" name="The Parasite&apos;s Kiss" hidden="false" profileTypeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" profileTypeName="Weapon">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Range" characteristicTypeId="6fa97fa8-ea74-4a27-a0fb-bc4e5f367464" value="12&quot;"/>
+            <characteristic name="Type" characteristicTypeId="077c342f-d7b9-45c6-b8af-88e97cafd3a2" value="Pistol 2"/>
+            <characteristic name="S" characteristicTypeId="59b1-319e-ec13-d466" value="1"/>
+            <characteristic name="AP" characteristicTypeId="75aa-a838-b675-6484" value="-2"/>
+            <characteristic name="D" characteristicTypeId="ae8a-3137-d65b-4ca7" value="2"/>
+            <characteristic name="Abilities" characteristicTypeId="837d-5e63-aeb7-1410" value="This weapon wounds on a 2+, unless it is targeting a VEHICLE, in which case it wounds on a 6+. Each time this weapon kills an enemy model, the bearer regains 1 lost wound."/>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c9ba-cfc7-0227-6765" type="max"/>
+        <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bdd0-2585-2667-f334" type="max"/>
+      </constraints>
+      <categoryLinks/>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs/>
+    </selectionEntry>
   </sharedSelectionEntries>
   <sharedSelectionEntryGroups>
     <selectionEntryGroup id="5489-b678-3c48-31c7" name="Tools of Torment" hidden="false" collective="false">

--- a/Aeldari - Drukhari.cat
+++ b/Aeldari - Drukhari.cat
@@ -12496,6 +12496,28 @@
         </entryLink>
       </entryLinks>
     </selectionEntryGroup>
+    <selectionEntryGroup id="e852-3a50-d3ca-9934" name="Relic" hidden="false" collective="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ae82-fea4-19e8-e0fa" type="max"/>
+      </constraints>
+      <categoryLinks/>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks>
+        <entryLink id="2cfb-0ddf-b62b-52c2" name="The Parasite&apos;s Kiss" hidden="false" targetId="efec-7b09-1a63-e41f" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+          <categoryLinks/>
+        </entryLink>
+      </entryLinks>
+    </selectionEntryGroup>
   </sharedSelectionEntryGroups>
   <sharedRules>
     <rule id="3216-c874-7ca1-2150" name="Insensible to Pain" hidden="false">

--- a/Aeldari - Drukhari.cat
+++ b/Aeldari - Drukhari.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="e0a4-2172-4397-e39a" name="Aeldari - Drukhari" book="Index: Xenos 1" revision="17" battleScribeVersion="2.01" gameSystemId="28ec-711c-d87f-3aeb" gameSystemRevision="1" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="e0a4-2172-4397-e39a" name="Aeldari - Drukhari" book="Index: Xenos 1" revision="18" battleScribeVersion="2.01" gameSystemId="28ec-711c-d87f-3aeb" gameSystemRevision="1" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <profiles/>
   <rules/>
   <infoLinks/>

--- a/Aeldari - Drukhari.cat
+++ b/Aeldari - Drukhari.cat
@@ -12210,7 +12210,7 @@
         <cost name="pts" costTypeId="points" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="853b-9d19-704f-6757" name="Blood Dancer" hidden="true" collective="false" type="upgrade">
+    <selectionEntry id="853b-9d19-704f-6757" name="Blood Dancer" hidden="false" collective="false" type="upgrade">
       <profiles/>
       <rules>
         <rule id="3e08-14ad-e776-d3c5" name="Blood Dancer" hidden="false">
@@ -12223,12 +12223,18 @@
       </rules>
       <infoLinks/>
       <modifiers>
-        <modifier type="set" field="hidden" value="false">
+        <modifier type="set" field="hidden" value="true">
           <repeats/>
           <conditions>
-            <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="99c9-6127-f78b-1f66" type="instanceOf"/>
+            <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="99c9-6127-f78b-1f66" type="notInstanceOf"/>
+            <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="4c47-af86-571d-3176" type="notInstanceOf"/>
           </conditions>
-          <conditionGroups/>
+          <conditionGroups>
+            <conditionGroup type="and">
+              <conditions/>
+              <conditionGroups/>
+            </conditionGroup>
+          </conditionGroups>
         </modifier>
       </modifiers>
       <constraints>


### PR DESCRIPTION
Some small updates to get the Drukhari current with Chapter Approved.  Overall changes are:

-Making Warlord 0-1 for all HQs.
-Getting Blood Dancer to appear for Succubus and Lelith
-Getting Master Regenesist to appear for Urien.
-Adding a relic option for the non-special HQs (future relics can be linked to the group)
-Correcting the cost of the Tantalus.