### PR TITLE
Added new rules, changes and units for space wolves

### DIFF
--- a/Imperium - Space Wolves.cat
+++ b/Imperium - Space Wolves.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="24b6-2b46-0063-2867" name="Imperium - Space Wolves" revision="88" battleScribeVersion="2.02" authorName="CrusherJoe" authorContact="@CrusherJoe" authorUrl="https://discord.gg/KqPVhds" library="false" gameSystemId="28ec-711c-d87f-3aeb" gameSystemRevision="1" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="24b6-2b46-0063-2867" name="Imperium - Space Wolves" revision="89" battleScribeVersion="2.02" authorName="CrusherJoe" authorContact="@CrusherJoe" authorUrl="https://discord.gg/KqPVhds" library="false" gameSystemId="28ec-711c-d87f-3aeb" gameSystemRevision="1" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <publications>
     <publication id="24b6-2b46-pubN65537" name="Codex: Space Wolves"/>
     <publication id="24b6-2b46-pubN166488" name="Chapter Approved 2017"/>
@@ -119,6 +119,7 @@
     <categoryEntry id="ec1d-8b79-1471-e8fc" name="Eliminator Squad" hidden="false"/>
     <categoryEntry id="1b53-08d9-7c68-b30e" name="Infiltrator Squad" hidden="false"/>
     <categoryEntry id="6720-939f-b4ed-7718" name="Suppressor Squad" hidden="false"/>
+    <categoryEntry id="d78a-9066-6f29-3930" name="Invictor Tactical Warsuit" hidden="false"/>
   </categoryEntries>
   <entryLinks>
     <entryLink id="bccc-fd65-07f8-77af" name="Ragnar Blackmane" hidden="false" collective="false" targetId="c730-c6a1-40ae-1bf0" type="selectionEntry"/>
@@ -167,7 +168,7 @@
     <entryLink id="9429-b3af-e286-807d" name="New EntryLink" hidden="false" collective="false" targetId="de3d-a10e-0f08-6c9c" type="selectionEntry"/>
     <entryLink id="486f-2f6b-6c0b-9322" name="Drop Pod" hidden="false" collective="false" targetId="901e-edf0-90dd-8130" type="selectionEntry"/>
     <entryLink id="2de4-794e-73af-63e0" name="New EntryLink" hidden="false" collective="false" targetId="bd95-3ac7-a2c0-a49d" type="selectionEntry"/>
-    <entryLink id="fa59-d640-767e-7f6d" name="New EntryLink" hidden="false" collective="false" targetId="4456-36bc-1b14-da0f" type="selectionEntry"/>
+    <entryLink id="fa59-d640-767e-7f6d" name="Imperial Space Marine" hidden="false" collective="false" targetId="4456-36bc-1b14-da0f" type="selectionEntry"/>
     <entryLink id="1109-b61c-4be8-108d" name="Land Raider" hidden="false" collective="false" targetId="7884-f70a-d9d1-d7c1" type="selectionEntry"/>
     <entryLink id="b6be-4102-53ca-bf08" name="New EntryLink" hidden="false" collective="false" targetId="817b-2247-549b-5ba9" type="selectionEntry"/>
     <entryLink id="b57d-83c2-0413-b5ce" name="New EntryLink" hidden="false" collective="false" targetId="b211-b39c-d07e-5e31" type="selectionEntry"/>
@@ -312,6 +313,9 @@
         <categoryLink id="acd5-6efc-d305-eff0" name="New CategoryLink" hidden="false" targetId="abf5fd55-9ac7-4263-8bc1-a9fb0a8fa6a6" primary="true"/>
       </categoryLinks>
     </entryLink>
+    <entryLink id="9c53-63c0-3919-9efe" name="Invictor Tactical Warsuit" hidden="false" collective="false" targetId="feb0-c88f-7608-1eaa" type="selectionEntry"/>
+    <entryLink id="b420-0126-ed31-dff2" name="Incursor Squad" page="" hidden="false" collective="false" targetId="674b-7928-5552-905b" type="selectionEntry"/>
+    <entryLink id="e376-eb01-fe38-6e93" name="Impulsor" hidden="false" collective="false" targetId="5de6-f371-d838-a3a1" type="selectionEntry"/>
   </entryLinks>
   <infoLinks>
     <infoLink id="62e2-2d8c-8242-d10f" name="Shock Assault" hidden="false" targetId="f9ce-5a8b-7abd-2395" type="rule"/>
@@ -7623,7 +7627,7 @@
     </selectionEntry>
     <selectionEntry id="9efa-8744-f254-c046" name="Inceptor Squad" hidden="false" collective="false" type="unit">
       <modifiers>
-        <modifier type="increment" field="e356-c769-5920-6e14" value="10">
+        <modifier type="increment" field="e356-c769-5920-6e14" value="10.0">
           <conditions>
             <condition field="selections" scope="9efa-8744-f254-c046" value="3.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="3200-23f7-1fb3-3c3f" type="greaterThan"/>
           </conditions>
@@ -11417,7 +11421,7 @@
         </selectionEntryGroup>
       </selectionEntryGroups>
       <entryLinks>
-        <entryLink id="5b05-75c6-e839-437d" name="New EntryLink" hidden="false" collective="false" targetId="a869-5624-fe55-fe95" type="selectionEntry">
+        <entryLink id="5b05-75c6-e839-437d" name="Dreadnought combat weapon" hidden="false" collective="false" targetId="a869-5624-fe55-fe95" type="selectionEntry">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="9ac4-55e5-7c0b-7594" type="min"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="d509-5353-9ed5-fe43" type="max"/>
@@ -13175,18 +13179,12 @@
           </conditions>
         </modifier>
       </modifiers>
