### PR TITLE
Blood Angels: Typo and Force Rules Added

### DIFF
--- a/Imperium - Blood Angels.cat
+++ b/Imperium - Blood Angels.cat
@@ -1,8 +1,21 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="eb0f-c144-a282-8bdc" name="Imperium - Blood Angels" book="Codex: Blood Angels" revision="39" battleScribeVersion="2.01" authorName="Crowbar90" gameSystemId="28ec-711c-d87f-3aeb" gameSystemRevision="1" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="eb0f-c144-a282-8bdc" name="Imperium - Blood Angels" book="Codex: Blood Angels" revision="40" battleScribeVersion="2.01" authorName="Crowbar90" gameSystemId="28ec-711c-d87f-3aeb" gameSystemRevision="1" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <profiles/>
   <rules/>
-  <infoLinks/>
+  <infoLinks>
+    <infoLink id="59cb-0435-fbd6-d3d2" name="Defenders of Humanity" hidden="false" targetId="d8df-0f76-de5e-42a0" type="rule">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+    </infoLink>
+    <infoLink id="9bf3-acff-6600-82de" name="The Red Thirst" hidden="false" targetId="2577-cb11-acb4-54c0" type="rule">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+    </infoLink>
+  </infoLinks>
   <costTypes/>
   <profileTypes>
     <profileType id="818c-0db1-36f0-462a" name="Explosion">
@@ -581,7 +594,7 @@
       <constraints/>
       <categoryLinks/>
     </entryLink>
-    <entryLink id="8d7e-a2eb-be2b-45ce" name="New EntryLink" hidden="false" targetId="1c3e-eb6f-1e80-d1bf" type="selectionEntry">
+    <entryLink id="8d7e-a2eb-be2b-45ce" name="Attack Bike Squad" hidden="false" targetId="1c3e-eb6f-1e80-d1bf" type="selectionEntry">
       <profiles/>
       <rules/>
       <infoLinks/>
@@ -637,7 +650,7 @@
       <constraints/>
       <categoryLinks/>
     </entryLink>
-    <entryLink id="603a-a2bf-1e33-1bd8" name="New EntryLink" hidden="false" targetId="507f-296e-0fd5-fcb6" type="selectionEntry">
+    <entryLink id="603a-a2bf-1e33-1bd8" name="Chaplain in Terminator Armour" hidden="false" targetId="507f-296e-0fd5-fcb6" type="selectionEntry">
       <profiles/>
       <rules/>
       <infoLinks/>
@@ -1005,7 +1018,7 @@
       <constraints/>
       <categoryLinks/>
     </entryLink>
-    <entryLink id="67c9-5d31-938e-3cec" name="New EntryLink" hidden="false" targetId="d3c0-214a-dd06-b140" type="selectionEntry">
+    <entryLink id="67c9-5d31-938e-3cec" name="Astorath" hidden="false" targetId="d3c0-214a-dd06-b140" type="selectionEntry">
       <profiles/>
       <rules/>
       <infoLinks/>
@@ -26705,6 +26718,20 @@
       <modifiers/>
       <description>Your Warlord can perform a Heroic Intervention if he is within 6&quot; of an enemy unit instead of only 3&quot;, and if he does so he can move up to 6&quot; rather than 3&quot;.</description>
     </rule>
+    <rule id="d8df-0f76-de5e-42a0" name="Defenders of Humanity" book="Codex: Blood Angels" page="" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <description>A unit with this ability that is within range of an objective marker (as specified in the mission) controls the objective marker even if there are more enemy models within range of that objective marker. If an enemy unit within range of the same objective marker has a similar ability, then the objective marker is controlled by the player who has the most models within range of it as normal.</description>
+    </rule>
+    <rule id="2577-cb11-acb4-54c0" name="The Red Thirst" book="" page="" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <description>In any turn in which a unit with this ability charged, was charged or made a Heroic Intervention, you may add 1 to its wound rolls in the Fight phase.</description>
+    </rule>
   </sharedRules>
   <sharedProfiles>
     <profile id="4c6e-5f3b-8fe7-13a6" name="Hand Flamer" book="Index: Imperium 1" page="213" hidden="false" profileTypeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" profileTypeName="Weapon">
@@ -27550,7 +27577,7 @@
       <infoLinks/>
       <modifiers/>
       <characteristics>
-        <characteristic name="Description" characteristicTypeId="21befb24-fc85-4f52-a745-64b2e48f8228" value="You can re-roll wound rolls of 1 for friendly CLOOD ANGELS units that are within 6&quot; of a friendly BLOOD ANGELS LIEUTENANT."/>
+        <characteristic name="Description" characteristicTypeId="21befb24-fc85-4f52-a745-64b2e48f8228" value="You can re-roll wound rolls of 1 for friendly BLOOD ANGELS units that are within 6&quot; of a friendly BLOOD ANGELS LIEUTENANT."/>
       </characteristics>
     </profile>
     <profile id="6e55-5deb-c20c-ae39" name="Razorback" hidden="false" profileTypeId="800f-21d0-4387-c943" profileTypeName="Unit">


### PR DESCRIPTION
Typo(Tactical Precision): CLOOD ANGELS -> BLOOD ANGELS
Added(Force Rules): Defenders of Humanity, The Red Thirst