### PR TITLE
Chapter Approved 2018 Thousand Sons Changes

### DIFF
--- a/Chaos - Chaos Space Marines.cat
+++ b/Chaos - Chaos Space Marines.cat
@@ -12373,7 +12373,7 @@ If your summoning roll included any doubles, your character then suffers a morta
       <selectionEntryGroups/>
       <entryLinks/>
       <costs>
-        <cost name="pts" costTypeId="points" value="11.0"/>
+        <cost name="pts" costTypeId="points" value="6.0"/>
         <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="0.0"/>
       </costs>
     </selectionEntry>

--- a/Chaos - Thousand Sons.cat
+++ b/Chaos - Thousand Sons.cat
@@ -4911,7 +4911,7 @@ If your summoning roll included any doubles, your character suffers a mortal wou
       <selectionEntryGroups/>
       <entryLinks/>
       <costs>
-        <cost name="pts" costTypeId="points" value="11.0"/>
+        <cost name="pts" costTypeId="points" value="6.0"/>
         <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="0.0"/>
       </costs>
     </selectionEntry>
@@ -5332,7 +5332,7 @@ If your summoning roll included any doubles, your character suffers a mortal wou
               <rules/>
               <infoLinks/>
               <modifiers>
-                <modifier type="set" field="points" value="25">
+                <modifier type="set" field="points" value="20">
                   <repeats/>
                   <conditions>
                     <condition field="selections" scope="5cae-15dc-4a5d-0b9b" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="75b4-d815-ac31-29dc" type="equalTo"/>
@@ -6504,7 +6504,6 @@ If your summoning roll included any doubles, your character suffers a mortal wou
       <selectionEntryGroups/>
       <entryLinks/>
       <costs>
-        <cost name="pts" costTypeId="points" value="1.0"/>
         <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="0.0"/>
       </costs>
     </selectionEntry>
@@ -8010,7 +8009,7 @@ If your summoning roll included any doubles, your character suffers a mortal wou
           <selectionEntryGroups/>
           <entryLinks/>
           <costs>
-            <cost name="pts" costTypeId="points" value="50.0"/>
+            <cost name="pts" costTypeId="points" value="40.0"/>
             <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="0.0"/>
           </costs>
         </selectionEntry>

--- a/Chaos - Thousand Sons.cat
+++ b/Chaos - Thousand Sons.cat
@@ -1944,7 +1944,7 @@ If your summoning roll included any doubles, your character suffers a mortal wou
               <selectionEntryGroups/>
               <entryLinks/>
               <costs>
-                <cost name="pts" costTypeId="points" value="25.0"/>
+                <cost name="pts" costTypeId="points" value="20.0"/>
                 <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="0.0"/>
               </costs>
             </selectionEntry>
@@ -3025,7 +3025,7 @@ If your summoning roll included any doubles, your character suffers a mortal wou
                   <selectionEntryGroups/>
                   <entryLinks/>
                   <costs>
-                    <cost name="pts" costTypeId="points" value="15.0"/>
+                    <cost name="pts" costTypeId="points" value="10.0"/>
                     <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="0.0"/>
                   </costs>
                 </selectionEntry>
@@ -3471,7 +3471,7 @@ If your summoning roll included any doubles, your character suffers a mortal wou
                       <selectionEntryGroups/>
                       <entryLinks/>
                       <costs>
-                        <cost name="pts" costTypeId="points" value="23.0"/>
+                        <cost name="pts" costTypeId="points" value="17.0"/>
                         <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="0.0"/>
                       </costs>
                     </selectionEntry>
@@ -5164,7 +5164,7 @@ If your summoning roll included any doubles, your character suffers a mortal wou
               <selectionEntryGroups/>
               <entryLinks/>
               <costs>
-                <cost name="pts" costTypeId="points" value="52.0"/>
+                <cost name="pts" costTypeId="points" value="30.0"/>
                 <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="0.0"/>
               </costs>
             </selectionEntry>
@@ -5194,7 +5194,7 @@ If your summoning roll included any doubles, your character suffers a mortal wou
               <selectionEntryGroups/>
               <entryLinks/>
               <costs>
-                <cost name="pts" costTypeId="points" value="43.0"/>
+                <cost name="pts" costTypeId="points" value="35.0"/>
                 <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="0.0"/>
               </costs>
             </selectionEntry>
@@ -5222,7 +5222,7 @@ If your summoning roll included any doubles, your character suffers a mortal wou
               <rules/>
               <infoLinks/>
               <modifiers>
