### PR TITLE
Warlord Validation

### DIFF
--- a/Tyranids - Genestealer Cults.cat
+++ b/Tyranids - Genestealer Cults.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="83b2-e602-931a-fea1" name="Tyranids - Genestealer Cults" book="Index: Xenos 2" revision="14" battleScribeVersion="2.01" authorName="GenWilhelm" authorUrl="http://battlescribedata.appspot.com/#/repo/wh40k" gameSystemId="28ec-711c-d87f-3aeb" gameSystemRevision="1" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="83b2-e602-931a-fea1" name="Tyranids - Genestealer Cults" book="Index: Xenos 2" revision="15" battleScribeVersion="2.01" authorName="GenWilhelm" authorUrl="http://battlescribedata.appspot.com/#/repo/wh40k" gameSystemId="28ec-711c-d87f-3aeb" gameSystemRevision="1" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <profiles/>
   <rules>
     <rule id="69ce-aa80-5a30-5d8b" name="Brood Brothers" book="Index: Xenos 2" page="112" hidden="false">
@@ -1069,7 +1069,7 @@
           <constraints/>
           <categoryLinks/>
         </entryLink>
-        <entryLink id="45ca-b442-af7e-a58c" name="Warlord" hidden="false" targetId="33f6-60da-7b70-5fee" type="selectionEntry">
+        <entryLink id="45ca-b442-af7e-a58c" name="Warlord" hidden="false" targetId="afad-6465-5489-7fb9" type="selectionEntry">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -3251,7 +3251,7 @@
           <constraints/>
           <categoryLinks/>
         </entryLink>
-        <entryLink id="e152-7a2e-7a1f-8b6f" name="Warlord" hidden="false" targetId="33f6-60da-7b70-5fee" type="selectionEntry">
+        <entryLink id="e152-7a2e-7a1f-8b6f" name="Warlord" hidden="false" targetId="afad-6465-5489-7fb9" type="selectionEntry">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -3432,7 +3432,7 @@
           <constraints/>
           <categoryLinks/>
         </entryLink>
-        <entryLink id="5fdd-d441-b4a6-fa29" name="Warlord" hidden="false" targetId="33f6-60da-7b70-5fee" type="selectionEntry">
+        <entryLink id="5fdd-d441-b4a6-fa29" name="Warlord" hidden="false" targetId="afad-6465-5489-7fb9" type="selectionEntry">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -5073,7 +5073,7 @@
           <constraints/>
           <categoryLinks/>
         </entryLink>
-        <entryLink id="8c25-fdab-4f04-0632" name="Warlord" hidden="false" targetId="33f6-60da-7b70-5fee" type="selectionEntry">
+        <entryLink id="8c25-fdab-4f04-0632" name="Warlord" hidden="false" targetId="afad-6465-5489-7fb9" type="selectionEntry">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -6073,6 +6073,31 @@
         <cost name="pts" costTypeId="points" value="0.0"/>
       </costs>
     </selectionEntry>
+    <selectionEntry id="afad-6465-5489-7fb9" name="Warlord" hidden="false" collective="false" type="upgrade">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6bed-d724-76ef-5667" type="max"/>
+      </constraints>
+      <categoryLinks>
+        <categoryLink id="2d20-5b3e-ed2e-65a2" name="New CategoryLink" hidden="false" targetId="ae09-117e-a6fa-316b" primary="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
+      </categoryLinks>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="0.0"/>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
   </sharedSelectionEntries>
   <sharedSelectionEntryGroups>
     <selectionEntryGroup id="87b1-40a9-6106-ca5e" name="Special Weapons" hidden="false" collective="false">
@@ -6372,7 +6397,7 @@
         <modifier type="set" field="hidden" value="true">
           <repeats/>
           <conditions>
-            <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="33f6-60da-7b70-5fee" type="equalTo"/>
+            <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="afad-6465-5489-7fb9" type="equalTo"/>
           </conditions>
           <conditionGroups/>
         </modifier>