-      <profiles>
-        <profile id="1eee-ec9f-0958-6877" name="Smoke Grenades" hidden="false" typeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" typeName="Abilities">
-          <characteristics>
-            <characteristic name="Description" typeId="21befb24-fc85-4f52-a745-64b2e48f8228">Once per battle, instead of shooting any weapons in the Shooting phase, this unit can use its smoke grenades; until your next Shooting phase, your opponent must subtract 1 from hit rolls for attacks made with ranged weapons that target this unit.</characteristic>
-          </characteristics>
-        </profile>
-      </profiles>
       <infoLinks>
         <infoLink id="4b31-9ccc-04d1-ecba" name="And They Shall Know No Fear" hidden="false" targetId="4ea8-94d3-ba39-042f" type="rule"/>
         <infoLink id="a4dd-98fc-209e-1654" name="Combat Squads" hidden="false" targetId="3e31-4e4b-6ab6-d90b" type="profile"/>
         <infoLink id="1638-3846-bd72-0146" name="Concealed Positions" hidden="false" targetId="5471-06f7-fab0-0e4b" type="profile"/>
         <infoLink id="e930-0d17-33b6-32ce" name="Omni-scramblers" hidden="false" targetId="4632-82db-5c5e-db39" type="profile"/>
+        <infoLink id="0235-78c5-31a0-8342" name="Smoke Grenades" hidden="false" targetId="0d60-a97a-1ce4-c8f3" type="profile"/>
       </infoLinks>
       <categoryLinks>
         <categoryLink id="152d-b185-46f7-b2c6" name="Faction: Imperium" hidden="false" targetId="84e2-9fa9-ebe6-1d18" primary="false"/>
@@ -13781,6 +13779,489 @@
       <costs>
         <cost name=" PL" typeId="e356-c769-5920-6e14" value="15.0"/>
         <cost name="pts" typeId="points" value="215.0"/>