-                <modifier type="set" field="points" value="25">
+                <modifier type="set" field="points" value="20">
                   <repeats/>
                   <conditions>
                     <condition field="selections" scope="5cae-15dc-4a5d-0b9b" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="788e-fb05-df3f-2a5b" type="equalTo"/>
@@ -5272,7 +5272,7 @@ If your summoning roll included any doubles, your character suffers a mortal wou
               <selectionEntryGroups/>
               <entryLinks/>
               <costs>
-                <cost name="pts" costTypeId="points" value="30.0"/>
+                <cost name="pts" costTypeId="points" value="16.0"/>
                 <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="0.0"/>
               </costs>
             </selectionEntry>
@@ -8256,7 +8256,7 @@ If your summoning roll included any doubles, your character suffers a mortal wou
               <selectionEntryGroups/>
               <entryLinks/>
               <costs>
-                <cost name="pts" costTypeId="points" value="50.0"/>
+                <cost name="pts" costTypeId="points" value="40.0"/>
                 <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="0.0"/>
               </costs>
             </selectionEntry>
@@ -8286,7 +8286,7 @@ If your summoning roll included any doubles, your character suffers a mortal wou
               <selectionEntryGroups/>
               <entryLinks/>
               <costs>
-                <cost name="pts" costTypeId="points" value="52.0"/>
+                <cost name="pts" costTypeId="points" value="40.0"/>
                 <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="0.0"/>
               </costs>
             </selectionEntry>
@@ -8489,7 +8489,7 @@ If your summoning roll included any doubles, your character suffers a mortal wou
       <selectionEntryGroups/>
       <entryLinks/>
       <costs>
-        <cost name="pts" costTypeId="points" value="22.0"/>
+        <cost name="pts" costTypeId="points" value="15.0"/>
         <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="0.0"/>
       </costs>
     </selectionEntry>
@@ -8720,7 +8720,7 @@ If your summoning roll included any doubles, your character suffers a mortal wou
       </selectionEntryGroups>
       <entryLinks/>
       <costs>
-        <cost name="pts" costTypeId="points" value="40.0"/>
+        <cost name="pts" costTypeId="points" value="30.0"/>
         <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="0.0"/>
       </costs>
     </selectionEntry>
@@ -9204,7 +9204,7 @@ If your summoning roll included any doubles, your character suffers a mortal wou
       <selectionEntryGroups/>
       <entryLinks/>
       <costs>
-        <cost name="pts" costTypeId="points" value="7.0"/>
+        <cost name="pts" costTypeId="points" value="3.0"/>
         <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="0.0"/>
       </costs>
     </selectionEntry>
@@ -9320,7 +9320,7 @@ If your summoning roll included any doubles, your character suffers a mortal wou
       <entryLinks/>
       <costs>
         <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="0.0"/>
-        <cost name="pts" costTypeId="points" value="15.0"/>
+        <cost name="pts" costTypeId="points" value="10.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="82df-c079-24a3-7b58" name="Tzaangor Shaman" hidden="false" collective="false" type="model">

--- a/Chaos - Thousand Sons.cat
+++ b/Chaos - Thousand Sons.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="c553-15f3-3890-be39" name="Chaos - Thousand Sons" book="Codex: Thousand Sons, Index: Chaos" revision="43" battleScribeVersion="2.01" authorName="BSData team" authorUrl="http://battlescribedata.appspot.com/#/repo/wh40k" gameSystemId="28ec-711c-d87f-3aeb" gameSystemRevision="1" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="c553-15f3-3890-be39" name="Chaos - Thousand Sons" book="Codex: Thousand Sons, Index: Chaos" revision="44" battleScribeVersion="2.01" authorName="BSData team" authorUrl="http://battlescribedata.appspot.com/#/repo/wh40k" gameSystemId="28ec-711c-d87f-3aeb" gameSystemRevision="1" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <profiles/>
   <rules>
     <rule id="aac0-53ce-e536-4514" name="Disciples of Tzeentch" hidden="false">
@@ -2643,7 +2643,7 @@ If your summoning roll included any doubles, your character suffers a mortal wou
         </entryLink>
       </entryLinks>
       <costs>
-        <cost name="pts" costTypeId="points" value="95.0"/>
+        <cost name="pts" costTypeId="points" value="90.0"/>
         <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="6.0"/>
       </costs>
     </selectionEntry>
@@ -3341,7 +3341,7 @@ If your summoning roll included any doubles, your character suffers a mortal wou
             </entryLink>
           </entryLinks>
           <costs>
