### PR TITLE
Grey Knight Psychic Power changes

### DIFF
--- a/Imperium - Grey Knights.cat
+++ b/Imperium - Grey Knights.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="0cc2-3545-6762-a3f7" name="Imperium - Grey Knights" book="Grey Knight 8th Edition Codex 2017" page="" revision="18" battleScribeVersion="2.01" authorName="tekton" authorContact="" gameSystemId="28ec-711c-d87f-3aeb" gameSystemRevision="1" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="0cc2-3545-6762-a3f7" name="Imperium - Grey Knights" book="Grey Knight 8th Edition Codex 2017" page="" revision="19" battleScribeVersion="2.01" authorName="tekton" authorContact="" gameSystemId="28ec-711c-d87f-3aeb" gameSystemRevision="1" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <profiles/>
   <rules/>
   <infoLinks/>
@@ -1063,7 +1063,7 @@
           <infoLinks/>
           <modifiers/>
         </infoLink>
-        <infoLink id="8b4a-a4c6-0a07-8e2a" name="Psyker (Sanctic 1 Squad)" hidden="false" targetId="b0e6-c2fd-8a9e-9258" type="profile">
+        <infoLink id="8b4a-a4c6-0a07-8e2a" name="Psyker (Sanctic 1)" hidden="false" targetId="100e-a5f5-4af4-8c40" type="profile">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -1796,15 +1796,6 @@
             <characteristic name="Save" characteristicTypeId="c0df-df94-abd7-e8d3" value="2+"/>
           </characteristics>
         </profile>
-        <profile id="d828-ceda-580f-8241" name="Psyker" hidden="false" profileTypeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" profileTypeName="Abilities">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <characteristics>
-            <characteristic name="Description" characteristicTypeId="21befb24-fc85-4f52-a745-64b2e48f8228" value="Lord Kaldor Draigo can attempt to manifest two psychic powers in each friendly Psychic phase and attempt to deny two psychic powers in each enemy Psychic phase. He knows the Smite psychic power and two psychic powers from the Sanctic discipline."/>
-          </characteristics>
-        </profile>
       </profiles>
       <rules/>
       <infoLinks>
@@ -1845,6 +1836,12 @@
           <modifiers/>
         </infoLink>
         <infoLink id="a2b8-0519-f7e2-fcc1" name="Bane of Evil" hidden="false" targetId="5e20-12a8-78b5-6d3f" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="3442-c8a0-949d-af5e" name="Psyker (Sanctic 2)" hidden="false" targetId="ab24-41ef-2542-25de" type="profile">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -3176,15 +3173,6 @@
             <characteristic name="Save" characteristicTypeId="c0df-df94-abd7-e8d3" value="2+"/>
           </characteristics>
         </profile>
-        <profile id="df69-3cd1-48e7-81d9" name="Psyker" hidden="false" profileTypeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" profileTypeName="Abilities">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <characteristics>
-            <characteristic name="Description" characteristicTypeId="21befb24-fc85-4f52-a745-64b2e48f8228" value="Grand Master Voldus can attempt to manifest three psychic powers in each friendly Psychic phase and attempt to deny three psychic powers in each enemy Psychic phase. He knows the Smite psychic power and three psychic powers from the Sanctic discipline."/>
-          </characteristics>
-        </profile>
       </profiles>
       <rules/>
       <infoLinks>
@@ -3219,6 +3207,12 @@
           <modifiers/>
         </infoLink>
         <infoLink id="f2e8-383a-cc46-b365" name="Smite (Rites of Banishment)" hidden="false" targetId="142a-cae9-795d-d610" type="profile">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="5ef3-f5cd-650c-4284" name="Psyker (Sanctic 3)" hidden="false" targetId="cccc-a033-cf65-962b" type="profile">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -3518,7 +3512,7 @@
           <infoLinks/>
           <modifiers/>
         </infoLink>
-        <infoLink id="173d-25be-615a-3c18" name="Psyker (Sanctic 1 Squad)" hidden="false" targetId="b0e6-c2fd-8a9e-9258" type="profile">
+        <infoLink id="173d-25be-615a-3c18" name="Psyker (Sanctic 1)" hidden="false" targetId="100e-a5f5-4af4-8c40" type="profile">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -4003,7 +3997,7 @@
           <infoLinks/>
           <modifiers/>
         </infoLink>