+        <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="feb0-c88f-7608-1eaa" name="Invictor Tactical Warsuit" hidden="false" collective="false" type="upgrade">
+      <profiles>
+        <profile id="493f-5b05-eb07-d675" name="Invictor Tactical Warsuit" hidden="false" typeId="800f-21d0-4387-c943" typeName="Unit">
+          <characteristics>
+            <characteristic name="M" typeId="0bdf-a96e-9e38-7779">*</characteristic>
+            <characteristic name="WS" typeId="e7f0-1278-0250-df0c">*</characteristic>
+            <characteristic name="BS" typeId="381b-eb28-74c3-df5f">*</characteristic>
+            <characteristic name="S" typeId="2218-aa3c-265f-2939">7</characteristic>
+            <characteristic name="T" typeId="9c9f-9774-a358-3a39">6</characteristic>
+            <characteristic name="W" typeId="f330-5e6e-4110-0978">13</characteristic>
+            <characteristic name="A" typeId="13fc-b29b-31f2-ab9f">4</characteristic>
+            <characteristic name="Ld" typeId="00ca-f8b8-876d-b705">8</characteristic>
+            <characteristic name="Save" typeId="c0df-df94-abd7-e8d3">3+</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="0a6d-4bed-b897-2640" name="Row1" hidden="false" typeId="5f4f-ea74-0630-4afe" typeName="Wound Track">
+          <characteristics>
+            <characteristic name="Remaining W" typeId="8e45-c866-b2d4-c9ab">7-13+</characteristic>
+            <characteristic name="Characteristic 1" typeId="bf41-c860-50bc-2a7e">10&quot;</characteristic>
+            <characteristic name="Characteristic 2" typeId="dc18-e51f-309b-8efa">3+</characteristic>
+            <characteristic name="Characteristic 3" typeId="df06-8eca-150f-90ba">3+</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="d457-d555-59da-9343" name="Row 2" hidden="false" typeId="5f4f-ea74-0630-4afe" typeName="Wound Track">
+          <characteristics>
+            <characteristic name="Remaining W" typeId="8e45-c866-b2d4-c9ab">4-6</characteristic>
+            <characteristic name="Characteristic 1" typeId="bf41-c860-50bc-2a7e">10&quot;</characteristic>
+            <characteristic name="Characteristic 2" typeId="dc18-e51f-309b-8efa">4+</characteristic>
+            <characteristic name="Characteristic 3" typeId="df06-8eca-150f-90ba">4+</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="c87c-1631-2b81-6b9d" name="Row3" hidden="false" typeId="5f4f-ea74-0630-4afe" typeName="Wound Track">
+          <characteristics>
+            <characteristic name="Remaining W" typeId="8e45-c866-b2d4-c9ab">1-3</characteristic>
+            <characteristic name="Characteristic 1" typeId="bf41-c860-50bc-2a7e">10&quot;</characteristic>
+            <characteristic name="Characteristic 2" typeId="dc18-e51f-309b-8efa">5+</characteristic>
+            <characteristic name="Characteristic 3" typeId="df06-8eca-150f-90ba">5+</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <infoLinks>
+        <infoLink id="d4d9-d3e3-ebc4-9b47" name="Explodes (6&quot;/D6)" hidden="false" targetId="6f8e-9512-0008-d677" type="rule"/>
+        <infoLink id="112d-24fe-45e6-694a" name="Concealed Position" hidden="false" targetId="efe4-0c8b-5f84-eaa2" type="profile"/>
+        <infoLink id="0c75-bd8d-779e-d3d9" name="Heavy Sidearm" hidden="false" targetId="208a-fb06-0f2e-c368" type="profile"/>
+        <infoLink id="87b6-bea1-fd75-8ea3" name="Hunters Unleashed" hidden="false" targetId="05af-49f8-8692-ec9f" type="rule"/>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="927c-10fc-6bef-7467" name="Elites" hidden="false" targetId="638d74c6-bd97-4de5-b65a-6aaa24e9f4b2" primary="true"/>
+        <categoryLink id="a151-7052-98c8-6320" name="Faction: Imperium" hidden="false" targetId="84e2-9fa9-ebe6-1d18" primary="false"/>
+        <categoryLink id="5b8c-4722-58fb-ebfe" name="Faction: Adeptus Astartes" hidden="false" targetId="c7b7-edbc-bc14-6238" primary="false"/>
+        <categoryLink id="434e-d9f2-75af-ffbf" name="Faction: Space Wolves" hidden="false" targetId="f093-e031-3131-7b82" primary="false"/>
+        <categoryLink id="bf57-46f1-4026-c87e" name="Vehicle" hidden="false" targetId="c8fd-783f-3230-493e" primary="false"/>
+        <categoryLink id="8816-341a-fa02-24a6" name="Invictor Tactical Warsuit" hidden="false" targetId="d78a-9066-6f29-3930" primary="false"/>
+      </categoryLinks>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="c1dc-bbbc-d4e4-17f0" name="New SelectionEntryGroup" hidden="false" collective="false" defaultSelectionEntryId="cbbf-4f8a-019e-9c52">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ea8c-62f0-4868-e211" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5a49-dc4f-b4d7-0b0a" type="min"/>
+          </constraints>
+          <entryLinks>
+            <entryLink id="0096-7d20-51ec-6105" name="Ironhail Heavy Stubber" hidden="false" collective="false" targetId="e8c2-5a34-bfab-1472" type="selectionEntry"/>
+            <entryLink id="cbbf-4f8a-019e-9c52" name="Incendium cannon" hidden="false" collective="false" targetId="15c6-16a1-e7ba-2be0" type="selectionEntry"/>
+          </entryLinks>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <entryLinks>
+        <entryLink id="f166-2a65-4a5b-c27a" name="Fragstorm Grenade Launcher" hidden="false" collective="false" targetId="f1af-915f-fe51-a757" type="selectionEntry">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a0eb-9fb2-23a2-363c" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e0dd-114e-4e15-da7c" type="min"/>
+          </constraints>
+        </entryLink>
+        <entryLink id="5018-bdcb-543b-ca59" name="Heavy bolter" hidden="false" collective="false" targetId="05ab-e7cc-e856-c36f" type="selectionEntry">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="257c-a58c-cff5-fc19" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="45dd-7c4f-377e-152b" type="min"/>
+          </constraints>
+        </entryLink>
+        <entryLink id="21c5-1562-5816-2451" name="2x Ironhail heavy stubber" hidden="false" collective="false" targetId="36e2-53b2-cf55-f12a" type="selectionEntry">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="93a9-149e-e028-a6c7" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f610-a363-7763-7838" type="max"/>
+          </constraints>
+        </entryLink>
+        <entryLink id="05e1-20aa-1d5e-c368" name="Invictor fist" hidden="false" collective="false" targetId="d3cd-e026-892d-9606" type="selectionEntry">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8de5-11d7-28ce-cb43" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f523-3e56-6145-2e59" type="min"/>
+          </constraints>
+        </entryLink>
+      </entryLinks>
+      <costs>
+        <cost name=" PL" typeId="e356-c769-5920-6e14" value="6.0"/>
+        <cost name="pts" typeId="points" value="90.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="15c6-16a1-e7ba-2be0" name="Incendium cannon" hidden="false" collective="false" type="upgrade">
+      <infoLinks>
+        <infoLink id="46f0-5d6d-d989-a8a3" name="Incendium cannon" hidden="false" targetId="90ee-be6c-bc4c-6175" type="profile"/>
+      </infoLinks>
+      <costs>
+        <cost name="pts" typeId="points" value="15.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="36e2-53b2-cf55-f12a" name="2x Ironhail heavy stubber" hidden="false" collective="false" type="upgrade">
+      <infoLinks>
+        <infoLink id="e0de-b2d3-73cf-7f20" name="Ironhail Heavy Stubber" hidden="false" targetId="7f73-3131-afbf-e23e" type="profile"/>
+      </infoLinks>
+      <costs>
+        <cost name="pts" typeId="points" value="12.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="d3cd-e026-892d-9606" name="Invictor fist" hidden="false" collective="false" type="upgrade">
+      <infoLinks>
+        <infoLink id="f7b7-ceb3-f6c3-f345" name="Invictor fist" hidden="false" targetId="7023-5be8-2888-e7d5" type="profile"/>
+      </infoLinks>
+    </selectionEntry>
+    <selectionEntry id="674b-7928-5552-905b" name="Incursor Squad" hidden="false" collective="false" type="unit">
+      <profiles>
+        <profile id="e355-d2ef-b34d-6610" name="Haywire Mine" hidden="false" typeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" typeName="Abilities">
+          <characteristics>
+            <characteristic name="Description" typeId="21befb24-fc85-4f52-a745-64b2e48f8228">In your Movement phase, one model from your army with a haywire mine that has not been primed can prime it. At any point during that model’s move, place one Primed Haywire Mine within 1&quot; of it, more than 3&quot; away from any enemy models and more than 6&quot; away from any other Primed Haywire Mines. If an enemy unit moves within 3&quot; of that Primed Haywire Mine, roll one D6; on a 2+ that enemy unit suffers D3 mortal wounds. If that unit is a Vehicle, it suffers D3+1 mortal wounds instead. That Primed Haywire Mine is then removed from play.
+
+The Primed Haywire Mine is represented by the Primed Haywire Mine model, but does not count as a model for any rules purposes.</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <infoLinks>
+        <infoLink id="0d82-e6d4-9e6d-3405" name="Concealed Positions" hidden="false" targetId="5471-06f7-fab0-0e4b" type="profile"/>
+        <infoLink id="e227-e02d-817b-16cd" name="Combat Squads" hidden="false" targetId="3e31-4e4b-6ab6-d90b" type="profile"/>
+        <infoLink id="2343-3c70-4279-c7aa" name="Multi-spectrum array" hidden="false" targetId="d8e8-ab30-8162-6a07" type="profile"/>
+        <infoLink id="6a15-d6cd-d444-765c" name="Smoke Grenades" hidden="false" targetId="0d60-a97a-1ce4-c8f3" type="profile"/>
+      </infoLinks>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="73f4-5aa2-5ef2-1055" name="Incursor" hidden="false" collective="false">
+          <constraints>
+            <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4912-1338-4daf-c6f1" type="min"/>
+            <constraint field="selections" scope="parent" value="9.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7560-7ea3-f442-02d3" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="ada1-cdef-45a7-8670" name="Incursor" hidden="false" typeId="800f-21d0-4387-c943" typeName="Unit">
+              <characteristics>
+                <characteristic name="M" typeId="0bdf-a96e-9e38-7779">6&quot;</characteristic>
+                <characteristic name="WS" typeId="e7f0-1278-0250-df0c">3+</characteristic>
+                <characteristic name="BS" typeId="381b-eb28-74c3-df5f">3+</characteristic>
+                <characteristic name="S" typeId="2218-aa3c-265f-2939">4</characteristic>
+                <characteristic name="T" typeId="9c9f-9774-a358-3a39">4</characteristic>
+                <characteristic name="W" typeId="f330-5e6e-4110-0978">2</characteristic>
+                <characteristic name="A" typeId="13fc-b29b-31f2-ab9f">2</characteristic>
+                <characteristic name="Ld" typeId="00ca-f8b8-876d-b705">7</characteristic>
+                <characteristic name="Save" typeId="c0df-df94-abd7-e8d3">3+</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <entryLinks>
+            <entryLink id="3dce-0e26-0129-9019" name="Bolt pistol" hidden="false" collective="false" targetId="37d3-7098-d596-9948" type="selectionEntry">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1539-f2ff-4b2b-50d9" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="892c-fa60-db67-917a" type="max"/>
+              </constraints>
+            </entryLink>
+            <entryLink id="53d6-9034-ba7e-1e31" name="Frag &amp; Krak grenades" hidden="false" collective="false" targetId="cddf-945e-1335-e681" type="selectionEntry">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f34d-d4c5-3dfe-a3f9" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="aba2-734a-5720-0a32" type="min"/>
+              </constraints>
+            </entryLink>
+            <entryLink id="dca5-39ec-a200-27d9" name="Occulus bolt carbine" hidden="false" collective="false" targetId="1bdd-c86d-292f-1984" type="selectionEntry">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="496f-d3b1-de65-bfed" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3118-3874-2fb3-1011" type="min"/>
+              </constraints>
+            </entryLink>
+            <entryLink id="2c9e-8a17-839a-c290" name="Paired combat blades" hidden="false" collective="false" targetId="6683-a537-8c7d-eee9" type="selectionEntry">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5dff-559e-befa-f737" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="885d-0711-cd77-3e28" type="min"/>
+              </constraints>
+            </entryLink>
+            <entryLink id="01ad-247b-ce74-5b03" name="Haywire mine" hidden="false" collective="false" targetId="58d6-3100-306e-dc3b" type="selectionEntry">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="88b8-2380-699f-7d38" type="max"/>
+              </constraints>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="097a-bcf6-dfc1-8a8a" name="Incursor Sergeant" hidden="false" collective="false">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ab35-1328-91a0-8215" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bf1a-25d3-7a39-00d9" type="min"/>
+          </constraints>
+          <profiles>
+            <profile id="a3f7-7304-e5c3-701a" name="Incursor Sergeant" hidden="false" typeId="800f-21d0-4387-c943" typeName="Unit">
+              <characteristics>
+                <characteristic name="M" typeId="0bdf-a96e-9e38-7779">6&quot;</characteristic>
+                <characteristic name="WS" typeId="e7f0-1278-0250-df0c">3+</characteristic>
+                <characteristic name="BS" typeId="381b-eb28-74c3-df5f">3+</characteristic>
+                <characteristic name="S" typeId="2218-aa3c-265f-2939">4</characteristic>
+                <characteristic name="T" typeId="9c9f-9774-a358-3a39">4</characteristic>
+                <characteristic name="W" typeId="f330-5e6e-4110-0978">2</characteristic>
+                <characteristic name="A" typeId="13fc-b29b-31f2-ab9f">3</characteristic>
+                <characteristic name="Ld" typeId="00ca-f8b8-876d-b705">8</characteristic>
+                <characteristic name="Save" typeId="c0df-df94-abd7-e8d3">3+</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <entryLinks>
+            <entryLink id="4b01-6ed7-43e7-cdd1" name="Bolt pistol" hidden="false" collective="false" targetId="37d3-7098-d596-9948" type="selectionEntry">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a5d2-025a-b7c5-b4c8" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="44fd-592f-e9a3-8e23" type="max"/>
+              </constraints>
+            </entryLink>
+            <entryLink id="ba2e-d140-5d37-f467" name="Frag &amp; Krak grenades" hidden="false" collective="false" targetId="cddf-945e-1335-e681" type="selectionEntry">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2d2c-33f6-709f-0057" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fd96-8de8-9a0c-a529" type="min"/>
+              </constraints>
+            </entryLink>
+            <entryLink id="8b4d-b459-c970-9c6e" name="Occulus bolt carbine" hidden="false" collective="false" targetId="1bdd-c86d-292f-1984" type="selectionEntry">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="31a9-2a6b-717b-42de" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a7e6-9b72-f24b-b985" type="min"/>
+              </constraints>
+            </entryLink>
+            <entryLink id="0ebc-1a6a-6b6b-0977" name="Paired combat blades" hidden="false" collective="false" targetId="6683-a537-8c7d-eee9" type="selectionEntry">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="de43-ae9c-d8f3-d158" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f0da-0b17-9fa1-dfff" type="min"/>
+              </constraints>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <costs>
+        <cost name="pts" typeId="points" value="19.0"/>
+        <cost name=" PL" typeId="e356-c769-5920-6e14" value="5.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="1bdd-c86d-292f-1984" name="Occulus bolt carbine" hidden="false" collective="false" type="upgrade">
+      <infoLinks>
+        <infoLink id="2c8e-8538-a0b0-cd7b" name="Occulus bolt carbine" hidden="false" targetId="ac95-9dde-2c91-e03b" type="profile"/>
+      </infoLinks>
+    </selectionEntry>
+    <selectionEntry id="6683-a537-8c7d-eee9" name="Paired combat blades" hidden="false" collective="false" type="upgrade">
+      <infoLinks>
+        <infoLink id="fb7d-a131-eb65-732b" name="Paired combat blades" hidden="false" targetId="3d14-f6bd-14bb-0091" type="profile"/>
+      </infoLinks>
+    </selectionEntry>
+    <selectionEntry id="58d6-3100-306e-dc3b" name="Haywire mine" hidden="false" collective="false" type="upgrade">
+      <infoLinks>
+        <infoLink id="0735-ce9d-b8fb-1a68" name="Haywire mine" hidden="false" targetId="322c-3e89-fa21-4460" type="profile"/>
+      </infoLinks>
+    </selectionEntry>
+    <selectionEntry id="5de6-f371-d838-a3a1" name="Impulsor" hidden="false" collective="false" type="model">
+      <profiles>
+        <profile id="da99-ac26-421e-d400" name="Impulsor" hidden="false" typeId="800f-21d0-4387-c943" typeName="Unit">
+          <characteristics>
+            <characteristic name="M" typeId="0bdf-a96e-9e38-7779">*</characteristic>
+            <characteristic name="WS" typeId="e7f0-1278-0250-df0c">6+</characteristic>
+            <characteristic name="BS" typeId="381b-eb28-74c3-df5f">*</characteristic>
+            <characteristic name="S" typeId="2218-aa3c-265f-2939">7</characteristic>
+            <characteristic name="T" typeId="9c9f-9774-a358-3a39">7</characteristic>
+            <characteristic name="W" typeId="f330-5e6e-4110-0978">11</characteristic>
+            <characteristic name="A" typeId="13fc-b29b-31f2-ab9f">*</characteristic>
+            <characteristic name="Ld" typeId="00ca-f8b8-876d-b705">8</characteristic>
+            <characteristic name="Save" typeId="c0df-df94-abd7-e8d3">3+</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="e47b-e13c-a228-0d13" name="Impulsor Wound Track 1" hidden="false" typeId="5f4f-ea74-0630-4afe" typeName="Wound Track">
+          <characteristics>
+            <characteristic name="Remaining W" typeId="8e45-c866-b2d4-c9ab">6-11+</characteristic>
+            <characteristic name="Characteristic 1" typeId="bf41-c860-50bc-2a7e">14&quot;</characteristic>
+            <characteristic name="Characteristic 2" typeId="dc18-e51f-309b-8efa">3+</characteristic>
+            <characteristic name="Characteristic 3" typeId="df06-8eca-150f-90ba">3</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="3f8c-cef1-b191-78ab" name="Impulsor Wound Track 2" hidden="false" typeId="5f4f-ea74-0630-4afe" typeName="Wound Track">
+          <characteristics>
+            <characteristic name="Remaining W" typeId="8e45-c866-b2d4-c9ab">3-5</characteristic>
+            <characteristic name="Characteristic 1" typeId="bf41-c860-50bc-2a7e">7&quot;</characteristic>
+            <characteristic name="Characteristic 2" typeId="dc18-e51f-309b-8efa">4+</characteristic>
+            <characteristic name="Characteristic 3" typeId="df06-8eca-150f-90ba">D3</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="e8b7-ae68-ee3e-718e" name="Impulsor Wound Track 3" hidden="false" typeId="5f4f-ea74-0630-4afe" typeName="Wound Track">
+          <characteristics>
+            <characteristic name="Remaining W" typeId="8e45-c866-b2d4-c9ab">1-2</characteristic>
+            <characteristic name="Characteristic 1" typeId="bf41-c860-50bc-2a7e">4&quot;</characteristic>
+            <characteristic name="Characteristic 2" typeId="dc18-e51f-309b-8efa">5+</characteristic>
+            <characteristic name="Characteristic 3" typeId="df06-8eca-150f-90ba">1</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="5b39-cf1d-62d2-bd2d" name="Impulsor" hidden="false" typeId="b3a8-0452-7436-44d1" typeName="Transport">
+          <characteristics>
+            <characteristic name="Capacity" typeId="15aa-1916-a38b-d223">This model has a transport capacity of 6 &lt;CHAPTER&gt; PRIMARIS INFANTRY models. It cannot transport JUMP PACK or MK X GRAVIS models.</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <infoLinks>
+        <infoLink id="d86c-59bf-5119-ed27" name="Explodes (6&quot;/D3)" hidden="false" targetId="0774-86ce-651c-1c7b" type="rule"/>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="f2ed-1e88-d475-0db2" name="New CategoryLink" hidden="false" targetId="1b66-3f5f-6705-079a" primary="true"/>
+      </categoryLinks>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="d0d8-f352-8f4e-aad2" name="Wargear Option" hidden="false" collective="false">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1089-f534-11f6-de3f" type="max"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="2526-1c0e-4898-378c" name="Shield Dome" hidden="false" collective="false" type="upgrade">
+              <profiles>
+                <profile id="3655-e035-01e2-3784" name="Shield Dome" hidden="false" typeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" typeName="Abilities">
+                  <characteristics>
+                    <characteristic name="Description" typeId="21befb24-fc85-4f52-a745-64b2e48f8228">A model with a shield dome has a 4+ invulnerable save.</characteristic>
+                  </characteristics>
+                </profile>
+              </profiles>
+              <costs>
+                <cost name="pts" typeId="points" value="18.0"/>
+                <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0"/>
+                <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="2602-a13e-16bc-83b0" name="Orbital Comms Array" hidden="false" collective="false" type="upgrade">
+              <profiles>
+                <profile id="80e2-14e9-2b97-d45c" name="Orbital Comms Array" hidden="false" typeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" typeName="Abilities">
+                  <characteristics>
+                    <characteristic name="Description" typeId="21befb24-fc85-4f52-a745-64b2e48f8228">In your Shooting phase, one model from your army with an orbital comms array that has not been used 
+this 
+battle 
+can 
+use 
+it 
+to 
+call 
+in 
+an 
+orbital 
+barrage. 
+If 
+it 
+does, 
+select 
+one 
+point 
+on 
+the 
+battlefield 
+and 
+roll 
+one 
+D6 
+for 
+each 
+unit 
+within 
+D6&quot; 
+of 
+that 
+point, 
+subtracting 
+1 
+from 
+the 
+result 
+if 
+the 
+unit 
+being 
+rolled 
+for 
+is 
+a 
+CHARACTER
+. 
+On 
+a 
+4+ 
+the 
+unit 
+being 
+rolled 
+for 
+suffers 
+D3 
+mortal 
+wounds.</characteristic>
+                  </characteristics>
+                </profile>
+              </profiles>
+              <costs>
+                <cost name="pts" typeId="points" value="18.0"/>
+                <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0"/>
+                <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="2735-6624-c60c-98e5" name="Bellicastus Missile Array" hidden="false" collective="false" type="upgrade">
+              <profiles>
+                <profile id="bc11-de35-5d6d-e9e8" name="Bellicastus Missile Array - Krak" hidden="false" typeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" typeName="Weapon">
+                  <characteristics>
+                    <characteristic name="Range" typeId="6fa97fa8-ea74-4a27-a0fb-bc4e5f367464">48&quot;</characteristic>
+                    <characteristic name="Type" typeId="077c342f-d7b9-45c6-b8af-88e97cafd3a2">Heavy 1</characteristic>
+                    <characteristic name="S" typeId="59b1-319e-ec13-d466">8</characteristic>
+                    <characteristic name="AP" typeId="75aa-a838-b675-6484">-2</characteristic>
+                    <characteristic name="D" typeId="ae8a-3137-d65b-4ca7">D6</characteristic>
+                    <characteristic name="Abilities" typeId="837d-5e63-aeb7-1410">-</characteristic>
+                  </characteristics>
+                </profile>
+                <profile id="5a7f-951e-7925-4ad4" name="Bellicastus Missile Array - Frag" hidden="false" typeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" typeName="Weapon">
+                  <characteristics>
+                    <characteristic name="Range" typeId="6fa97fa8-ea74-4a27-a0fb-bc4e5f367464">48&quot;</characteristic>
+                    <characteristic name="Type" typeId="077c342f-d7b9-45c6-b8af-88e97cafd3a2">Heavy D6</characteristic>
+                    <characteristic name="S" typeId="59b1-319e-ec13-d466">4</characteristic>
+                    <characteristic name="AP" typeId="75aa-a838-b675-6484">0</characteristic>
+                    <characteristic name="D" typeId="ae8a-3137-d65b-4ca7">1</characteristic>
+                    <characteristic name="Abilities" typeId="837d-5e63-aeb7-1410">-</characteristic>
+                  </characteristics>
+                </profile>
+                <profile id="1dd6-bdb0-2b55-329e" name="Bellicastus Missile Array - Icarus" hidden="false" typeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" typeName="Weapon">
+                  <characteristics>
+                    <characteristic name="Range" typeId="6fa97fa8-ea74-4a27-a0fb-bc4e5f367464">48&quot;</characteristic>
+                    <characteristic name="Type" typeId="077c342f-d7b9-45c6-b8af-88e97cafd3a2">Heavy D3</characteristic>
+                    <characteristic name="S" typeId="59b1-319e-ec13-d466">7</characteristic>
+                    <characteristic name="AP" typeId="75aa-a838-b675-6484">-1</characteristic>
+                    <characteristic name="D" typeId="ae8a-3137-d65b-4ca7">D3</characteristic>
+                    <characteristic name="Abilities" typeId="837d-5e63-aeb7-1410">When resolving an attack made with this weapon, add 1 to the hit roll if the target can FLY; otherwise subtract 1 from the hit roll</characteristic>
+                  </characteristics>
+                </profile>
+              </profiles>
+              <costs>
+                <cost name="pts" typeId="points" value="17.0"/>
+                <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0"/>
+                <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="b7b2-b68b-447a-386c" name="Ironhail Sytalon Array" hidden="false" collective="false" type="upgrade">
+              <profiles>
+                <profile id="6e61-66f6-752a-dab9" name="Ironhail Sytalon Array" hidden="false" typeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" typeName="Weapon">
+                  <characteristics>
+                    <characteristic name="Range" typeId="6fa97fa8-ea74-4a27-a0fb-bc4e5f367464">36&quot;</characteristic>
+                    <characteristic name="Type" typeId="077c342f-d7b9-45c6-b8af-88e97cafd3a2">Heavy 6</characteristic>
+                    <characteristic name="S" typeId="59b1-319e-ec13-d466">4</characteristic>
+                    <characteristic name="AP" typeId="75aa-a838-b675-6484">-1</characteristic>
+                    <characteristic name="D" typeId="ae8a-3137-d65b-4ca7">1</characteristic>
+                    <characteristic name="Abilities" typeId="837d-5e63-aeb7-1410">When resolving an attack made with this weapon, add 1 to the hit roll and 1 to the wound roll if the target can FLY; otherwise subtract 1 from the hit roll.</characteristic>
+                  </characteristics>
+                </profile>
+              </profiles>
+              <costs>
+                <cost name="pts" typeId="points" value="5.0"/>
+                <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0"/>
+                <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="5c89-6606-6072-1096" name="Side Weapons" hidden="false" collective="false">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e2aa-8f8d-034e-7adc" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bedc-9584-1f54-1160" type="max"/>
+          </constraints>
+          <entryLinks>
+            <entryLink id="d39e-aa13-cf53-63e1" name="2x Fragstorm Grenade Launchers" hidden="false" collective="false" targetId="fc75-e0cc-bdc8-858f" type="selectionEntry"/>
+            <entryLink id="0500-ee30-8f50-f2a7" name="2x Storm Bolters" hidden="false" collective="false" targetId="391c-6e58-cc90-7442" type="selectionEntry"/>
+          </entryLinks>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <entryLinks>
+        <entryLink id="c964-07ab-bdba-1d18" name="Ironhail Heavy Stubber" hidden="false" collective="false" targetId="e8c2-5a34-bfab-1472" type="selectionEntry">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b97e-470e-9469-afa9" type="max"/>
+          </constraints>
+        </entryLink>
+      </entryLinks>
+      <costs>
+        <cost name="pts" typeId="points" value="75.0"/>
+        <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0"/>
         <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
       </costs>
     </selectionEntry>