-            <cost name="pts" costTypeId="points" value="33.0"/>
+            <cost name="pts" costTypeId="points" value="30.0"/>
             <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="0.0"/>
           </costs>
         </selectionEntry>
@@ -3409,7 +3409,7 @@ If your summoning roll included any doubles, your character suffers a mortal wou
                 </entryLink>
               </entryLinks>
               <costs>
-                <cost name="pts" costTypeId="points" value="33.0"/>
+                <cost name="pts" costTypeId="points" value="30.0"/>
                 <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="0.0"/>
               </costs>
             </selectionEntry>
@@ -3505,7 +3505,7 @@ If your summoning roll included any doubles, your character suffers a mortal wou
                 </entryLink>
               </entryLinks>
               <costs>
-                <cost name="pts" costTypeId="points" value="33.0"/>
+                <cost name="pts" costTypeId="points" value="30.0"/>
                 <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="0.0"/>
               </costs>
             </selectionEntry>
@@ -4369,7 +4369,7 @@ If your summoning roll included any doubles, your character suffers a mortal wou
         </entryLink>
       </entryLinks>
       <costs>
-        <cost name="pts" costTypeId="points" value="120.0"/>
+        <cost name="pts" costTypeId="points" value="102.0"/>
         <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="8.0"/>
       </costs>
     </selectionEntry>

--- a/Chaos - Thousand Sons.cat
+++ b/Chaos - Thousand Sons.cat
@@ -6096,7 +6096,7 @@ If your summoning roll included any doubles, your character suffers a mortal wou
           </selectionEntryGroups>
           <entryLinks/>
           <costs>
-            <cost name="pts" costTypeId="points" value="4.0"/>
+            <cost name="pts" costTypeId="points" value="5.0"/>
             <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="0.0"/>
           </costs>
         </selectionEntry>
@@ -6153,7 +6153,7 @@ If your summoning roll included any doubles, your character suffers a mortal wou
               <entryLinks/>
               <costs>
                 <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="0.0"/>
-                <cost name="pts" costTypeId="points" value="4.0"/>
+                <cost name="pts" costTypeId="points" value="5.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="8ae9-c17b-af6b-0d9e" name="Chaos Cultist w/ autopistol and brutal assault weapon" hidden="false" collective="false" type="model">
@@ -6225,7 +6225,7 @@ If your summoning roll included any doubles, your character suffers a mortal wou
               </entryLinks>
               <costs>
                 <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="0.0"/>
-                <cost name="pts" costTypeId="points" value="4.0"/>
+                <cost name="pts" costTypeId="points" value="5.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="7d90-d691-a7cb-4fd3" name="Chaos Cultist w/ special weapon" hidden="false" collective="false" type="model">
@@ -6281,7 +6281,7 @@ If your summoning roll included any doubles, your character suffers a mortal wou
               </selectionEntryGroups>
               <entryLinks/>
               <costs>
-                <cost name="pts" costTypeId="points" value="4.0"/>
+                <cost name="pts" costTypeId="points" value="5.0"/>
                 <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="0.0"/>
               </costs>
             </selectionEntry>

--- a/Chaos - Thousand Sons.cat
+++ b/Chaos - Thousand Sons.cat
@@ -1709,7 +1709,7 @@ If your summoning roll included any doubles, your character suffers a mortal wou
         </entryLink>
       </entryLinks>
       <costs>
-        <cost name="pts" costTypeId="points" value="140.0"/>
+        <cost name="pts" costTypeId="points" value="120.0"/>
         <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="11.0"/>
       </costs>
     </selectionEntry>
@@ -1977,7 +1977,7 @@ If your summoning roll included any doubles, your character suffers a mortal wou
       </selectionEntryGroups>
       <entryLinks/>
       <costs>
-        <cost name="pts" costTypeId="points" value="138.0"/>
+        <cost name="pts" costTypeId="points" value="120.0"/>
         <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="10.0"/>
       </costs>
     </selectionEntry>
@@ -2251,7 +2251,7 @@ If your summoning roll included any doubles, your character suffers a mortal wou
       </selectionEntryGroups>
       <entryLinks/>
       <costs>
-        <cost name="pts" costTypeId="points" value="140.0"/>
+        <cost name="pts" costTypeId="points" value="120.0"/>
         <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="9.0"/>
       </costs>
     </selectionEntry>
@@ -2922,7 +2922,7 @@ If your summoning roll included any doubles, your character suffers a mortal wou
             </entryLink>
           </entryLinks>
           <costs>