-        <infoLink id="cfc0-0a4e-cbef-9915" name="Psyker (Sanctic 1 Squad)" hidden="false" targetId="b0e6-c2fd-8a9e-9258" type="profile">
+        <infoLink id="cfc0-0a4e-cbef-9915" name="Psyker (Sanctic 1)" hidden="false" targetId="100e-a5f5-4af4-8c40" type="profile">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -4640,7 +4634,7 @@
           <infoLinks/>
           <modifiers/>
         </infoLink>
-        <infoLink id="c8af-2e13-68da-731d" name="New InfoLink" hidden="false" targetId="b0e6-c2fd-8a9e-9258" type="profile">
+        <infoLink id="c8af-2e13-68da-731d" name="Psyker (Sanctic 1)" hidden="false" targetId="100e-a5f5-4af4-8c40" type="profile">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -5494,7 +5488,7 @@
           <infoLinks/>
           <modifiers/>
         </infoLink>
-        <infoLink id="c8f6-f141-0dd6-60c8" name="New InfoLink" hidden="false" targetId="b0e6-c2fd-8a9e-9258" type="profile">
+        <infoLink id="c8f6-f141-0dd6-60c8" name="Psyker (Sanctic 1)" hidden="false" targetId="100e-a5f5-4af4-8c40" type="profile">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -6349,7 +6343,7 @@
           <infoLinks/>
           <modifiers/>
         </infoLink>
-        <infoLink id="c89f-ff34-66db-239d" name="New InfoLink" hidden="false" targetId="b0e6-c2fd-8a9e-9258" type="profile">
+        <infoLink id="c89f-ff34-66db-239d" name="Psyker (Sanctic 1)" hidden="false" targetId="100e-a5f5-4af4-8c40" type="profile">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -12410,7 +12404,10 @@
           <categoryLinks/>
         </entryLink>
       </entryLinks>
-      <costs/>
+      <costs>
+        <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="0.0"/>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
     </selectionEntry>
   </sharedSelectionEntries>
   <sharedSelectionEntryGroups>
@@ -14775,7 +14772,10 @@
           <selectionEntries/>
           <selectionEntryGroups/>
           <entryLinks/>
-          <costs/>
+          <costs>
+            <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="0.0"/>
+            <cost name="pts" costTypeId="points" value="0.0"/>
+          </costs>
         </selectionEntry>
         <selectionEntry id="efd1-09f0-1f59-f538" name="Double (3CP)" hidden="false" collective="false" type="upgrade">
           <profiles/>
@@ -14787,7 +14787,10 @@
           <selectionEntries/>
           <selectionEntryGroups/>
           <entryLinks/>
-          <costs/>
+          <costs>
+            <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="0.0"/>
+            <cost name="pts" costTypeId="points" value="0.0"/>
+          </costs>
         </selectionEntry>
       </selectionEntries>
       <selectionEntryGroups/>
@@ -15573,8 +15576,8 @@
       <characteristics>
         <characteristic name="Cast" characteristicTypeId="5afb-9914-904b-d3b3" value="1"/>
         <characteristic name="Deny" characteristicTypeId="b5ac-9c20-5d5a-6f9b" value="1"/>
-        <characteristic name="Powers Known" characteristicTypeId="69d7-b45e-00a2-7e46" value="1"/>
-        <characteristic name="Other" characteristicTypeId="c2e2-f115-0003-5d7b" value="Sanctic"/>
+        <characteristic name="Powers Known" characteristicTypeId="69d7-b45e-00a2-7e46" value="Smite and one power from the Santic discipline"/>
+        <characteristic name="Other" characteristicTypeId="c2e2-f115-0003-5d7b" value=""/>
       </characteristics>
     </profile>
     <profile id="ab24-41ef-2542-25de" name="Psyker (Sanctic 2)" hidden="false" profileTypeId="bc97-dea9-9e88-bb7d" profileTypeName="Psyker">
@@ -15584,21 +15587,9 @@
       <modifiers/>
       <characteristics>
         <characteristic name="Cast" characteristicTypeId="5afb-9914-904b-d3b3" value="2"/>
