### PR TITLE
Add a note to Grot tanks to explain constraints

### DIFF
--- a/Orks.cat
+++ b/Orks.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="11b5-77b9-31bf-7b74" name="Orks" book="Index: Xenos 2" revision="15" battleScribeVersion="2.01" authorName="tag8833" authorContact="Github" gameSystemId="28ec-711c-d87f-3aeb" gameSystemRevision="1" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="11b5-77b9-31bf-7b74" name="Orks" book="Index: Xenos 2" revision="16" battleScribeVersion="2.01" authorName="tag8833" authorContact="Github" gameSystemId="28ec-711c-d87f-3aeb" gameSystemRevision="1" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <profiles/>
   <rules/>
   <infoLinks/>
@@ -2120,14 +2120,14 @@
       </selectionEntries>
       <selectionEntryGroups/>
       <entryLinks>
-        <entryLink id="de2a-e364-08ff-f130" name="New EntryLink" hidden="false" targetId="cb1c-c83b-5adb-5663" type="selectionEntryGroup">
+        <entryLink id="de2a-e364-08ff-f130" name="Power of the WAAAGH!" hidden="false" targetId="cb1c-c83b-5adb-5663" type="selectionEntryGroup">
           <profiles/>
           <rules/>
           <infoLinks/>
           <modifiers/>
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="67e7-ee25-0d0b-ccc8" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d68f-c332-bf68-4fc9" type="min"/>
+            <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d68f-c332-bf68-4fc9" type="min"/>
           </constraints>
           <categoryLinks/>
         </entryLink>
@@ -14862,7 +14862,23 @@
           <constraints/>
         </categoryLink>
       </categoryLinks>
-      <selectionEntries/>
+      <selectionEntries>
+        <selectionEntry id="046c-df28-59d9-d547" name="Big Mek Required" hidden="false" collective="false" type="upgrade">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7642-e858-79e6-bbbb" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bdc8-85db-0a3d-e1c3" type="max"/>
+          </constraints>
+          <categoryLinks/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks/>
+          <costs/>
+        </selectionEntry>
+      </selectionEntries>
       <selectionEntryGroups>
         <selectionEntryGroup id="1069-a41d-6ed3-b330" name="Mob" hidden="false" collective="false" defaultSelectionEntryId="1952-cfd1-6c20-5406">
           <profiles/>
@@ -16996,6 +17012,12 @@
       <rules/>
       <infoLinks>
         <infoLink id="7a39-29f5-588e-8df3" name="Mobile Fortress" hidden="false" targetId="4984-fddb-b1ad-d7a3" type="profile">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="74f3-8621-746b-46eb" name="Explodes (6+/6&quot;/D6)" hidden="false" targetId="8159-a610-444f-d93c" type="profile">
           <profiles/>
           <rules/>
           <infoLinks/>


### PR DESCRIPTION
I added a mandatory Upgrade to Grot Tanks that explains they require a big mek.   Closes #2881

Added explosions to attlewagon w/ Supa-Kannon  Closes #2755