### PR TITLE
Fix Wraithguard in CA

### DIFF
--- a/Aeldari - Craftworlds.cat
+++ b/Aeldari - Craftworlds.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="30b2-6f64-b85e-b4dc" name="Aeldari - Craftworlds" book="Codex: Craftworlds, Index: Xenos 1, Blackstone Fortress" revision="48" battleScribeVersion="2.01" gameSystemId="28ec-711c-d87f-3aeb" gameSystemRevision="1" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="30b2-6f64-b85e-b4dc" name="Aeldari - Craftworlds" book="Codex: Craftworlds, Index: Xenos 1, Blackstone Fortress" revision="49" battleScribeVersion="2.01" gameSystemId="28ec-711c-d87f-3aeb" gameSystemRevision="1" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <profiles/>
   <rules/>
   <infoLinks/>

--- a/Aeldari - Craftworlds.cat
+++ b/Aeldari - Craftworlds.cat
@@ -10249,7 +10249,7 @@
               <rules/>
               <infoLinks/>
               <modifiers>
-                <modifier type="increment" field="points" value="22">
+                <modifier type="increment" field="points" value="20">
                   <repeats>
                     <repeat field="selections" scope="ec4c-ec53-025c-8b6f" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="4c28-19d6-7077-99cb" repeats="1" roundUp="false"/>
                   </repeats>
@@ -10265,7 +10265,7 @@
               <rules/>
               <infoLinks/>
               <modifiers>
-                <modifier type="increment" field="points" value="17">
+                <modifier type="increment" field="points" value="15">
                   <repeats>
                     <repeat field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="model" repeats="1" roundUp="false"/>
                   </repeats>
@@ -15247,7 +15247,7 @@
       <entryLinks/>
       <costs>
         <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="0.0"/>
-        <cost name="pts" costTypeId="points" value="15.0"/>
+        <cost name="pts" costTypeId="points" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="6dc8-22dc-4168-84f5" name="Witchblade" hidden="false" collective="false" type="upgrade">
@@ -15936,7 +15936,7 @@
       <entryLinks/>
       <costs>
         <cost name=" PL" costTypeId="e356-c769-5920-6e14" value="0.0"/>
-        <cost name="pts" costTypeId="points" value="15.0"/>
+        <cost name="pts" costTypeId="points" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="6336-ee3e-00ae-aeb9" name="Aeldari Blade" hidden="false" collective="false" type="upgrade">


### PR DESCRIPTION
Fixes #3987 - removes base cost from the Selection Entry (as it causes double counting) and changes the inc cost to 15 for Wraithcannon, and 20 for D-Scythe in the selection entry group.