@@ -15167,6 +15648,9 @@
     </rule>
     <rule id="87a0-1e8f-4535-6dd1" name="Defenders of Humanity" hidden="false">
       <description>A Unit with this ability that is within range of an objective marker (as specified in the mission) controls the objective marker even if there are more enemy models within range of that objective marker. If an enemy unit within range of the same objective marker has a similar ability, then the objective marker is controlled by the player who has the most models within range of it as normal.</description>
+    </rule>
+    <rule id="0774-86ce-651c-1c7b" name="Explodes (6&quot;/D3)" hidden="false">
+      <description>If this model is reduced to 0 wounds, roll a D6 before removing it from the battlefield and before any embarked models disembark. On a 6 it explodes, and each unit within 6&quot; suffers D3 mortal wounds.</description>
     </rule>
   </sharedRules>
   <sharedProfiles>
@@ -17231,7 +17715,7 @@ Matched Play: This model and any units embarked aboard it are exempt from the Ta
         <characteristic name="Description" typeId="21befb24-fc85-4f52-a745-64b2e48f8228">You can add 1 to Deny the Witch tests you take for this model against enemy PSYKERS within 12&quot;.</characteristic>
       </characteristics>
     </profile>
-    <profile id="4fa7-3fc0-8910-a15b" name="Heavy Onslaught Gatling Cannon" hidden="false" typeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" typeName="Weapon">
+    <profile id="4fa7-3fc0-8910-a15b" name="Heavy Onslaught Gatling Cannon" page="" hidden="false" typeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" typeName="Weapon">
       <characteristics>
         <characteristic name="Range" typeId="6fa97fa8-ea74-4a27-a0fb-bc4e5f367464">30&quot;</characteristic>
         <characteristic name="Type" typeId="077c342f-d7b9-45c6-b8af-88e97cafd3a2">Heavy 12</characteristic>