--- a/Tyranids.cat
+++ b/Tyranids.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="7150-5917-ae80-68c5" name="Tyranids" book="Codex: Tyranids" revision="28" battleScribeVersion="2.01" authorName="GenWilhelm" authorUrl="http://battlescribedata.appspot.com/#/repo/wh40k" gameSystemId="28ec-711c-d87f-3aeb" gameSystemRevision="1" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="7150-5917-ae80-68c5" name="Tyranids" book="Codex: Tyranids" revision="29" battleScribeVersion="2.01" authorName="GenWilhelm" authorUrl="http://battlescribedata.appspot.com/#/repo/wh40k" gameSystemId="28ec-711c-d87f-3aeb" gameSystemRevision="1" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <profiles/>
   <rules/>
   <infoLinks/>
@@ -954,7 +954,7 @@
           <constraints/>
           <categoryLinks/>
         </entryLink>
-        <entryLink id="7a27-e46a-7b82-d92f" name="Warlord" hidden="false" targetId="33f6-60da-7b70-5fee" type="selectionEntry">
+        <entryLink id="7a27-e46a-7b82-d92f" name="Warlord" hidden="false" targetId="c832-2f4e-ee51-f481" type="selectionEntry">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -3121,7 +3121,7 @@
           <constraints/>
           <categoryLinks/>
         </entryLink>
-        <entryLink id="c0fe-f682-c70b-1885" name="Warlord" hidden="false" targetId="33f6-60da-7b70-5fee" type="selectionEntry">
+        <entryLink id="c0fe-f682-c70b-1885" name="Warlord" hidden="false" targetId="c832-2f4e-ee51-f481" type="selectionEntry">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -5754,7 +5754,7 @@
           <constraints/>
           <categoryLinks/>
         </entryLink>
-        <entryLink id="d7a7-e407-1ee7-4fee" name="Warlord" hidden="false" targetId="33f6-60da-7b70-5fee" type="selectionEntry">
+        <entryLink id="d7a7-e407-1ee7-4fee" name="Warlord" hidden="false" targetId="c832-2f4e-ee51-f481" type="selectionEntry">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -6387,7 +6387,7 @@
           <constraints/>
           <categoryLinks/>
         </entryLink>
-        <entryLink id="275f-30ce-0b98-a39b" name="Warlord" hidden="false" targetId="33f6-60da-7b70-5fee" type="selectionEntry">
+        <entryLink id="275f-30ce-0b98-a39b" name="Warlord" hidden="false" targetId="c832-2f4e-ee51-f481" type="selectionEntry">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -8085,7 +8085,7 @@
           <constraints/>
           <categoryLinks/>
         </entryLink>
-        <entryLink id="0059-9d22-1999-0ec8" name="Warlord" hidden="false" targetId="33f6-60da-7b70-5fee" type="selectionEntry">
+        <entryLink id="0059-9d22-1999-0ec8" name="Warlord" hidden="false" targetId="c832-2f4e-ee51-f481" type="selectionEntry">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -8286,7 +8286,7 @@
           <constraints/>
           <categoryLinks/>
         </entryLink>
-        <entryLink id="841a-67a2-9295-ed1e" name="Warlord" hidden="false" targetId="33f6-60da-7b70-5fee" type="selectionEntry">
+        <entryLink id="841a-67a2-9295-ed1e" name="Warlord" hidden="false" targetId="c832-2f4e-ee51-f481" type="selectionEntry">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -8439,7 +8439,7 @@
           <constraints/>
           <categoryLinks/>
         </entryLink>
-        <entryLink id="7305-dfa7-9e77-1956" name="Warlord" hidden="false" targetId="33f6-60da-7b70-5fee" type="selectionEntry">
+        <entryLink id="7305-dfa7-9e77-1956" name="Warlord" hidden="false" targetId="c832-2f4e-ee51-f481" type="selectionEntry">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -8710,7 +8710,7 @@
           <constraints/>
           <categoryLinks/>
         </entryLink>