-            <cost name="pts" costTypeId="points" value="18.0"/>
+            <cost name="pts" costTypeId="points" value="16.0"/>
             <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="0.0"/>
           </costs>
         </selectionEntry>
@@ -2984,7 +2984,7 @@ If your summoning roll included any doubles, your character suffers a mortal wou
               <selectionEntryGroups/>
               <entryLinks/>
               <costs>
-                <cost name="pts" costTypeId="points" value="18.0"/>
+                <cost name="pts" costTypeId="points" value="16.0"/>
                 <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="0.0"/>
               </costs>
             </selectionEntry>
@@ -3033,7 +3033,7 @@ If your summoning roll included any doubles, your character suffers a mortal wou
               <selectionEntryGroups/>
               <entryLinks/>
               <costs>
-                <cost name="pts" costTypeId="points" value="18.0"/>
+                <cost name="pts" costTypeId="points" value="16.0"/>
                 <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="0.0"/>
               </costs>
             </selectionEntry>
@@ -3070,7 +3070,7 @@ If your summoning roll included any doubles, your character suffers a mortal wou
                 </entryLink>
               </entryLinks>
               <costs>
-                <cost name="pts" costTypeId="points" value="18.0"/>
+                <cost name="pts" costTypeId="points" value="16.0"/>
                 <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="0.0"/>
               </costs>
             </selectionEntry>
@@ -5348,7 +5348,7 @@ If your summoning roll included any doubles, your character suffers a mortal wou
       </selectionEntryGroups>
       <entryLinks/>
       <costs>
-        <cost name="pts" costTypeId="points" value="72.0"/>
+        <cost name="pts" costTypeId="points" value="60.0"/>
         <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="7.0"/>
       </costs>
     </selectionEntry>
@@ -6466,7 +6466,7 @@ If your summoning roll included any doubles, your character suffers a mortal wou
           <selectionEntryGroups/>
           <entryLinks/>
           <costs>
-            <cost name="pts" costTypeId="points" value="33.0"/>
+            <cost name="pts" costTypeId="points" value="25.0"/>
             <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="2.0"/>
           </costs>
         </selectionEntry>
@@ -8372,7 +8372,7 @@ If your summoning roll included any doubles, your character suffers a mortal wou
       </selectionEntryGroups>
       <entryLinks/>
       <costs>
-        <cost name="pts" costTypeId="points" value="119.0"/>
+        <cost name="pts" costTypeId="points" value="100.0"/>
         <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="9.0"/>
       </costs>
     </selectionEntry>
@@ -10197,7 +10197,7 @@ If your summoning roll included any doubles, your character suffers a mortal wou
       <entryLinks/>
       <costs>
         <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="8.0"/>
-        <cost name="pts" costTypeId="points" value="150.0"/>
+        <cost name="pts" costTypeId="points" value="125.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="1b20-1c27-6f89-ddbe" name="Relics of the Thousand Sons (1 Relic)" hidden="false" collective="false" type="upgrade">

--- a/Chaos - Thousand Sons.cat
+++ b/Chaos - Thousand Sons.cat
@@ -8057,7 +8057,7 @@ If your summoning roll included any doubles, your character suffers a mortal wou
         </entryLink>
       </entryLinks>
       <costs>
-        <cost name="pts" costTypeId="points" value="239.0"/>
+        <cost name="pts" costTypeId="points" value="200.0"/>
         <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="19.0"/>
       </costs>
     </selectionEntry>

--- a/Warhammer 40,000 8th Edition.gst
+++ b/Warhammer 40,000 8th Edition.gst
@@ -5352,7 +5352,7 @@
       <selectionEntryGroups/>
       <entryLinks/>
       <costs>
-        <cost name="pts" costTypeId="points" value="9.0"/>
+        <cost name="pts" costTypeId="points" value="6.0"/>
         <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="0.0"/>
       </costs>
     </selectionEntry>
@@ -5452,7 +5452,7 @@
       <selectionEntryGroups/>
       <entryLinks/>
       <costs>
-        <cost name="pts" costTypeId="points" value="7.0"/>
+        <cost name="pts" costTypeId="points" value="5.0"/>
         <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="0.0"/>
       </costs>
     </selectionEntry>
@@ -5612,7 +5612,7 @@
       <selectionEntryGroups/>
       <entryLinks/>
       <costs>
-        <cost name="pts" costTypeId="points" value="17.0"/>
+        <cost name="pts" costTypeId="points" value="12.0"/>
         <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="0.0"/>
       </costs>
     </selectionEntry>