@@ -17480,6 +17964,68 @@ Matched Play: This model and any units embarked aboard it are exempt from the Ta
     <profile id="065e-2049-9270-b84a" name="Power of the Machine Spirit" hidden="false" typeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" typeName="Abilities">
       <characteristics>
         <characteristic name="Description" typeId="21befb24-fc85-4f52-a745-64b2e48f8228">This model does not suffer he penalty to hit rolls for moving and firing Heavy Weapons.</characteristic>
+      </characteristics>
+    </profile>
+    <profile id="90ee-be6c-bc4c-6175" name="Incendium cannon" hidden="false" typeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" typeName="Weapon">
+      <characteristics>
+        <characteristic name="Range" typeId="6fa97fa8-ea74-4a27-a0fb-bc4e5f367464">12</characteristic>
+        <characteristic name="Type" typeId="077c342f-d7b9-45c6-b8af-88e97cafd3a2">Heavy 2D6</characteristic>
+        <characteristic name="S" typeId="59b1-319e-ec13-d466">5</characteristic>
+        <characteristic name="AP" typeId="75aa-a838-b675-6484">-1</characteristic>
+        <characteristic name="D" typeId="ae8a-3137-d65b-4ca7">1</characteristic>
+        <characteristic name="Abilities" typeId="837d-5e63-aeb7-1410">When resolving an attack made with this weapon, do not make a hit roll: it automatically scores a hit.</characteristic>
+      </characteristics>
+    </profile>
+    <profile id="7023-5be8-2888-e7d5" name="Invictor fist" hidden="false" typeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" typeName="Weapon">
+      <characteristics>
+        <characteristic name="Range" typeId="6fa97fa8-ea74-4a27-a0fb-bc4e5f367464">Melee</characteristic>
+        <characteristic name="Type" typeId="077c342f-d7b9-45c6-b8af-88e97cafd3a2">Melee</characteristic>
+        <characteristic name="S" typeId="59b1-319e-ec13-d466">x2</characteristic>
+        <characteristic name="AP" typeId="75aa-a838-b675-6484">-3</characteristic>
+        <characteristic name="D" typeId="ae8a-3137-d65b-4ca7">3</characteristic>
+        <characteristic name="Abilities" typeId="837d-5e63-aeb7-1410"/>
+      </characteristics>
+    </profile>
+    <profile id="208a-fb06-0f2e-c368" name="Heavy Sidearm" hidden="false" typeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" typeName="Abilities">
+      <characteristics>
+        <characteristic name="Description" typeId="21befb24-fc85-4f52-a745-64b2e48f8228">Whilst this model is within 1&quot; of any enemy units, its heavy bolter has a Type characteristic of Pistol 3.</characteristic>
+      </characteristics>
+    </profile>
+    <profile id="ac95-9dde-2c91-e03b" name="Occulus bolt carbine" hidden="false" typeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" typeName="Weapon">
+      <characteristics>
+        <characteristic name="Range" typeId="6fa97fa8-ea74-4a27-a0fb-bc4e5f367464">24&quot;</characteristic>
+        <characteristic name="Type" typeId="077c342f-d7b9-45c6-b8af-88e97cafd3a2">Rapid Fire 1</characteristic>
+        <characteristic name="S" typeId="59b1-319e-ec13-d466">4</characteristic>
+        <characteristic name="AP" typeId="75aa-a838-b675-6484">0</characteristic>
+        <characteristic name="D" typeId="ae8a-3137-d65b-4ca7">1</characteristic>
+        <characteristic name="Abilities" typeId="837d-5e63-aeb7-1410">When resolving an attack made with this weapon, the target does not receive the benefit of cover to its saving throw.</characteristic>
+      </characteristics>
+    </profile>
+    <profile id="3d14-f6bd-14bb-0091" name="Paired combat blades" hidden="false" typeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" typeName="Weapon">
+      <characteristics>
+        <characteristic name="Range" typeId="6fa97fa8-ea74-4a27-a0fb-bc4e5f367464">Melee</characteristic>
+        <characteristic name="Type" typeId="077c342f-d7b9-45c6-b8af-88e97cafd3a2">Melee</characteristic>
+        <characteristic name="S" typeId="59b1-319e-ec13-d466">User</characteristic>
+        <characteristic name="AP" typeId="75aa-a838-b675-6484">0</characteristic>
+        <characteristic name="D" typeId="ae8a-3137-d65b-4ca7">1</characteristic>
+        <characteristic name="Abilities" typeId="837d-5e63-aeb7-1410">When resolving an attack made with this weapon, the target does not receive the benefit of cover to its saving throw</characteristic>
+      </characteristics>
+    </profile>
+    <profile id="322c-3e89-fa21-4460" name="Haywire mine" hidden="false" typeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" typeName="Abilities">
+      <characteristics>
+        <characteristic name="Description" typeId="21befb24-fc85-4f52-a745-64b2e48f8228">In your Movement phase, one model from your army with a haywire mine that has not been primed can prime it. At any point during that model’s move, place one Primed Haywire Mine within 1&quot; of it, more than 3&quot; away from any enemy models and more than 6&quot; away from any other Primed Haywire Mines. If an enemy unit moves within 3&quot; of that Primed Haywire Mine, roll one D6; on a 2+ that enemy unit suffers D3 mortal wounds. If that unit is a Vehicle, it suffers D3+1 mortal wounds instead. That Primed Haywire Mine is then removed from play.
+
+The Primed Haywire Mine is represented by the Primed Haywire Mine model, but does not count as a model for any rules purposes.</characteristic>
+      </characteristics>
+    </profile>
+    <profile id="d8e8-ab30-8162-6a07" name="Multi-spectrum array" hidden="false" typeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" typeName="Abilities">
+      <characteristics>
+        <characteristic name="Description" typeId="21befb24-fc85-4f52-a745-64b2e48f8228">When resolving an attack made with a ranged weapon by a model in this unit, ignore hit roll modifiers and Ballistic Skill modifiers.</characteristic>
+      </characteristics>
+    </profile>
+    <profile id="0d60-a97a-1ce4-c8f3" name="Smoke Grenades" hidden="false" typeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" typeName="Abilities">
+      <characteristics>
+        <characteristic name="Description" typeId="21befb24-fc85-4f52-a745-64b2e48f8228">Once per battle, instead of shooting any weapons in the Shooting phase, this unit can use its smoke grenades; until your next Shooting phase, your opponent must subtract 1 from hit rolls for attacks made with ranged weapons that target this unit.</characteristic>
       </characteristics>
     </profile>
   </sharedProfiles>


### PR DESCRIPTION
Changed everything that was changed in the August 2019 errata for the space wolves file only. Hasn't changed things in Space Marines File.
Added Shock Assault and Bolter Discipline to the shared rules part.
Added Impulsor, Incursor Squad and Invictor Tactical Warsuit.