-        <entryLink id="35a8-c369-2d9f-bd05" name="Warlord" hidden="false" targetId="33f6-60da-7b70-5fee" type="selectionEntry">
+        <entryLink id="35a8-c369-2d9f-bd05" name="Warlord" hidden="false" targetId="c832-2f4e-ee51-f481" type="selectionEntry">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -9002,7 +9002,7 @@
           <constraints/>
           <categoryLinks/>
         </entryLink>
-        <entryLink id="874f-5747-2b99-c6d7" name="Warlord" hidden="false" targetId="33f6-60da-7b70-5fee" type="selectionEntry">
+        <entryLink id="874f-5747-2b99-c6d7" name="Warlord" hidden="false" targetId="c832-2f4e-ee51-f481" type="selectionEntry">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -11627,7 +11627,7 @@
           <constraints/>
           <categoryLinks/>
         </entryLink>
-        <entryLink id="b300-97f5-0a76-becc" name="Warlord" hidden="false" targetId="33f6-60da-7b70-5fee" type="selectionEntry">
+        <entryLink id="b300-97f5-0a76-becc" name="Warlord" hidden="false" targetId="c832-2f4e-ee51-f481" type="selectionEntry">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -13688,7 +13688,7 @@
           <constraints/>
           <categoryLinks/>
         </entryLink>
-        <entryLink id="f413-0fab-2dbe-69a9" name="Warlord" hidden="false" targetId="33f6-60da-7b70-5fee" type="selectionEntry">
+        <entryLink id="f413-0fab-2dbe-69a9" name="Warlord" hidden="false" targetId="c832-2f4e-ee51-f481" type="selectionEntry">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -14039,6 +14039,28 @@
         <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="0.0"/>
         <cost name="pts" costTypeId="points" value="0.0"/>
       </costs>
+    </selectionEntry>
+    <selectionEntry id="c832-2f4e-ee51-f481" name="Warlord" hidden="false" collective="false" type="upgrade">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f3a9-90e3-49a9-c280" type="max"/>
+      </constraints>
+      <categoryLinks>
+        <categoryLink id="7c55-02bd-f4c7-f11a" name="New CategoryLink" hidden="false" targetId="ae09-117e-a6fa-316b" primary="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
+      </categoryLinks>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs/>
     </selectionEntry>
   </sharedSelectionEntries>
   <sharedSelectionEntryGroups>
@@ -15022,7 +15044,7 @@
         <modifier type="set" field="hidden" value="true">
           <repeats/>
           <conditions>
-            <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="33f6-60da-7b70-5fee" type="equalTo"/>
+            <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="c832-2f4e-ee51-f481" type="equalTo"/>
           </conditions>
           <conditionGroups/>
         </modifier>

--- a/Warhammer 40,000 8th Edition.gst
+++ b/Warhammer 40,000 8th Edition.gst
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<gameSystem id="28ec-711c-d87f-3aeb" name="Warhammer 40,000 8th Edition" revision="36" battleScribeVersion="2.01" authorName="BSData Organisation" authorContact="@BSData" authorUrl="http://battlescribedata.appspot.com/#/repo/wh40k" xmlns="http://www.battlescribe.net/schema/gameSystemSchema">
+<gameSystem id="28ec-711c-d87f-3aeb" name="Warhammer 40,000 8th Edition" revision="37" battleScribeVersion="2.01" authorName="BSData Organisation" authorContact="@BSData" authorUrl="http://battlescribedata.appspot.com/#/repo/wh40k" xmlns="http://www.battlescribe.net/schema/gameSystemSchema">
   <profiles/>
   <rules/>
   <infoLinks/>
@@ -337,6 +337,15 @@
       <modifiers/>
       <constraints/>
     </categoryEntry>
+    <categoryEntry id="ae09-117e-a6fa-316b" name="Warlord" hidden="true">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" id="a991-ad91-7d5f-92d1" type="max"/>
+      </constraints>
+    </categoryEntry>
   </categoryEntries>
   <forceEntries>
     <forceEntry id="a0c7-2a71-bae0-215d" name="Patrol Detachment" hidden="false">