-        <characteristic name="Deny" characteristicTypeId="b5ac-9c20-5d5a-6f9b" value="1"/>
-        <characteristic name="Powers Known" characteristicTypeId="69d7-b45e-00a2-7e46" value="2"/>
-        <characteristic name="Other" characteristicTypeId="c2e2-f115-0003-5d7b" value="Sanctic"/>
-      </characteristics>
-    </profile>
-    <profile id="b0e6-c2fd-8a9e-9258" name="Psyker (Sanctic 1 Squad)" hidden="false" profileTypeId="bc97-dea9-9e88-bb7d" profileTypeName="Psyker">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <characteristics>
-        <characteristic name="Cast" characteristicTypeId="5afb-9914-904b-d3b3" value="1"/>
-        <characteristic name="Deny" characteristicTypeId="b5ac-9c20-5d5a-6f9b" value="1"/>
-        <characteristic name="Powers Known" characteristicTypeId="69d7-b45e-00a2-7e46" value="1"/>
-        <characteristic name="Other" characteristicTypeId="c2e2-f115-0003-5d7b" value="When manifesting or denying a psychic power, first select a model in the unit - measure range, visibility, etc. from this model. If the unit suffers Perils of the Warp, is suffers D3 mortal wounds as described in the core rules, but units within 6&quot; with only suffer damage if the Perils of the Warp cause the last model in the manifesting unit to be slain."/>
+        <characteristic name="Deny" characteristicTypeId="b5ac-9c20-5d5a-6f9b" value="2"/>
+        <characteristic name="Powers Known" characteristicTypeId="69d7-b45e-00a2-7e46" value="Smite and two powers from the Santic discipline"/>
+        <characteristic name="Other" characteristicTypeId="c2e2-f115-0003-5d7b" value=""/>
       </characteristics>
     </profile>
     <profile id="0e74-2adc-df5c-ef69" name="Purifier" hidden="false" profileTypeId="800f-21d0-4387-c943" profileTypeName="Unit">
@@ -15700,9 +15691,9 @@
       <modifiers/>
       <characteristics>
         <characteristic name="Cast" characteristicTypeId="5afb-9914-904b-d3b3" value="3"/>
-        <characteristic name="Deny" characteristicTypeId="b5ac-9c20-5d5a-6f9b" value="2"/>
-        <characteristic name="Powers Known" characteristicTypeId="69d7-b45e-00a2-7e46" value="3"/>
-        <characteristic name="Other" characteristicTypeId="c2e2-f115-0003-5d7b" value="Sanctic"/>
+        <characteristic name="Deny" characteristicTypeId="b5ac-9c20-5d5a-6f9b" value="3"/>
+        <characteristic name="Powers Known" characteristicTypeId="69d7-b45e-00a2-7e46" value="Smite and three powers from the Santic discipline"/>
+        <characteristic name="Other" characteristicTypeId="c2e2-f115-0003-5d7b" value=""/>
       </characteristics>
     </profile>
     <profile id="0bfb-85df-d64f-c8c1" name="Astral Aim" hidden="false" profileTypeId="ae70-4738-0161-bec0" profileTypeName="Psychic Power">
@@ -15848,7 +15839,7 @@
       <characteristics>
         <characteristic name="Cast" characteristicTypeId="5afb-9914-904b-d3b3" value="2"/>
         <characteristic name="Deny" characteristicTypeId="b5ac-9c20-5d5a-6f9b" value="1"/>
-        <characteristic name="Powers Known" characteristicTypeId="69d7-b45e-00a2-7e46" value="Smite, +1"/>
+        <characteristic name="Powers Known" characteristicTypeId="69d7-b45e-00a2-7e46" value="Smite and one power from the Santic discipline"/>
         <characteristic name="Other" characteristicTypeId="c2e2-f115-0003-5d7b" value="Sanctic"/>
       </characteristics>
     </profile>


### PR DESCRIPTION
Fixes BSData/wh40k#2856

Tried to bring style in line with other factions using the phrase "Smite and one power form the Santic discipline" for the `Powers Known` characteristic. Also removed redundant "Psyker (Santic 1 Squad) `profile`." Verified each unit against Codex: Grey Knights.