@@ -5640,7 +5640,7 @@
       <selectionEntryGroups/>
       <entryLinks/>
       <costs>
-        <cost name="pts" costTypeId="points" value="25.0"/>
+        <cost name="pts" costTypeId="points" value="20.0"/>
         <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="0.0"/>
       </costs>
     </selectionEntry>
@@ -5674,7 +5674,7 @@
       <selectionEntryGroups/>
       <entryLinks/>
       <costs>
-        <cost name="pts" costTypeId="points" value="11.0"/>
+        <cost name="pts" costTypeId="points" value="8.0"/>
         <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="0.0"/>
       </costs>
     </selectionEntry>
@@ -5748,7 +5748,7 @@
       <selectionEntryGroups/>
       <entryLinks/>
       <costs>
-        <cost name="pts" costTypeId="points" value="19.0"/>
+        <cost name="pts" costTypeId="points" value="15.0"/>
         <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="0.0"/>
       </costs>
     </selectionEntry>
@@ -5814,7 +5814,7 @@
       <selectionEntryGroups/>
       <entryLinks/>
       <costs>
-        <cost name="pts" costTypeId="points" value="27.0"/>
+        <cost name="pts" costTypeId="points" value="22.0"/>
         <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="0.0"/>
       </costs>
     </selectionEntry>
@@ -5954,7 +5954,7 @@
       <selectionEntryGroups/>
       <entryLinks/>
       <costs>
-        <cost name="pts" costTypeId="points" value="4.0"/>
+        <cost name="pts" costTypeId="points" value="2.0"/>
         <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="0.0"/>
       </costs>
     </selectionEntry>
@@ -7252,7 +7252,7 @@
       <selectionEntryGroups/>
       <entryLinks/>
       <costs>
-        <cost name="pts" costTypeId="points" value="34.0"/>
+        <cost name="pts" costTypeId="points" value="28.0"/>
         <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="0.0"/>
       </costs>
     </selectionEntry>
@@ -7302,7 +7302,7 @@
       <selectionEntryGroups/>
       <entryLinks/>
       <costs>
-        <cost name="pts" costTypeId="points" value="50.0"/>
+        <cost name="pts" costTypeId="points" value="40.0"/>
         <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="0.0"/>
       </costs>
     </selectionEntry>
@@ -11533,7 +11533,7 @@
       <selectionEntryGroups/>
       <entryLinks/>
       <costs>
-        <cost name="pts" costTypeId="points" value="11.0"/>
+        <cost name="pts" costTypeId="points" value="6.0"/>
         <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="0.0"/>
       </costs>
     </selectionEntry>

--- a/Warhammer 40,000 8th Edition.gst
+++ b/Warhammer 40,000 8th Edition.gst
@@ -7010,7 +7010,7 @@
       <selectionEntryGroups/>
       <entryLinks/>
       <costs>
-        <cost name="pts" costTypeId="points" value="15.0"/>
+        <cost name="pts" costTypeId="points" value="10.0"/>
         <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="0.0"/>
       </costs>
     </selectionEntry>

--- a/Warhammer 40,000 8th Edition.gst
+++ b/Warhammer 40,000 8th Edition.gst
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<gameSystem id="28ec-711c-d87f-3aeb" name="Warhammer 40,000 8th Edition" revision="58" battleScribeVersion="2.01" authorName="BSData Organisation" authorContact="@BSData" authorUrl="http://battlescribedata.appspot.com/#/repo/wh40k" xmlns="http://www.battlescribe.net/schema/gameSystemSchema">
+<gameSystem id="28ec-711c-d87f-3aeb" name="Warhammer 40,000 8th Edition" revision="59" battleScribeVersion="2.01" authorName="BSData Organisation" authorContact="@BSData" authorUrl="http://battlescribedata.appspot.com/#/repo/wh40k" xmlns="http://www.battlescribe.net/schema/gameSystemSchema">
   <profiles/>
   <rules/>
   <infoLinks/>


### PR DESCRIPTION
These are all the points changes for Codex Thousand Sons from Chapter Approved 2018.

I had to change 3 files, as some items were common across multiple lists.  I have uprevved the version numbers for these files.This means that some of the common changes that apply to other armies (ie. Twin Lascannon going from 50 to 40 points) are in here since they apply to the Thousand Sons but other changes to those armies won't be present (ie. other changes to Codex CSM)

The changes are just point values; I didn't have to add/remove any unit entries, which kept the changes simple.