@@ -499,6 +508,13 @@
             <constraint field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" id="806f-d1ee-da05-0983" type="max"/>
           </constraints>
         </categoryLink>
+        <categoryLink id="9b48-cd5f-3949-adc6" name="Warlord" hidden="true" targetId="ae09-117e-a6fa-316b" primary="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
       </categoryLinks>
     </forceEntry>
     <forceEntry id="564e-55d5-79bc-a4d7" name="Battalion Detachment +3CP" hidden="false">
@@ -660,6 +676,13 @@
           <constraints>
             <constraint field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" id="dd16-f9e4-6928-db00" type="max"/>
           </constraints>
+        </categoryLink>
+        <categoryLink id="70a3-5965-8dfd-0dff" name="Warlord" hidden="true" targetId="ae09-117e-a6fa-316b" primary="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
         </categoryLink>
       </categoryLinks>
     </forceEntry>
@@ -826,6 +849,13 @@
             <constraint field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" id="b905-bc19-8b25-f26a" type="max"/>
           </constraints>
         </categoryLink>
+        <categoryLink id="b505-6d2b-bb65-191e" name="Warlord" hidden="true" targetId="ae09-117e-a6fa-316b" primary="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
       </categoryLinks>
     </forceEntry>
     <forceEntry id="41af-75ce-79d2-ddff" name="Vanguard Detachment +1CP" hidden="false">
@@ -987,6 +1017,13 @@
           <constraints>
             <constraint field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" id="1449-c900-5e63-561c" type="max"/>
           </constraints>
+        </categoryLink>
+        <categoryLink id="c3f6-3055-bcd0-788b" name="Warlord" hidden="true" targetId="ae09-117e-a6fa-316b" primary="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
         </categoryLink>
       </categoryLinks>
     </forceEntry>
@@ -1150,6 +1187,13 @@
             <constraint field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" id="68bd-f7ab-859e-fb22" type="max"/>
           </constraints>
         </categoryLink>
+        <categoryLink id="0144-c043-6326-c755" name="Warlord" hidden="true" targetId="ae09-117e-a6fa-316b" primary="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
       </categoryLinks>
     </forceEntry>
     <forceEntry id="3c85-9649-d2da-9bde" name="Outrider Detachment +1CP" hidden="false">
@@ -1312,6 +1356,13 @@
             <constraint field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" id="3de0-5460-f04b-09ba" type="max"/>
           </constraints>
         </categoryLink>
+        <categoryLink id="5411-43af-9074-78ae" name="Warlord" hidden="true" targetId="ae09-117e-a6fa-316b" primary="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
       </categoryLinks>
     </forceEntry>
     <forceEntry id="5baf-eed5-bb85-7325" name="Supreme Command Detachment +1CP" hidden="false">
@@ -1422,6 +1473,13 @@
             <constraint field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" id="83e7-e60b-0ad5-1d24" type="max"/>
           </constraints>
         </categoryLink>
+        <categoryLink id="2421-180e-769d-d51f" name="Warlord" hidden="true" targetId="ae09-117e-a6fa-316b" primary="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
       </categoryLinks>
     </forceEntry>
     <forceEntry id="d513-cbf5-9bfc-7270" name="Super-Heavy Detachment +3CP" hidden="false">
@@ -1473,6 +1531,13 @@
             <constraint field="selections" scope="force" value="5.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" id="e8fa-5d51-0e94-764b" type="max"/>
             <constraint field="selections" scope="force" value="3.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" id="67f2-9795-52db-5a70" type="min"/>
           </constraints>
+        </categoryLink>
+        <categoryLink id="9ca8-4fb9-709b-b9a6" name="Warlord" hidden="true" targetId="ae09-117e-a6fa-316b" primary="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
         </categoryLink>
       </categoryLinks>
     </forceEntry>
@@ -1526,6 +1591,13 @@
             <constraint field="selections" scope="force" value="3.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" id="fc65-2978-7619-e375" type="min"/>
           </constraints>
         </categoryLink>
+        <categoryLink id="33b2-565d-d44c-99a7" name="Warlord" hidden="true" targetId="ae09-117e-a6fa-316b" primary="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
       </categoryLinks>
     </forceEntry>
     <forceEntry id="224b-1070-218f-fdf4" name="Super-Heavy Auxiliary Detachment" hidden="false">
@@ -1552,6 +1624,13 @@
             <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" id="4384-497e-3b4a-d259" type="max"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1b8f-4518-f394-33f4" type="min"/>
           </constraints>
+        </categoryLink>
+        <categoryLink id="b1a6-0fc5-d615-d4eb" name="Warlord" hidden="true" targetId="ae09-117e-a6fa-316b" primary="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
         </categoryLink>
       </categoryLinks>
     </forceEntry>
@@ -1604,6 +1683,13 @@
             <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" id="26f5-481b-d941-b4ca" type="min"/>
             <constraint field="selections" scope="force" value="3.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" id="0214-a689-7537-aafa" type="max"/>
           </constraints>
+        </categoryLink>
+        <categoryLink id="663d-4540-136a-98c1" name="Warlord" hidden="true" targetId="ae09-117e-a6fa-316b" primary="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
         </categoryLink>
       </categoryLinks>
     </forceEntry>
@@ -1675,6 +1761,13 @@
           <constraints/>
         </categoryLink>
         <categoryLink id="1d7c-3253-d90d-6e3a" name="Dedicated Transport" hidden="false" targetId="1b66-3f5f-6705-079a" primary="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
+        <categoryLink id="09fb-b9a5-3cb5-b0d5" name="Warlord" hidden="true" targetId="ae09-117e-a6fa-316b" primary="false">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -1755,6 +1848,13 @@
           <constraints/>
         </categoryLink>
         <categoryLink id="7751-b628-068c-ae45" name="Fortification" hidden="false" targetId="d713cda3-5d0f-40d8-b621-69233263ec2a" primary="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
+        <categoryLink id="9a65-6b3b-5e44-03e8" name="Warlord" hidden="true" targetId="ae09-117e-a6fa-316b" primary="false">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -1924,6 +2024,13 @@
             <constraint field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" id="4240-b0fc-8a69-2871" type="max"/>
           </constraints>
         </categoryLink>
+        <categoryLink id="7187-699d-2503-992c" name="Warlord" hidden="true" targetId="ae09-117e-a6fa-316b" primary="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
       </categoryLinks>
     </forceEntry>
     <forceEntry id="810f-6b53-1e3b-fe9d" name="Planetstrike Defender +5 CP" book="Chapter Approved 2017" page="34" hidden="false">
@@ -2087,6 +2194,13 @@
             <constraint field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" id="ee38-3431-abb2-9e62" type="max"/>
           </constraints>
         </categoryLink>
+        <categoryLink id="3c3b-27e3-c0b7-b3ee" name="Warlord" hidden="true" targetId="ae09-117e-a6fa-316b" primary="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
       </categoryLinks>
     </forceEntry>
     <forceEntry id="c048-e584-e628-474e" name="Stronghold Assault Attacker +5 CP" book="Chapter Approved 2017" page="46" hidden="false">
@@ -2249,6 +2363,13 @@
           <constraints>
             <constraint field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" id="9a18-2f70-70ee-6230" type="max"/>
           </constraints>
+        </categoryLink>
+        <categoryLink id="eed4-ea5f-257c-0699" name="Warlord" hidden="true" targetId="ae09-117e-a6fa-316b" primary="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
         </categoryLink>
       </categoryLinks>
     </forceEntry>
@@ -2428,6 +2549,13 @@
           <constraints>
             <constraint field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" id="6ce3-81ab-8b21-3ef4" type="max"/>
           </constraints>
+        </categoryLink>
+        <categoryLink id="3e5e-b1fa-a208-60bd" name="Warlord" hidden="true" targetId="ae09-117e-a6fa-316b" primary="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
         </categoryLink>
       </categoryLinks>
     </forceEntry>


### PR DESCRIPTION
Allows complete relic validation in rosters using multiple factions, as per #2318.