### PR TITLE
Space Wolves - Invictor, Termite Assault Drill Eliminators, Aggressors and Tartaros \ Orks - Warboss fix

### DIFF
--- a/Imperium - Space Wolves.cat
+++ b/Imperium - Space Wolves.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="24b6-2b46-0063-2867" name="Imperium - Space Wolves" revision="90" battleScribeVersion="2.03" authorName="CrusherJoe" authorContact="@CrusherJoe" authorUrl="https://discord.gg/KqPVhds" library="false" gameSystemId="28ec-711c-d87f-3aeb" gameSystemRevision="1" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="24b6-2b46-0063-2867" name="Imperium - Space Wolves" revision="91" battleScribeVersion="2.03" authorName="CrusherJoe" authorContact="@CrusherJoe" authorUrl="https://discord.gg/KqPVhds" library="false" gameSystemId="28ec-711c-d87f-3aeb" gameSystemRevision="1" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <publications>
     <publication id="24b6-2b46-pubN65537" name="Codex: Space Wolves"/>
     <publication id="24b6-2b46-pubN166488" name="Chapter Approved 2017"/>
@@ -296,11 +296,6 @@
     <entryLink id="bad4-e47f-9dc5-8080" name="Thunderhawk Assault Gunship" hidden="false" collective="false" import="true" targetId="1ea8-e5a1-3a69-7697" type="selectionEntry"/>
     <entryLink id="32a6-8a30-885b-63d3" name="Thunderhawk Transporter" hidden="false" collective="false" import="true" targetId="0caa-04e2-7796-7750" type="selectionEntry"/>
     <entryLink id="ab04-955c-c9c7-0df2" name="Mortis Dreadnought" hidden="false" collective="false" import="true" targetId="8f67-d315-b9ff-f564" type="selectionEntry"/>
-    <entryLink id="f4be-42ff-b66e-5200" name="Termite Assault Drill" hidden="false" collective="false" import="true" targetId="d708-a325-b0c4-67a5" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="84d4-5b4e-640a-0617" name="New CategoryLink" hidden="false" targetId="1b66-3f5f-6705-079a" primary="true"/>
-      </categoryLinks>
-    </entryLink>
     <entryLink id="fac7-55a3-0c4e-eb05" name="Terrax-Pattern Termite Assault Drill" hidden="false" collective="false" import="true" targetId="732b-967e-1bca-5846" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="d1a1-5d57-14bb-d6cc" name="New CategoryLink" hidden="false" targetId="1b66-3f5f-6705-079a" primary="true"/>
@@ -4661,7 +4656,7 @@
     </selectionEntry>
     <selectionEntry id="c4f9-57b1-ebb0-d9bf" name="Wolf Guard on Bikes" hidden="false" collective="false" import="true" type="unit">
       <modifiers>
-        <modifier type="increment" field="e356-c769-5920-6e14" value="14">
+        <modifier type="increment" field="e356-c769-5920-6e14" value="14.0">
           <conditions>
             <condition field="selections" scope="c4f9-57b1-ebb0-d9bf" value="5.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" childId="model" type="greaterThan"/>
           </conditions>
@@ -5718,12 +5713,12 @@
           <selectionEntries>
             <selectionEntry id="53c9-1092-bafc-4352" name="Grey Hunter w/Bolt Pistol" hidden="false" collective="false" import="true" type="model">
               <modifiers>
-                <modifier type="decrement" field="a5d2-c34c-209a-e754" value="1">
+                <modifier type="decrement" field="a5d2-c34c-209a-e754" value="1.0">
                   <conditions>
                     <condition field="selections" scope="2e39-6ee4-1903-7c95" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="97b4-a43a-9131-9a88" type="atLeast"/>
                   </conditions>
                 </modifier>
-                <modifier type="decrement" field="a5d2-c34c-209a-e754" value="1">
+                <modifier type="decrement" field="a5d2-c34c-209a-e754" value="1.0">
                   <conditions>
                     <condition field="selections" scope="2e39-6ee4-1903-7c95" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7c36-446f-9b97-299a" type="atLeast"/>
                   </conditions>
@@ -9069,7 +9064,7 @@
                     <characteristic name="S" typeId="2218-aa3c-265f-2939">4</characteristic>
                     <characteristic name="T" typeId="9c9f-9774-a358-3a39">5</characteristic>
                     <characteristic name="W" typeId="f330-5e6e-4110-0978">3</characteristic>
-                    <characteristic name="A" typeId="13fc-b29b-31f2-ab9f">2</characteristic>
+                    <characteristic name="A" typeId="13fc-b29b-31f2-ab9f">3</characteristic>
                     <characteristic name="Ld" typeId="00ca-f8b8-876d-b705">7</characteristic>
                     <characteristic name="Save" typeId="c0df-df94-abd7-e8d3">3+</characteristic>
                   </characteristics>
@@ -10106,7 +10101,6 @@
       </profiles>
       <costs>
         <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0"/>
-        <cost name="pts" typeId="points" value="0.0"/>
         <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
       </costs>
     </selectionEntry>
@@ -11166,7 +11160,7 @@
         <categoryLink id="a201-52c0-4fdf-9117" name="Wolf Guard" hidden="false" targetId="051a-d40e-0909-aea2" primary="false"/>
       </categoryLinks>
       <selectionEntryGroups>
-        <selectionEntryGroup id="3845-b49c-e4e0-9305" name="Wolf Guard Tartaros Terminators" hidden="false" collective="false" import="true">
+        <selectionEntryGroup id="3845-b49c-e4e0-9305" name="Wolf Guard Tartaros Terminators" hidden="false" collective="false" import="true" defaultSelectionEntryId="caaa-4b04-ba85-5f1a">
           <constraints>
             <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5b65-d52f-610a-709d" type="min"/>
             <constraint field="selections" scope="parent" value="10.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5d19-510d-b8a7-19e1" type="max"/>
@@ -11180,7 +11174,7 @@
               <selectionEntryGroups>
                 <selectionEntryGroup id="d498-9acc-d7fd-29d5" name="Weapon Options" hidden="false" collective="false" import="true">
                   <selectionEntryGroups>
-                    <selectionEntryGroup id="00ac-4d88-c4dd-8123" name="Ranged Options" hidden="false" collective="false" import="true">
+                    <selectionEntryGroup id="00ac-4d88-c4dd-8123" name="Ranged Options" hidden="false" collective="false" import="true" defaultSelectionEntryId="f994-96e7-7d1a-8d8c">
                       <modifiers>
                         <modifier type="set" field="9727-7a25-c327-b9fb" value="0.0">
                           <conditions>
@@ -11203,7 +11197,7 @@
                         <entryLink id="cdcb-85b0-492c-5d30" name="New EntryLink" hidden="false" collective="false" import="true" targetId="250a-10f2-a1c6-36ff" type="selectionEntry"/>
                       </entryLinks>
                     </selectionEntryGroup>
-                    <selectionEntryGroup id="85a9-2937-3fef-396d" name="Melee Options" hidden="false" collective="false" import="true">
+                    <selectionEntryGroup id="85a9-2937-3fef-396d" name="Melee Options" hidden="false" collective="false" import="true" defaultSelectionEntryId="8ba3-ad8f-a955-6b87">
                       <constraints>
                         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" id="9237-95c3-7e2d-ec8a" type="max"/>
                         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6811-a1c4-9a33-68a6" type="min"/>
@@ -11340,7 +11334,7 @@
         <entryLink id="2ff6-5ad0-9c48-ba37" name="Battle Honours" hidden="false" collective="false" import="true" targetId="5518-d0f5-a880-d71c" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
-        <cost name=" PL" typeId="e356-c769-5920-6e14" value="13.0"/>
+        <cost name=" PL" typeId="e356-c769-5920-6e14" value="12.0"/>
         <cost name="pts" typeId="points" value="0.0"/>
         <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
       </costs>
@@ -12583,11 +12577,6 @@
                     <repeat field="selections" scope="99e5-51dd-84a0-9325" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="model" repeats="1" roundUp="false"/>
                   </repeats>
                 </modifier>
-                <modifier type="decrement" field="points" value="1.0">
-                  <repeats>
-                    <repeat field="selections" scope="99e5-51dd-84a0-9325" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b90f-0eae-339e-db0f" repeats="1" roundUp="false"/>
-                  </repeats>
-                </modifier>
               </modifiers>
             </entryLink>
             <entryLink id="4a8f-b962-f719-d3c5" name="Bolt rifle" hidden="false" collective="false" import="true" targetId="fbf3-4fc8-f474-e3db" type="selectionEntry"/>
@@ -12977,11 +12966,7 @@
         <cost name="pts" typeId="points" value="15.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="8d81-b2e4-e4f9-c295" name="Bolt sniper rifle" hidden="false" collective="true" import="true" type="upgrade">
-      <constraints>
-        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0f30-ddc9-a191-8e91" type="min"/>
-        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="db6d-0871-eefb-0c49" type="max"/>
-      </constraints>
+    <selectionEntry id="8d81-b2e4-e4f9-c295" name="Bolt sniper rifle" hidden="false" collective="false" import="true" type="upgrade">
       <profiles>
         <profile id="30e1-dd2b-1d7b-9504" name="Bolt sniper rifle" hidden="false" typeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" typeName="Weapon">
           <characteristics>
@@ -12997,27 +12982,27 @@
           <characteristics>
             <characteristic name="Range" typeId="6fa97fa8-ea74-4a27-a0fb-bc4e5f367464">36&quot;</characteristic>
             <characteristic name="Type" typeId="077c342f-d7b9-45c6-b8af-88e97cafd3a2">Heavy 1</characteristic>
-            <characteristic name="S" typeId="59b1-319e-ec13-d466">4</characteristic>
-            <characteristic name="AP" typeId="75aa-a838-b675-6484">-2</characteristic>
-            <characteristic name="D" typeId="ae8a-3137-d65b-4ca7">D3</characteristic>
-            <characteristic name="Abilities" typeId="837d-5e63-aeb7-1410">If you make a wound roll of 6+ for this weapon, it inflicts 1 mortal wound in addition to its normal damage.</characteristic>
+            <characteristic name="S" typeId="59b1-319e-ec13-d466">5</characteristic>
+            <characteristic name="AP" typeId="75aa-a838-b675-6484">-1</characteristic>
+            <characteristic name="D" typeId="ae8a-3137-d65b-4ca7">1</characteristic>
+            <characteristic name="Abilities" typeId="837d-5e63-aeb7-1410">This weapon can target units that are not visible to the bearer. When resolving an attack made with this weapon, add 2 to the hit roll, and the target does not receive the benefit of cover to its saving throw</characteristic>
           </characteristics>
         </profile>
         <profile id="9c0d-b2dd-40c2-e947" name="Bolt sniper rifle - Mortis round" hidden="false" typeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" typeName="Weapon">
           <characteristics>
             <characteristic name="Range" typeId="6fa97fa8-ea74-4a27-a0fb-bc4e5f367464">36&quot;</characteristic>
             <characteristic name="Type" typeId="077c342f-d7b9-45c6-b8af-88e97cafd3a2">Heavy 1</characteristic>
-            <characteristic name="S" typeId="59b1-319e-ec13-d466">4</characteristic>
-            <characteristic name="AP" typeId="75aa-a838-b675-6484">-1</characteristic>
-            <characteristic name="D" typeId="ae8a-3137-d65b-4ca7">1</characteristic>
-            <characteristic name="Abilities" typeId="837d-5e63-aeb7-1410">This weapon can target units that are not visible to the bearer. Add 2 to hit rolls made for this weapon. Units do not receive the benefit of cover to their saving throws against attacks made with this weapon.</characteristic>
+            <characteristic name="S" typeId="59b1-319e-ec13-d466">5</characteristic>
+            <characteristic name="AP" typeId="75aa-a838-b675-6484">-2</characteristic>
+            <characteristic name="D" typeId="ae8a-3137-d65b-4ca7">D3</characteristic>
+            <characteristic name="Abilities" typeId="837d-5e63-aeb7-1410">When resolving an attack made with this weapon, a wound roll of 6+ inflicts 1 mortal wound on the target in addition to any other damage.</characteristic>
           </characteristics>
         </profile>
         <profile id="57a8-e729-bcc7-8157" name="Bolt sniper rifle - Hyperfrag round" hidden="false" typeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" typeName="Weapon">
           <characteristics>
             <characteristic name="Range" typeId="6fa97fa8-ea74-4a27-a0fb-bc4e5f367464">36&quot;</characteristic>
             <characteristic name="Type" typeId="077c342f-d7b9-45c6-b8af-88e97cafd3a2">Heavy D3</characteristic>
-            <characteristic name="S" typeId="59b1-319e-ec13-d466">4</characteristic>
+            <characteristic name="S" typeId="59b1-319e-ec13-d466">5</characteristic>
             <characteristic name="AP" typeId="75aa-a838-b675-6484">0</characteristic>
             <characteristic name="D" typeId="ae8a-3137-d65b-4ca7">1</characteristic>
             <characteristic name="Abilities" typeId="837d-5e63-aeb7-1410">-</characteristic>
@@ -13031,6 +13016,18 @@
       </costs>
     </selectionEntry>
     <selectionEntry id="7b17-4c90-fcf3-f317" name="Eliminator Squad" hidden="false" collective="false" import="true" type="unit">
+      <profiles>
+        <profile id="db9e-ecb0-8f9b-ad12" name="Covering Fire" hidden="false" typeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" typeName="Abilities">
+          <characteristics>
+            <characteristic name="Description" typeId="21befb24-fc85-4f52-a745-64b2e48f8228">The first time this unit’s Eliminator Sergeant fires Overwatch with an instigator bolt carbine in your opponent’s turn, this unit can, after it has resolved its Overwatch, move as if it were your Movement phase (it cannot Advance as part of this move).</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="03a4-8c3f-3fb9-f74d" name="Guided Aim" hidden="false" typeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" typeName="Abilities">
+          <characteristics>
+            <characteristic name="Description" typeId="21befb24-fc85-4f52-a745-64b2e48f8228">Instead of shooting in your Shooting phase, this unit’s Eliminator Sergeant can guide his squad’s aim. Until the end of that phase, when resolving an attack made with a ranged weapon by a model in this unit, add 1 to the hit roll and wound roll.</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
       <infoLinks>
         <infoLink id="400a-a606-901b-e7a1" name="And They Shall Know No Fear" hidden="false" targetId="4ea8-94d3-ba39-042f" type="rule"/>
         <infoLink id="f68d-b66a-f52b-2984" name="Concealed Positions" hidden="false" targetId="5471-06f7-fab0-0e4b" type="profile"/>
@@ -13045,122 +13042,197 @@
         <categoryLink id="3d25-3bf8-726c-6efb" name="Space Wolves" hidden="false" targetId="f093-e031-3131-7b82" primary="false"/>
         <categoryLink id="40f4-d179-75fb-fc6a" name="New CategoryLink" hidden="false" targetId="abf5fd55-9ac7-4263-8bc1-a9fb0a8fa6a6" primary="true"/>
       </categoryLinks>
-      <selectionEntries>
-        <selectionEntry id="6c23-02cf-fd86-59b9" name="Eliminator" hidden="false" collective="false" import="true" type="upgrade">
+      <selectionEntryGroups>
+        <selectionEntryGroup id="3e67-23fc-d48f-9184" name="Eliminators" hidden="false" collective="false" import="true" defaultSelectionEntryId="e8a1-b12a-f983-a93c">
           <constraints>
-            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3f49-bb97-25d6-2a53" type="min"/>
-            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bb7e-3826-07f8-2bd0" type="max"/>
+            <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6cdb-8609-dfee-6907" type="max"/>
+            <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0ffb-2732-6fae-3c7c" type="min"/>
           </constraints>
-          <profiles>
-            <profile id="4736-90db-c494-8d7c" name="Eliminator" hidden="false" typeId="800f-21d0-4387-c943" typeName="Unit">
-              <characteristics>
-                <characteristic name="M" typeId="0bdf-a96e-9e38-7779">6&quot;</characteristic>
-                <characteristic name="WS" typeId="e7f0-1278-0250-df0c">3+</characteristic>
-                <characteristic name="BS" typeId="381b-eb28-74c3-df5f">3+</characteristic>
-                <characteristic name="S" typeId="2218-aa3c-265f-2939">4</characteristic>
-                <characteristic name="T" typeId="9c9f-9774-a358-3a39">4</characteristic>
-                <characteristic name="W" typeId="f330-5e6e-4110-0978">2</characteristic>
-                <characteristic name="A" typeId="13fc-b29b-31f2-ab9f">2</characteristic>
-                <characteristic name="Ld" typeId="00ca-f8b8-876d-b705">7</characteristic>
-                <characteristic name="Save" typeId="c0df-df94-abd7-e8d3">3+</characteristic>
-              </characteristics>
-            </profile>
-          </profiles>
           <selectionEntries>
-            <selectionEntry id="c56c-bf0c-455c-ff2b" name="Camo cloak" hidden="false" collective="true" import="true" type="upgrade">
+            <selectionEntry id="e1c6-f9dd-8e97-f797" name="Eliminator Sergeant" hidden="false" collective="false" import="true" type="model">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="71fb-4a0e-ff6d-2510" type="min"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b392-db95-57dd-a4ee" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ea5f-3dbc-3c89-411c" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9996-d2d3-9a20-110d" type="min"/>
               </constraints>
-              <infoLinks>
-                <infoLink id="97fa-1c45-1dcf-f57e" name="Camo cloaks" hidden="false" targetId="b754-9672-4689-cefb" type="profile"/>
-              </infoLinks>
+              <profiles>
+                <profile id="e76b-6ab6-9dbc-3680" name="Eliminator Sergeant" hidden="false" typeId="800f-21d0-4387-c943" typeName="Unit">
+                  <characteristics>
+                    <characteristic name="M" typeId="0bdf-a96e-9e38-7779">6&quot;</characteristic>
+                    <characteristic name="WS" typeId="e7f0-1278-0250-df0c">3+</characteristic>
+                    <characteristic name="BS" typeId="381b-eb28-74c3-df5f">3+</characteristic>
+                    <characteristic name="S" typeId="2218-aa3c-265f-2939">4</characteristic>
+                    <characteristic name="T" typeId="9c9f-9774-a358-3a39">4</characteristic>
+                    <characteristic name="W" typeId="f330-5e6e-4110-0978">2</characteristic>
+                    <characteristic name="A" typeId="13fc-b29b-31f2-ab9f">3</characteristic>
+                    <characteristic name="Ld" typeId="00ca-f8b8-876d-b705">8</characteristic>
+                    <characteristic name="Save" typeId="c0df-df94-abd7-e8d3">3+</characteristic>
+                  </characteristics>
+                </profile>
+              </profiles>
+              <selectionEntries>
+                <selectionEntry id="4ff5-4ec9-83f7-c683" name="Camo cloak" hidden="false" collective="false" import="true" type="upgrade">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="de50-9392-ab1a-507f" type="min"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3d9c-f557-afe4-d39a" type="max"/>
+                  </constraints>
+                  <infoLinks>
+                    <infoLink id="02b5-9db3-b16d-41f1" name="Camo cloaks" hidden="false" targetId="b754-9672-4689-cefb" type="profile"/>
+                  </infoLinks>
+                  <costs>
+                    <cost name="pts" typeId="points" value="3.0"/>
+                    <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0"/>
+                    <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
+                  </costs>
+                </selectionEntry>
+              </selectionEntries>
+              <selectionEntryGroups>
+                <selectionEntryGroup id="d8e1-5607-18c2-d47c" name="Weapon Option" hidden="false" collective="false" import="true">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="69f1-9d1f-3804-d508" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4b5a-62e8-452e-0ecd" type="min"/>
+                  </constraints>
+                  <entryLinks>
+                    <entryLink id="03f4-66d3-e06b-0a65" name="Bolt sniper rifle" hidden="false" collective="false" import="true" targetId="8d81-b2e4-e4f9-c295" type="selectionEntry"/>
+                    <entryLink id="420c-236f-f3cb-960d" name="Instigator bolt carbine" hidden="false" collective="false" import="true" targetId="67b5-9303-198a-ee18" type="selectionEntry"/>
+                    <entryLink id="a6e6-0991-13ea-9cdf" name="Las fusil" hidden="false" collective="false" import="true" targetId="3b91-753d-a35d-9bbe" type="selectionEntry"/>
+                  </entryLinks>
+                </selectionEntryGroup>
+              </selectionEntryGroups>
+              <entryLinks>
+                <entryLink id="839b-83f2-72ff-fe9a" name="Bolt pistol" hidden="false" collective="false" import="true" targetId="37d3-7098-d596-9948" type="selectionEntry">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="16db-365a-c695-d2b9" type="min"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c61b-40dc-3fd6-0ab9" type="max"/>
+                  </constraints>
+                </entryLink>
+                <entryLink id="b1ad-6693-0a2e-1e5e" name="Frag &amp; Krak grenades" hidden="false" collective="false" import="true" targetId="cddf-945e-1335-e681" type="selectionEntry">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="24d4-5a78-b3d0-4566" type="min"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e3d4-add7-b563-210d" type="max"/>
+                  </constraints>
+                </entryLink>
+              </entryLinks>
               <costs>
-                <cost name="pts" typeId="points" value="3.0"/>
                 <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0"/>
                 <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
+                <cost name="pts" typeId="points" value="18.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="e8a1-b12a-f983-a93c" name="Eliminator w/ Bolt sniper rifle" hidden="false" collective="false" import="true" type="model">
+              <modifiers>
+                <modifier type="decrement" field="d5c3-6d3e-701a-2306" value="1.0">
+                  <conditions>
+                    <condition field="selections" scope="7b17-4c90-fcf3-f317" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="df3e-66f7-ee13-7193" type="atLeast"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d5c3-6d3e-701a-2306" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="d38e-9e83-27e4-04c1" name="Eliminator" hidden="false" targetId="bba0-2f30-36d5-c6af" type="profile"/>
+              </infoLinks>
+              <selectionEntries>
+                <selectionEntry id="71c4-698f-cc53-17f4" name="Camo cloak" hidden="false" collective="false" import="true" type="upgrade">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="934d-89b1-7659-eba2" type="min"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="de97-48cd-2b18-a93a" type="max"/>
+                  </constraints>
+                  <infoLinks>
+                    <infoLink id="8b49-1dc9-172d-813a" name="Camo cloaks" hidden="false" targetId="b754-9672-4689-cefb" type="profile"/>
+                  </infoLinks>
+                  <costs>
+                    <cost name="pts" typeId="points" value="3.0"/>
+                    <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0"/>
+                    <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
+                  </costs>
+                </selectionEntry>
+              </selectionEntries>
+              <entryLinks>
+                <entryLink id="ef9c-e654-57d5-b5ba" name="Frag &amp; Krak grenades" hidden="false" collective="false" import="true" targetId="cddf-945e-1335-e681" type="selectionEntry">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0cd5-74fd-6785-9628" type="min"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9eb1-3527-c981-3fcd" type="max"/>
+                  </constraints>
+                </entryLink>
+                <entryLink id="c12b-1f01-a687-6aa5" name="Bolt pistol" hidden="false" collective="false" import="true" targetId="37d3-7098-d596-9948" type="selectionEntry">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="540e-f365-4328-5f6d" type="min"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="af88-eb5c-1689-265f" type="max"/>
+                  </constraints>
+                </entryLink>
+                <entryLink id="38a7-2501-5fcb-d3be" name="Bolt sniper rifle" hidden="false" collective="false" import="true" targetId="8d81-b2e4-e4f9-c295" type="selectionEntry">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3ad6-16bf-29bf-de5a" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2df0-127c-a8f0-b29e" type="min"/>
+                  </constraints>
+                </entryLink>
+              </entryLinks>
+              <costs>
+                <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0"/>
+                <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
+                <cost name="pts" typeId="points" value="18.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="df3e-66f7-ee13-7193" name="Eliminator w/ Las fusil" hidden="false" collective="false" import="true" type="model">
+              <modifiers>
+                <modifier type="decrement" field="3a1c-fe72-adca-fc94" value="1.0">
+                  <conditions>
+                    <condition field="selections" scope="7b17-4c90-fcf3-f317" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="e8a1-b12a-f983-a93c" type="atLeast"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3a1c-fe72-adca-fc94" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="8e12-e29a-8852-0455" name="Eliminator" hidden="false" targetId="bba0-2f30-36d5-c6af" type="profile"/>
+              </infoLinks>
+              <selectionEntries>
+                <selectionEntry id="a9f5-20a9-f2a1-b958" name="Camo cloak" hidden="false" collective="false" import="true" type="upgrade">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="032c-554b-2475-7eff" type="min"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1361-2c98-b3a7-f610" type="max"/>
+                  </constraints>
+                  <infoLinks>
+                    <infoLink id="f2a2-1cec-b556-2fff" name="Camo cloaks" hidden="false" targetId="b754-9672-4689-cefb" type="profile"/>
+                  </infoLinks>
+                  <costs>
+                    <cost name="pts" typeId="points" value="3.0"/>
+                    <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0"/>
+                    <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
+                  </costs>
+                </selectionEntry>
+              </selectionEntries>
+              <entryLinks>
+                <entryLink id="865c-70ac-6fb5-8713" name="Bolt pistol" hidden="false" collective="false" import="true" targetId="37d3-7098-d596-9948" type="selectionEntry">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ce82-ad09-e0a4-1313" type="min"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="373a-3efd-cf92-e767" type="max"/>
+                  </constraints>
+                </entryLink>
+                <entryLink id="4624-34f7-b9d4-6ead" name="Frag &amp; Krak grenades" hidden="false" collective="false" import="true" targetId="cddf-945e-1335-e681" type="selectionEntry">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8308-2390-e79a-6b78" type="min"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="23df-4a57-a636-df26" type="max"/>
+                  </constraints>
+                </entryLink>
+                <entryLink id="d336-04b4-3c6c-8f57" name="Las fusil" hidden="false" collective="false" import="true" targetId="3b91-753d-a35d-9bbe" type="selectionEntry">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5c3e-5899-6df1-d653" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="70de-8292-4469-03b7" type="min"/>
+                  </constraints>
+                </entryLink>
+              </entryLinks>
+              <costs>
+                <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0"/>
+                <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
+                <cost name="pts" typeId="points" value="18.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
-          <entryLinks>
-            <entryLink id="db93-137c-6e4a-1f65" name="Bolt sniper rifle" hidden="false" collective="false" import="true" targetId="8d81-b2e4-e4f9-c295" type="selectionEntry"/>
-            <entryLink id="2762-ce40-ddcb-0b74" name="Bolt pistol" hidden="false" collective="false" import="true" targetId="37d3-7098-d596-9948" type="selectionEntry">
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7734-2fcc-237c-5949" type="min"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9f60-1e8b-538c-1e74" type="max"/>
-              </constraints>
-            </entryLink>
-            <entryLink id="98c3-b2e4-b16d-6240" name="Frag &amp; Krak grenades" hidden="false" collective="false" import="true" targetId="cddf-945e-1335-e681" type="selectionEntry">
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8bb6-2108-e116-d53f" type="min"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9d40-59e8-3e76-37a2" type="max"/>
-              </constraints>
-            </entryLink>
-          </entryLinks>
-          <costs>
-            <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0"/>
-            <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
-            <cost name="pts" typeId="points" value="18.0"/>
-          </costs>
-        </selectionEntry>
-        <selectionEntry id="bb5b-d823-acc5-e39c" name="Eliminator Sergeant" hidden="false" collective="false" import="true" type="upgrade">
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b6a6-df93-f1f2-301e" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f8ee-e65f-8747-3ffc" type="max"/>
-          </constraints>
-          <profiles>
-            <profile id="8d4c-4404-b5d8-3b63" name="Eliminator Sergeant" hidden="false" typeId="800f-21d0-4387-c943" typeName="Unit">
-              <characteristics>
-                <characteristic name="M" typeId="0bdf-a96e-9e38-7779">6&quot;</characteristic>
-                <characteristic name="WS" typeId="e7f0-1278-0250-df0c">3+</characteristic>
-                <characteristic name="BS" typeId="381b-eb28-74c3-df5f">3+</characteristic>
-                <characteristic name="S" typeId="2218-aa3c-265f-2939">4</characteristic>
-                <characteristic name="T" typeId="9c9f-9774-a358-3a39">4</characteristic>
-                <characteristic name="W" typeId="f330-5e6e-4110-0978">2</characteristic>
-                <characteristic name="A" typeId="13fc-b29b-31f2-ab9f">3</characteristic>
-                <characteristic name="Ld" typeId="00ca-f8b8-876d-b705">8</characteristic>
-                <characteristic name="Save" typeId="c0df-df94-abd7-e8d3">3+</characteristic>
-              </characteristics>
-            </profile>
-          </profiles>
-          <selectionEntries>
-            <selectionEntry id="86dd-358d-bd91-e0be" name="Camo cloak" hidden="false" collective="false" import="true" type="upgrade">
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="760a-78dd-02ef-fb4e" type="min"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3a24-ed5e-84a8-72dc" type="max"/>
-              </constraints>
-              <infoLinks>
-                <infoLink id="479f-f4b6-8a02-8071" name="Camo cloaks" hidden="false" targetId="b754-9672-4689-cefb" type="profile"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="3.0"/>
-                <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0"/>
-                <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
-              </costs>
-            </selectionEntry>
-          </selectionEntries>
-          <entryLinks>
-            <entryLink id="b890-3c27-2ad9-e2cc" name="Bolt sniper rifle" hidden="false" collective="false" import="true" targetId="8d81-b2e4-e4f9-c295" type="selectionEntry"/>
-            <entryLink id="e5b1-549e-0f36-22e3" name="Bolt pistol" hidden="false" collective="false" import="true" targetId="37d3-7098-d596-9948" type="selectionEntry">
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e042-000a-77c3-6da0" type="min"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0253-70a2-00ec-2903" type="max"/>
-              </constraints>
-            </entryLink>
-            <entryLink id="6f07-3ee4-99c2-ec45" name="Frag &amp; Krak grenades" hidden="false" collective="false" import="true" targetId="cddf-945e-1335-e681" type="selectionEntry">
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="00bd-847a-6000-62a1" type="min"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="dd3d-b65c-9565-3b01" type="max"/>
-              </constraints>
-            </entryLink>
-          </entryLinks>
-          <costs>
-            <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0"/>
-            <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
-            <cost name="pts" typeId="points" value="18.0"/>
-          </costs>
-        </selectionEntry>
-      </selectionEntries>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
       <entryLinks>
         <entryLink id="fdca-1dea-d557-463f" name="Has Battle Honours" hidden="false" collective="false" import="true" targetId="4763-757f-499f-d998" type="selectionEntry"/>
         <entryLink id="ee74-c410-b0c8-e492" name="Battle Honours" hidden="false" collective="false" import="true" targetId="5518-d0f5-a880-d71c" type="selectionEntryGroup"/>
@@ -13843,8 +13915,8 @@
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5a49-dc4f-b4d7-0b0a" type="min"/>
           </constraints>
           <entryLinks>
-            <entryLink id="0096-7d20-51ec-6105" name="Ironhail Autocannon" hidden="false" collective="false" import="true" targetId="1697-cae5-36eb-e3e9" type="selectionEntry"/>
             <entryLink id="cbbf-4f8a-019e-9c52" name="Incendium cannon" hidden="false" collective="false" import="true" targetId="15c6-16a1-e7ba-2be0" type="selectionEntry"/>
+            <entryLink id="f112-38fe-de70-4cfb" name="Twin ironhail autocannon" hidden="false" collective="false" import="true" targetId="9c1b-9df0-65bf-1c34" type="selectionEntry"/>
           </entryLinks>
         </selectionEntryGroup>
       </selectionEntryGroups>
@@ -13969,6 +14041,8 @@
           </entryLinks>
           <costs>
             <cost name="pts" typeId="points" value="19.0"/>
+            <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0"/>
+            <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="f31d-1ef3-bc93-b593" name="Incursor Sergeant" hidden="false" collective="false" import="true" type="upgrade">
@@ -14019,6 +14093,8 @@
           </entryLinks>
           <costs>
             <cost name="pts" typeId="points" value="19.0"/>
+            <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0"/>
+            <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
           </costs>
         </selectionEntry>
       </selectionEntries>
@@ -14032,6 +14108,7 @@
       <costs>
         <cost name=" PL" typeId="e356-c769-5920-6e14" value="5.0"/>
         <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
+        <cost name="pts" typeId="points" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="1bdd-c86d-292f-1984" name="Occulus bolt carbine" hidden="false" collective="true" import="true" type="upgrade">
@@ -14292,9 +14369,34 @@ wounds.</characteristic>
         <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="1697-cae5-36eb-e3e9" name="Ironhail Autocannon" hidden="false" collective="false" import="true" type="upgrade">
+    <selectionEntry id="9c1b-9df0-65bf-1c34" name="Twin ironhail autocannon" hidden="false" collective="false" import="true" type="upgrade">
+      <infoLinks>
+        <infoLink id="621d-88b5-0e71-651b" name="Twin ironhail autocannon" hidden="false" targetId="a406-dba2-0f6f-9487" type="profile"/>
+      </infoLinks>
       <costs>
         <cost name="pts" typeId="points" value="20.0"/>
+        <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0"/>
+        <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="67b5-9303-198a-ee18" name="Instigator bolt carbine" hidden="false" collective="false" import="true" type="upgrade">
+      <infoLinks>
+        <infoLink id="422a-22a8-65ab-0d92" name="Instigator bolt carbine" hidden="false" targetId="9577-186e-74bf-e8c2" type="profile"/>
+      </infoLinks>
+      <costs>
+        <cost name="pts" typeId="points" value="5.0"/>
+        <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0"/>
+        <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="3b91-753d-a35d-9bbe" name="Las fusil" hidden="false" collective="false" import="true" type="upgrade">
+      <infoLinks>
+        <infoLink id="fe23-e024-40f4-37a7" name="Las fusil" hidden="false" targetId="5e3b-7904-3d29-e563" type="profile"/>
+      </infoLinks>
+      <costs>
+        <cost name="pts" typeId="points" value="15.0"/>
+        <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0"/>
+        <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
       </costs>
     </selectionEntry>
   </sharedSelectionEntries>
@@ -18058,6 +18160,49 @@ The Primed Haywire Mine is represented by the Primed Haywire Mine model, but doe
     <profile id="0d60-a97a-1ce4-c8f3" name="Smoke Grenades" hidden="false" typeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" typeName="Abilities">
       <characteristics>
         <characteristic name="Description" typeId="21befb24-fc85-4f52-a745-64b2e48f8228">Once per battle, instead of shooting any weapons in the Shooting phase, this unit can use its smoke grenades; until your next Shooting phase, your opponent must subtract 1 from hit rolls for attacks made with ranged weapons that target this unit.</characteristic>
+      </characteristics>
+    </profile>
+    <profile id="a406-dba2-0f6f-9487" name="Twin ironhail autocannon" hidden="false" typeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" typeName="Weapon">
+      <characteristics>
+        <characteristic name="Range" typeId="6fa97fa8-ea74-4a27-a0fb-bc4e5f367464">48&quot;</characteristic>
+        <characteristic name="Type" typeId="077c342f-d7b9-45c6-b8af-88e97cafd3a2">Heavy 6</characteristic>
+        <characteristic name="S" typeId="59b1-319e-ec13-d466">7</characteristic>
+        <characteristic name="AP" typeId="75aa-a838-b675-6484">-1</characteristic>
+        <characteristic name="D" typeId="ae8a-3137-d65b-4ca7">1</characteristic>
+        <characteristic name="Abilities" typeId="837d-5e63-aeb7-1410">-</characteristic>
+      </characteristics>
+    </profile>
+    <profile id="9577-186e-74bf-e8c2" name="Instigator bolt carbine" hidden="false" typeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" typeName="Weapon">
+      <characteristics>
+        <characteristic name="Range" typeId="6fa97fa8-ea74-4a27-a0fb-bc4e5f367464">24&quot;</characteristic>
+        <characteristic name="Type" typeId="077c342f-d7b9-45c6-b8af-88e97cafd3a2">Assault 1</characteristic>
+        <characteristic name="S" typeId="59b1-319e-ec13-d466">4</characteristic>
+        <characteristic name="AP" typeId="75aa-a838-b675-6484">-1</characteristic>
+        <characteristic name="D" typeId="ae8a-3137-d65b-4ca7">2</characteristic>
+        <characteristic name="Abilities" typeId="837d-5e63-aeb7-1410">This weapon can target a Character even if it is not the closest enemy unit.</characteristic>
+      </characteristics>
+    </profile>
+    <profile id="5e3b-7904-3d29-e563" name="Las fusil" hidden="false" typeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" typeName="Weapon">
+      <characteristics>
+        <characteristic name="Range" typeId="6fa97fa8-ea74-4a27-a0fb-bc4e5f367464">36</characteristic>
+        <characteristic name="Type" typeId="077c342f-d7b9-45c6-b8af-88e97cafd3a2">Heavy 1</characteristic>
+        <characteristic name="S" typeId="59b1-319e-ec13-d466">8</characteristic>
+        <characteristic name="AP" typeId="75aa-a838-b675-6484">-3</characteristic>
+        <characteristic name="D" typeId="ae8a-3137-d65b-4ca7">3</characteristic>
+        <characteristic name="Abilities" typeId="837d-5e63-aeb7-1410"/>
+      </characteristics>
+    </profile>
+    <profile id="bba0-2f30-36d5-c6af" name="Eliminator" hidden="false" typeId="800f-21d0-4387-c943" typeName="Unit">
+      <characteristics>
+        <characteristic name="M" typeId="0bdf-a96e-9e38-7779">6&quot;</characteristic>
+        <characteristic name="WS" typeId="e7f0-1278-0250-df0c">3+</characteristic>
+        <characteristic name="BS" typeId="381b-eb28-74c3-df5f">3+</characteristic>
+        <characteristic name="S" typeId="2218-aa3c-265f-2939">4</characteristic>
+        <characteristic name="T" typeId="9c9f-9774-a358-3a39">4</characteristic>
+        <characteristic name="W" typeId="f330-5e6e-4110-0978">2</characteristic>
+        <characteristic name="A" typeId="13fc-b29b-31f2-ab9f">2</characteristic>
+        <characteristic name="Ld" typeId="00ca-f8b8-876d-b705">7</characteristic>
+        <characteristic name="Save" typeId="c0df-df94-abd7-e8d3">3+</characteristic>
       </characteristics>
     </profile>
   </sharedProfiles>

--- a/Orks.cat
+++ b/Orks.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="11b5-77b9-31bf-7b74" name="Orks" revision="54" battleScribeVersion="2.02" authorName="BSData Developers" authorContact="@Tag8833" authorUrl="https://discord.gg/KqPVhds" library="false" gameSystemId="28ec-711c-d87f-3aeb" gameSystemRevision="1" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="11b5-77b9-31bf-7b74" name="Orks" revision="55" battleScribeVersion="2.03" authorName="BSData Developers" authorContact="@Tag8833" authorUrl="https://discord.gg/KqPVhds" library="false" gameSystemId="28ec-711c-d87f-3aeb" gameSystemRevision="1" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <publications>
     <publication id="11b5-77b9-pubN65537" name="Codex: Orks"/>
     <publication id="11b5-77b9-pubN69765" name="Index: Xenos 2"/>
@@ -139,59 +139,55 @@
     <categoryEntry id="78e6-5cfc-20d3-d002" name="Wagon" hidden="false"/>
   </categoryEntries>
   <entryLinks>
-    <entryLink id="140b-7829-a8c0-3d3b" name="Warboss" hidden="false" collective="false" targetId="5da7-8cb2-c66c-5c45" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="7ea0-7fc5-ef16-a309" name="New CategoryLink" hidden="false" targetId="848a6ff2-0def-4c72-8433-ff7da70e6bc7" primary="true"/>
-      </categoryLinks>
-    </entryLink>
-    <entryLink id="de66-8bdc-ac4d-1fbc" name="Warboss in MA" hidden="false" collective="false" targetId="6a49-f7e4-4c4b-3548" type="selectionEntry"/>
-    <entryLink id="c243-87ad-6ddf-1081" name="New EntryLink" hidden="false" collective="false" targetId="aa39-9f9d-0e78-2f8a" type="selectionEntry"/>
-    <entryLink id="43ed-f88f-fe67-90fd" name="Weirdboy" hidden="false" collective="false" targetId="4087-8bfc-973a-f88b" type="selectionEntry"/>
-    <entryLink id="a4cb-236b-91d7-6343" name="New EntryLink" hidden="false" collective="false" targetId="48c5-847b-42a3-54a9" type="selectionEntry"/>
-    <entryLink id="5919-96f8-f901-0810" name="New EntryLink" hidden="false" collective="false" targetId="f517-6aa6-7d19-13c2" type="selectionEntry"/>
-    <entryLink id="e15c-ad5b-8127-7efb" name="New EntryLink" hidden="false" collective="false" targetId="1387-57d0-6d81-dbcb" type="selectionEntry"/>
-    <entryLink id="616f-3d06-53bf-4454" name="New EntryLink" hidden="false" collective="false" targetId="a267-1463-18ed-c330" type="selectionEntry"/>
-    <entryLink id="49f4-083c-a5ec-87f5" name="New EntryLink" hidden="false" collective="false" targetId="f654-3f0e-3775-807c" type="selectionEntry"/>
-    <entryLink id="674f-5ac5-816a-9d60" name="New EntryLink" hidden="false" collective="false" targetId="3a83-48ec-8a34-1471" type="selectionEntry"/>
-    <entryLink id="3b48-7738-9fd4-617a" name="New EntryLink" hidden="false" collective="false" targetId="6f08-a7c2-fdc2-9565" type="selectionEntry"/>
-    <entryLink id="38fe-6b37-024d-4cc7" name="New EntryLink" hidden="false" collective="false" targetId="06ff-697d-8aa1-2dd0" type="selectionEntry"/>
-    <entryLink id="f936-cfae-68df-76bd" name="Kaptin Badrukk" hidden="false" collective="false" targetId="8ced-c9f4-249d-0fc3" type="selectionEntry"/>
-    <entryLink id="43b8-74a7-9ff7-de0d" name="New EntryLink" hidden="false" collective="false" targetId="0d18-8bfc-b6ac-920e" type="selectionEntry"/>
-    <entryLink id="1c60-3ef1-7f7f-c38f" name="New EntryLink" hidden="false" collective="false" targetId="9037-5d51-7e69-51aa" type="selectionEntry"/>
-    <entryLink id="e891-db86-4983-2a05" name="New EntryLink" hidden="false" collective="false" targetId="4923-2dbf-7fd5-8828" type="selectionEntry"/>
-    <entryLink id="1c7b-ea7d-7177-2010" name="Gretchin" hidden="false" collective="false" targetId="96ec-51fe-cd61-b2c1" type="selectionEntry"/>
-    <entryLink id="14d9-a588-df5b-62ac" name="New EntryLink" hidden="false" collective="false" targetId="4a86-9031-67e9-cb27" type="selectionEntry"/>
-    <entryLink id="f9cc-8b46-ce81-28cc" name="New EntryLink" hidden="false" collective="false" targetId="b4f7-fe86-812e-602c" type="selectionEntry"/>
-    <entryLink id="e467-b440-db76-a3d7" name="Nob with Waaagh! Banner" hidden="false" collective="false" targetId="d134-3bdb-4db3-203e" type="selectionEntry"/>
-    <entryLink id="0c2a-34ba-db71-28ef" name="New EntryLink" hidden="false" collective="false" targetId="50bb-821a-aaac-4b0f" type="selectionEntry"/>
-    <entryLink id="f620-edde-f675-4f73" name="New EntryLink" hidden="false" collective="false" targetId="0d17-9ee8-267d-9824" type="selectionEntry"/>
-    <entryLink id="15b2-24f6-b380-d5b1" name="New EntryLink" hidden="false" collective="false" targetId="271f-ceb6-0cde-d108" type="selectionEntry"/>
-    <entryLink id="8abd-2e14-89ef-b4fa" name="New EntryLink" hidden="false" collective="false" targetId="2056-01cf-da87-974d" type="selectionEntry"/>
-    <entryLink id="c160-6f07-0220-2da6" name="New EntryLink" hidden="false" collective="false" targetId="7945-13e5-5ad9-1667" type="selectionEntry"/>
-    <entryLink id="7df6-4093-e24c-10dc" name="New EntryLink" hidden="false" collective="false" targetId="28e9-a883-f67f-ff5a" type="selectionEntry"/>
-    <entryLink id="4513-06fa-60c2-8d11" name="New EntryLink" hidden="false" collective="false" targetId="d28d-7a82-0ac3-9391" type="selectionEntry"/>
-    <entryLink id="cd7a-a403-71cd-0269" name="New EntryLink" hidden="false" collective="false" targetId="826d-99ed-ff5d-7082" type="selectionEntry"/>
-    <entryLink id="82e5-5895-fcff-20fc" name="Burna-bommer" hidden="false" collective="false" targetId="a5bc-9929-50fa-c7fb" type="selectionEntry"/>
-    <entryLink id="24a3-a4a4-34f7-ee58" name="New EntryLink" hidden="false" collective="false" targetId="73ba-a086-3038-c166" type="selectionEntry"/>
-    <entryLink id="7eb3-ad3d-e93b-eec0" name="New EntryLink" hidden="false" collective="false" targetId="0cd2-fd7c-2b53-78f0" type="selectionEntry"/>
-    <entryLink id="87c5-8a18-3876-76d6" name="New EntryLink" hidden="false" collective="false" targetId="88f3-f1da-0592-9755" type="selectionEntry"/>
-    <entryLink id="b394-bcc9-95fa-ce68" name="New EntryLink" hidden="false" collective="false" targetId="d5f1-6fff-d11b-0091" type="selectionEntry"/>
-    <entryLink id="844f-05a8-e76f-632e" name="New EntryLink" hidden="false" collective="false" targetId="f7ee-37e2-efd6-a351" type="selectionEntry"/>
-    <entryLink id="e40b-5b26-427b-2e89" name="New EntryLink" hidden="false" collective="false" targetId="98a5-e209-f687-1ee6" type="selectionEntry"/>
-    <entryLink id="af13-ff57-e87c-8342" name="New EntryLink" hidden="false" collective="false" targetId="8383-113c-08bc-3f40" type="selectionEntry"/>
-    <entryLink id="67c5-2853-ee59-3e18" name="New EntryLink" hidden="false" collective="false" targetId="5002-4d47-db8c-d39f" type="selectionEntry"/>
-    <entryLink id="2a0f-4f78-89a2-d26e" name="Battlewagon" hidden="false" collective="false" targetId="f0b4-c759-e809-424e" type="selectionEntry"/>
-    <entryLink id="9f98-1478-b761-401b" name="New EntryLink" hidden="false" collective="false" targetId="7e8f-2745-5160-1161" type="selectionEntry"/>
-    <entryLink id="3ab3-9709-48c9-5408" name="New EntryLink" hidden="false" collective="false" targetId="963f-1e91-85d2-f6d6" type="selectionEntry"/>
-    <entryLink id="de14-3873-5b48-e4b6" name="New EntryLink" hidden="false" collective="false" targetId="efe5-5715-d739-d18e" type="selectionEntry"/>
-    <entryLink id="cd55-7d20-4a0c-ca96" name="New EntryLink" hidden="false" collective="false" targetId="6cbb-033d-b491-4076" type="selectionEntry"/>
-    <entryLink id="3456-73fe-892c-0069" name="New EntryLink" hidden="false" collective="false" targetId="bdf8-0eca-cfc0-07fd" type="selectionEntry"/>
-    <entryLink id="2479-2fe1-ea5b-7d2e" name="New EntryLink" hidden="false" collective="false" targetId="8d81-3378-2c49-7b5c" type="selectionEntry"/>
-    <entryLink id="4eba-9be9-4ebb-912a" name="New EntryLink" hidden="false" collective="false" targetId="8ef1-3dff-656f-1a8c" type="selectionEntry"/>
-    <entryLink id="9e27-2f60-2c03-2b41" name="New EntryLink" hidden="false" collective="false" targetId="5bcd-2f69-1bb9-070d" type="selectionEntry"/>
-    <entryLink id="bbb5-3a21-c5eb-58d6" name="Zhadsnark Da Ripper" hidden="false" collective="false" targetId="2472-0afa-3962-274a" type="selectionEntry"/>
-    <entryLink id="3187-4d9a-338a-463b" name="Ork Mek Boss Buzzgob" hidden="false" collective="false" targetId="36e2-087e-77dd-441b" type="selectionEntry"/>
-    <entryLink id="46c9-a6b1-6814-a072" name="Grot Tanks" hidden="false" collective="false" targetId="c7e2-297c-a0f9-a9fe" type="selectionEntry">
+    <entryLink id="140b-7829-a8c0-3d3b" name="Warboss" hidden="false" collective="false" import="true" targetId="5da7-8cb2-c66c-5c45" type="selectionEntry"/>
+    <entryLink id="de66-8bdc-ac4d-1fbc" name="Warboss in MA" hidden="false" collective="false" import="true" targetId="6a49-f7e4-4c4b-3548" type="selectionEntry"/>
+    <entryLink id="c243-87ad-6ddf-1081" name="New EntryLink" hidden="false" collective="false" import="true" targetId="aa39-9f9d-0e78-2f8a" type="selectionEntry"/>
+    <entryLink id="43ed-f88f-fe67-90fd" name="Weirdboy" hidden="false" collective="false" import="true" targetId="4087-8bfc-973a-f88b" type="selectionEntry"/>
+    <entryLink id="a4cb-236b-91d7-6343" name="New EntryLink" hidden="false" collective="false" import="true" targetId="48c5-847b-42a3-54a9" type="selectionEntry"/>
+    <entryLink id="5919-96f8-f901-0810" name="New EntryLink" hidden="false" collective="false" import="true" targetId="f517-6aa6-7d19-13c2" type="selectionEntry"/>
+    <entryLink id="e15c-ad5b-8127-7efb" name="New EntryLink" hidden="false" collective="false" import="true" targetId="1387-57d0-6d81-dbcb" type="selectionEntry"/>
+    <entryLink id="616f-3d06-53bf-4454" name="New EntryLink" hidden="false" collective="false" import="true" targetId="a267-1463-18ed-c330" type="selectionEntry"/>
+    <entryLink id="49f4-083c-a5ec-87f5" name="New EntryLink" hidden="false" collective="false" import="true" targetId="f654-3f0e-3775-807c" type="selectionEntry"/>
+    <entryLink id="674f-5ac5-816a-9d60" name="New EntryLink" hidden="false" collective="false" import="true" targetId="3a83-48ec-8a34-1471" type="selectionEntry"/>
+    <entryLink id="3b48-7738-9fd4-617a" name="New EntryLink" hidden="false" collective="false" import="true" targetId="6f08-a7c2-fdc2-9565" type="selectionEntry"/>
+    <entryLink id="38fe-6b37-024d-4cc7" name="New EntryLink" hidden="false" collective="false" import="true" targetId="06ff-697d-8aa1-2dd0" type="selectionEntry"/>
+    <entryLink id="f936-cfae-68df-76bd" name="Kaptin Badrukk" hidden="false" collective="false" import="true" targetId="8ced-c9f4-249d-0fc3" type="selectionEntry"/>
+    <entryLink id="43b8-74a7-9ff7-de0d" name="New EntryLink" hidden="false" collective="false" import="true" targetId="0d18-8bfc-b6ac-920e" type="selectionEntry"/>
+    <entryLink id="1c60-3ef1-7f7f-c38f" name="New EntryLink" hidden="false" collective="false" import="true" targetId="9037-5d51-7e69-51aa" type="selectionEntry"/>
+    <entryLink id="e891-db86-4983-2a05" name="New EntryLink" hidden="false" collective="false" import="true" targetId="4923-2dbf-7fd5-8828" type="selectionEntry"/>
+    <entryLink id="1c7b-ea7d-7177-2010" name="Gretchin" hidden="false" collective="false" import="true" targetId="96ec-51fe-cd61-b2c1" type="selectionEntry"/>
+    <entryLink id="14d9-a588-df5b-62ac" name="New EntryLink" hidden="false" collective="false" import="true" targetId="4a86-9031-67e9-cb27" type="selectionEntry"/>
+    <entryLink id="f9cc-8b46-ce81-28cc" name="New EntryLink" hidden="false" collective="false" import="true" targetId="b4f7-fe86-812e-602c" type="selectionEntry"/>
+    <entryLink id="e467-b440-db76-a3d7" name="Nob with Waaagh! Banner" hidden="false" collective="false" import="true" targetId="d134-3bdb-4db3-203e" type="selectionEntry"/>
+    <entryLink id="0c2a-34ba-db71-28ef" name="New EntryLink" hidden="false" collective="false" import="true" targetId="50bb-821a-aaac-4b0f" type="selectionEntry"/>
+    <entryLink id="f620-edde-f675-4f73" name="New EntryLink" hidden="false" collective="false" import="true" targetId="0d17-9ee8-267d-9824" type="selectionEntry"/>
+    <entryLink id="15b2-24f6-b380-d5b1" name="New EntryLink" hidden="false" collective="false" import="true" targetId="271f-ceb6-0cde-d108" type="selectionEntry"/>
+    <entryLink id="8abd-2e14-89ef-b4fa" name="New EntryLink" hidden="false" collective="false" import="true" targetId="2056-01cf-da87-974d" type="selectionEntry"/>
+    <entryLink id="c160-6f07-0220-2da6" name="New EntryLink" hidden="false" collective="false" import="true" targetId="7945-13e5-5ad9-1667" type="selectionEntry"/>
+    <entryLink id="7df6-4093-e24c-10dc" name="New EntryLink" hidden="false" collective="false" import="true" targetId="28e9-a883-f67f-ff5a" type="selectionEntry"/>
+    <entryLink id="4513-06fa-60c2-8d11" name="New EntryLink" hidden="false" collective="false" import="true" targetId="d28d-7a82-0ac3-9391" type="selectionEntry"/>
+    <entryLink id="cd7a-a403-71cd-0269" name="New EntryLink" hidden="false" collective="false" import="true" targetId="826d-99ed-ff5d-7082" type="selectionEntry"/>
+    <entryLink id="82e5-5895-fcff-20fc" name="Burna-bommer" hidden="false" collective="false" import="true" targetId="a5bc-9929-50fa-c7fb" type="selectionEntry"/>
+    <entryLink id="24a3-a4a4-34f7-ee58" name="New EntryLink" hidden="false" collective="false" import="true" targetId="73ba-a086-3038-c166" type="selectionEntry"/>
+    <entryLink id="7eb3-ad3d-e93b-eec0" name="New EntryLink" hidden="false" collective="false" import="true" targetId="0cd2-fd7c-2b53-78f0" type="selectionEntry"/>
+    <entryLink id="87c5-8a18-3876-76d6" name="New EntryLink" hidden="false" collective="false" import="true" targetId="88f3-f1da-0592-9755" type="selectionEntry"/>
+    <entryLink id="b394-bcc9-95fa-ce68" name="New EntryLink" hidden="false" collective="false" import="true" targetId="d5f1-6fff-d11b-0091" type="selectionEntry"/>
+    <entryLink id="844f-05a8-e76f-632e" name="New EntryLink" hidden="false" collective="false" import="true" targetId="f7ee-37e2-efd6-a351" type="selectionEntry"/>
+    <entryLink id="e40b-5b26-427b-2e89" name="New EntryLink" hidden="false" collective="false" import="true" targetId="98a5-e209-f687-1ee6" type="selectionEntry"/>
+    <entryLink id="af13-ff57-e87c-8342" name="New EntryLink" hidden="false" collective="false" import="true" targetId="8383-113c-08bc-3f40" type="selectionEntry"/>
+    <entryLink id="67c5-2853-ee59-3e18" name="New EntryLink" hidden="false" collective="false" import="true" targetId="5002-4d47-db8c-d39f" type="selectionEntry"/>
+    <entryLink id="2a0f-4f78-89a2-d26e" name="Battlewagon" hidden="false" collective="false" import="true" targetId="f0b4-c759-e809-424e" type="selectionEntry"/>
+    <entryLink id="9f98-1478-b761-401b" name="New EntryLink" hidden="false" collective="false" import="true" targetId="7e8f-2745-5160-1161" type="selectionEntry"/>
+    <entryLink id="3ab3-9709-48c9-5408" name="New EntryLink" hidden="false" collective="false" import="true" targetId="963f-1e91-85d2-f6d6" type="selectionEntry"/>
+    <entryLink id="de14-3873-5b48-e4b6" name="New EntryLink" hidden="false" collective="false" import="true" targetId="efe5-5715-d739-d18e" type="selectionEntry"/>
+    <entryLink id="cd55-7d20-4a0c-ca96" name="New EntryLink" hidden="false" collective="false" import="true" targetId="6cbb-033d-b491-4076" type="selectionEntry"/>
+    <entryLink id="3456-73fe-892c-0069" name="New EntryLink" hidden="false" collective="false" import="true" targetId="bdf8-0eca-cfc0-07fd" type="selectionEntry"/>
+    <entryLink id="2479-2fe1-ea5b-7d2e" name="New EntryLink" hidden="false" collective="false" import="true" targetId="8d81-3378-2c49-7b5c" type="selectionEntry"/>
+    <entryLink id="4eba-9be9-4ebb-912a" name="New EntryLink" hidden="false" collective="false" import="true" targetId="8ef1-3dff-656f-1a8c" type="selectionEntry"/>
+    <entryLink id="9e27-2f60-2c03-2b41" name="New EntryLink" hidden="false" collective="false" import="true" targetId="5bcd-2f69-1bb9-070d" type="selectionEntry"/>
+    <entryLink id="bbb5-3a21-c5eb-58d6" name="Zhadsnark Da Ripper" hidden="false" collective="false" import="true" targetId="2472-0afa-3962-274a" type="selectionEntry"/>
+    <entryLink id="3187-4d9a-338a-463b" name="Ork Mek Boss Buzzgob" hidden="false" collective="false" import="true" targetId="36e2-087e-77dd-441b" type="selectionEntry"/>
+    <entryLink id="46c9-a6b1-6814-a072" name="Grot Tanks" hidden="false" collective="false" import="true" targetId="c7e2-297c-a0f9-a9fe" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="d039-e5ba-4bab-bf16" value="-1">
           <conditionGroups>
@@ -211,29 +207,29 @@
         <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d039-e5ba-4bab-bf16" type="max"/>
       </constraints>
     </entryLink>
-    <entryLink id="985a-6513-f3ae-6235" name="Grot Mega-Tank" hidden="false" collective="false" targetId="688b-7929-cf2f-6c5d" type="selectionEntry"/>
-    <entryLink id="8421-0cdc-3dc6-7821" name="Squiggoth" hidden="false" collective="false" targetId="e6c8-1855-9421-3cc4" type="selectionEntry"/>
-    <entryLink id="9dd2-ed77-fe1c-0838" name="Big Trakk" hidden="false" collective="false" targetId="9576-6195-fe16-dab7" type="selectionEntry"/>
-    <entryLink id="ac27-3368-8f46-33b6" name="&apos;Chinork&apos; Warkopta" hidden="false" collective="false" targetId="d382-287a-3c10-6596" type="selectionEntry"/>
-    <entryLink id="11d9-19ef-7dae-8545" name="Battlewagon W/ Supa-Kannon" hidden="false" collective="false" targetId="83bd-01d2-82f5-1e73" type="selectionEntry"/>
-    <entryLink id="00b6-be8f-91ec-96a1" name="Gargantuan Squiggoth" hidden="false" collective="false" targetId="e8f4-86e5-a97d-2817" type="selectionEntry"/>
-    <entryLink id="d271-f79b-df7e-3e45" name="Kill Tank" hidden="false" collective="false" targetId="5521-9ab8-c925-50c2" type="selectionEntry"/>
-    <entryLink id="1989-d713-5df2-b7c1" name="Kustom Stompa" hidden="false" collective="false" targetId="e75a-217f-2d54-09e1" type="selectionEntry"/>
-    <entryLink id="968d-7a5c-9dcd-d0c3" name="Lifta Wagon" hidden="false" collective="false" targetId="6879-dd66-6ee7-56a8" type="selectionEntry"/>
-    <entryLink id="e19f-c57e-029e-cd6c" name="Meka-Dread" hidden="false" collective="false" targetId="1254-ab58-4b43-66ab" type="selectionEntry"/>
-    <entryLink id="afb8-67e3-8da1-656e" name="Grot Bomm Launcha (Open/Narrative)" hidden="false" collective="false" targetId="de51-4ce6-1a6b-ca70" type="selectionEntry"/>
-    <entryLink id="f570-e61d-1ed0-e9c3" name="Attack Fighta (Open/Narrative)" hidden="false" collective="false" targetId="e3c1-9af9-b021-7b95" type="selectionEntry"/>
-    <entryLink id="45ac-fb0e-3793-6dd2" name="Fighta-Bommer (Open/Narrative)" hidden="false" collective="false" targetId="ce2e-a0ad-29b2-3eab" type="selectionEntry"/>
-    <entryLink id="fe79-4551-b074-ae0d" name="BoneBreaker" hidden="false" collective="false" targetId="e185-cc94-ec1e-9b84" type="selectionEntry"/>
-    <entryLink id="82f0-f4fb-8c89-59ea" name="Boomdakka Snazzwagon" hidden="false" collective="false" targetId="f81f-4af6-bf20-9655" type="selectionEntry"/>
-    <entryLink id="ff43-8e5a-eff3-17fd" name="Deffkilla Wartrike" hidden="false" collective="false" targetId="02b9-11f4-6969-f8bd" type="selectionEntry"/>
-    <entryLink id="08c8-bd36-0fa8-95d7" name="Gunwagon" hidden="false" collective="false" targetId="e7d1-7688-5cbb-557f" type="selectionEntry"/>
-    <entryLink id="8444-f1ba-f89f-ad58" name="Kustom Boosta Blastas" hidden="false" collective="false" targetId="437b-75b3-db04-d55d" type="selectionEntry"/>
-    <entryLink id="2a59-3e32-707f-c185" name="Megatrukk Scrapjet" hidden="false" collective="false" targetId="365a-9db9-ab7e-0235" type="selectionEntry"/>
-    <entryLink id="436c-4907-e84e-1646" name="Rukkatrukk Squigbuggy" hidden="false" collective="false" targetId="9771-81af-630b-74a3" type="selectionEntry"/>
-    <entryLink id="519b-f98a-a1e3-2e4e" name="Shokkjump Dragstas" hidden="false" collective="false" targetId="3e2b-6a43-cae2-f7ad" type="selectionEntry"/>
-    <entryLink id="150c-d62e-0e72-1a89" name="Mekboy Workshop" hidden="false" collective="false" targetId="8c9b-9002-d5df-136d" type="selectionEntry"/>
-    <entryLink id="b02a-5919-f6d2-f369" name="Clan Kultur" hidden="false" collective="false" targetId="fee6-89eb-b8fc-9982" type="selectionEntry">
+    <entryLink id="985a-6513-f3ae-6235" name="Grot Mega-Tank" hidden="false" collective="false" import="true" targetId="688b-7929-cf2f-6c5d" type="selectionEntry"/>
+    <entryLink id="8421-0cdc-3dc6-7821" name="Squiggoth" hidden="false" collective="false" import="true" targetId="e6c8-1855-9421-3cc4" type="selectionEntry"/>
+    <entryLink id="9dd2-ed77-fe1c-0838" name="Big Trakk" hidden="false" collective="false" import="true" targetId="9576-6195-fe16-dab7" type="selectionEntry"/>
+    <entryLink id="ac27-3368-8f46-33b6" name="&apos;Chinork&apos; Warkopta" hidden="false" collective="false" import="true" targetId="d382-287a-3c10-6596" type="selectionEntry"/>
+    <entryLink id="11d9-19ef-7dae-8545" name="Battlewagon W/ Supa-Kannon" hidden="false" collective="false" import="true" targetId="83bd-01d2-82f5-1e73" type="selectionEntry"/>
+    <entryLink id="00b6-be8f-91ec-96a1" name="Gargantuan Squiggoth" hidden="false" collective="false" import="true" targetId="e8f4-86e5-a97d-2817" type="selectionEntry"/>
+    <entryLink id="d271-f79b-df7e-3e45" name="Kill Tank" hidden="false" collective="false" import="true" targetId="5521-9ab8-c925-50c2" type="selectionEntry"/>
+    <entryLink id="1989-d713-5df2-b7c1" name="Kustom Stompa" hidden="false" collective="false" import="true" targetId="e75a-217f-2d54-09e1" type="selectionEntry"/>
+    <entryLink id="968d-7a5c-9dcd-d0c3" name="Lifta Wagon" hidden="false" collective="false" import="true" targetId="6879-dd66-6ee7-56a8" type="selectionEntry"/>
+    <entryLink id="e19f-c57e-029e-cd6c" name="Meka-Dread" hidden="false" collective="false" import="true" targetId="1254-ab58-4b43-66ab" type="selectionEntry"/>
+    <entryLink id="afb8-67e3-8da1-656e" name="Grot Bomm Launcha (Open/Narrative)" hidden="false" collective="false" import="true" targetId="de51-4ce6-1a6b-ca70" type="selectionEntry"/>
+    <entryLink id="f570-e61d-1ed0-e9c3" name="Attack Fighta (Open/Narrative)" hidden="false" collective="false" import="true" targetId="e3c1-9af9-b021-7b95" type="selectionEntry"/>
+    <entryLink id="45ac-fb0e-3793-6dd2" name="Fighta-Bommer (Open/Narrative)" hidden="false" collective="false" import="true" targetId="ce2e-a0ad-29b2-3eab" type="selectionEntry"/>
+    <entryLink id="fe79-4551-b074-ae0d" name="BoneBreaker" hidden="false" collective="false" import="true" targetId="e185-cc94-ec1e-9b84" type="selectionEntry"/>
+    <entryLink id="82f0-f4fb-8c89-59ea" name="Boomdakka Snazzwagon" hidden="false" collective="false" import="true" targetId="f81f-4af6-bf20-9655" type="selectionEntry"/>
+    <entryLink id="ff43-8e5a-eff3-17fd" name="Deffkilla Wartrike" hidden="false" collective="false" import="true" targetId="02b9-11f4-6969-f8bd" type="selectionEntry"/>
+    <entryLink id="08c8-bd36-0fa8-95d7" name="Gunwagon" hidden="false" collective="false" import="true" targetId="e7d1-7688-5cbb-557f" type="selectionEntry"/>
+    <entryLink id="8444-f1ba-f89f-ad58" name="Kustom Boosta Blastas" hidden="false" collective="false" import="true" targetId="437b-75b3-db04-d55d" type="selectionEntry"/>
+    <entryLink id="2a59-3e32-707f-c185" name="Megatrukk Scrapjet" hidden="false" collective="false" import="true" targetId="365a-9db9-ab7e-0235" type="selectionEntry"/>
+    <entryLink id="436c-4907-e84e-1646" name="Rukkatrukk Squigbuggy" hidden="false" collective="false" import="true" targetId="9771-81af-630b-74a3" type="selectionEntry"/>
+    <entryLink id="519b-f98a-a1e3-2e4e" name="Shokkjump Dragstas" hidden="false" collective="false" import="true" targetId="3e2b-6a43-cae2-f7ad" type="selectionEntry"/>
+    <entryLink id="150c-d62e-0e72-1a89" name="Mekboy Workshop" hidden="false" collective="false" import="true" targetId="8c9b-9002-d5df-136d" type="selectionEntry"/>
+    <entryLink id="b02a-5919-f6d2-f369" name="Clan Kultur" hidden="false" collective="false" import="true" targetId="fee6-89eb-b8fc-9982" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="e189-0ab5-c4fd-1629" value="0.0">
           <conditions>
@@ -256,11 +252,11 @@
         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e189-0ab5-c4fd-1629" type="min"/>
       </constraints>
     </entryLink>
-    <entryLink id="e3b2-20b5-7d5b-085f" name="Big Mek W/ Shokk Attack Gun" hidden="false" collective="false" targetId="63ac-bded-f230-452a" type="selectionEntry"/>
-    <entryLink id="ab25-8733-3d16-0aac" name="Extra Gubbins (1/3 CP)" hidden="false" collective="false" targetId="5d56-647b-a086-2ded" type="selectionEntry"/>
-    <entryLink id="d0e8-e76c-8595-d172" name="Dethrolla Battle Fortress" hidden="false" collective="false" targetId="6758-d594-1ac7-ddb2" type="selectionEntry"/>
-    <entryLink id="d6e1-7b39-3560-7a4e" name="Kill Krusha" hidden="false" collective="false" targetId="103b-3e49-086b-dd50" type="selectionEntry"/>
-    <entryLink id="5145-6931-147e-52a7" name="!Battle Fortress" hidden="false" collective="false" targetId="3ad5-6885-e38b-122b" type="selectionEntry">
+    <entryLink id="e3b2-20b5-7d5b-085f" name="Big Mek W/ Shokk Attack Gun" hidden="false" collective="false" import="true" targetId="63ac-bded-f230-452a" type="selectionEntry"/>
+    <entryLink id="ab25-8733-3d16-0aac" name="Extra Gubbins (1/3 CP)" hidden="false" collective="false" import="true" targetId="5d56-647b-a086-2ded" type="selectionEntry"/>
+    <entryLink id="d0e8-e76c-8595-d172" name="Dethrolla Battle Fortress" hidden="false" collective="false" import="true" targetId="6758-d594-1ac7-ddb2" type="selectionEntry"/>
+    <entryLink id="d6e1-7b39-3560-7a4e" name="Kill Krusha" hidden="false" collective="false" import="true" targetId="103b-3e49-086b-dd50" type="selectionEntry"/>
+    <entryLink id="5145-6931-147e-52a7" name="!Battle Fortress" hidden="false" collective="false" import="true" targetId="3ad5-6885-e38b-122b" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="true">
           <conditions>
@@ -272,7 +268,7 @@
         <categoryLink id="3b29-7ba5-35e3-1346" name="New CategoryLink" hidden="false" targetId="c888f08a-6cea-4a01-8126-d374a9231554" primary="true"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="8313-fc0a-3829-8f9e" name="!Kart" hidden="false" collective="false" targetId="f94f-4950-cc3d-f356" type="selectionEntry">
+    <entryLink id="8313-fc0a-3829-8f9e" name="!Kart" hidden="false" collective="false" import="true" targetId="f94f-4950-cc3d-f356" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="true">
           <conditions>
@@ -284,7 +280,7 @@
         <categoryLink id="4efb-4f4d-fe29-6886" name="New CategoryLink" hidden="false" targetId="1b66-3f5f-6705-079a" primary="true"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="8c0d-2ba3-117e-4f48" name="!Wagon" hidden="false" collective="false" targetId="1cc7-17cf-1d6f-7b14" type="selectionEntry">
+    <entryLink id="8c0d-2ba3-117e-4f48" name="!Wagon" hidden="false" collective="false" import="true" targetId="1cc7-17cf-1d6f-7b14" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="true">
           <conditions>
@@ -296,7 +292,7 @@
         <categoryLink id="6f77-1dd7-58f5-6962" name="New CategoryLink" hidden="false" targetId="abf5fd55-9ac7-4263-8bc1-a9fb0a8fa6a6" primary="true"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="723e-3f2c-afb1-c075" name="Specialist Detachment" hidden="false" collective="false" targetId="fc96-1331-c935-0c46" type="selectionEntry"/>
+    <entryLink id="723e-3f2c-afb1-c075" name="Specialist Detachment" hidden="false" collective="false" import="true" targetId="fc96-1331-c935-0c46" type="selectionEntry"/>
   </entryLinks>
   <rules>
     <rule id="fac1-6afc-e5c9-35c2" name="Dis Is Ours! Zog Off!" hidden="false">
@@ -304,7 +300,7 @@
     </rule>
   </rules>
   <sharedSelectionEntries>
-    <selectionEntry id="5da7-8cb2-c66c-5c45" name="Warboss" publicationId="11b5-77b9-pubN65537" page="85" hidden="false" collective="false" type="unit">
+    <selectionEntry id="5da7-8cb2-c66c-5c45" name="Warboss" publicationId="11b5-77b9-pubN65537" page="85" hidden="false" collective="false" import="true" type="unit">
       <profiles>
         <profile id="4efb-2096-02a1-2471" name="Warboss" hidden="false" typeId="800f-21d0-4387-c943" typeName="Unit">
           <characteristics>
@@ -336,44 +332,44 @@
         <categoryLink id="fdb7-3db6-d349-7564" name="New CategoryLink" hidden="false" targetId="1c58-037f-7b58-1223" primary="false"/>
       </categoryLinks>
       <selectionEntryGroups>
-        <selectionEntryGroup id="790e-18fb-69c9-2fc2" name="Shooty Arm" hidden="false" collective="false" defaultSelectionEntryId="0378-433b-7369-09a0">
+        <selectionEntryGroup id="790e-18fb-69c9-2fc2" name="Shooty Arm" hidden="false" collective="false" import="true" defaultSelectionEntryId="0378-433b-7369-09a0">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="64f2-5de0-9712-b49e" type="min"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="59df-a655-d952-a877" type="max"/>
           </constraints>
           <entryLinks>
-            <entryLink id="0378-433b-7369-09a0" name="Kombi-Rokkit" hidden="false" collective="false" targetId="3511-0070-0667-abf2" type="selectionEntry"/>
-            <entryLink id="aa20-5e1f-58d5-7990" name="Kombi-Skorcha" hidden="false" collective="false" targetId="b6c7-06c8-b7fb-05a7" type="selectionEntry"/>
-            <entryLink id="6089-edca-9879-1569" name="Kustom Shoota" hidden="false" collective="false" targetId="df47-a9ec-a22e-a2b6" type="selectionEntry"/>
-            <entryLink id="29dd-c3b9-57e3-8012" name="Shoota (Index)" hidden="false" collective="false" targetId="33fd-f9ce-0809-8a9b" type="selectionEntry"/>
+            <entryLink id="0378-433b-7369-09a0" name="Kombi-Rokkit" hidden="false" collective="false" import="true" targetId="3511-0070-0667-abf2" type="selectionEntry"/>
+            <entryLink id="aa20-5e1f-58d5-7990" name="Kombi-Skorcha" hidden="false" collective="false" import="true" targetId="b6c7-06c8-b7fb-05a7" type="selectionEntry"/>
+            <entryLink id="6089-edca-9879-1569" name="Kustom Shoota" hidden="false" collective="false" import="true" targetId="df47-a9ec-a22e-a2b6" type="selectionEntry"/>
+            <entryLink id="29dd-c3b9-57e3-8012" name="Shoota (Index)" hidden="false" collective="false" import="true" targetId="33fd-f9ce-0809-8a9b" type="selectionEntry"/>
           </entryLinks>
         </selectionEntryGroup>
-        <selectionEntryGroup id="efe3-7d9a-21be-5b4b" name="Stabby Arm" hidden="false" collective="false" defaultSelectionEntryId="3c3f-9c34-43c6-57b2">
+        <selectionEntryGroup id="efe3-7d9a-21be-5b4b" name="Stabby Arm" hidden="false" collective="false" import="true" defaultSelectionEntryId="3c3f-9c34-43c6-57b2">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b38d-6875-008e-ea59" type="min"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="84d4-2d64-4585-683c" type="max"/>
           </constraints>
           <entryLinks>
-            <entryLink id="68a5-7150-356b-27ac" name="Big Choppa" hidden="false" collective="false" targetId="0470-1b47-489b-14c9" type="selectionEntry"/>
-            <entryLink id="3c3f-9c34-43c6-57b2" name="Power Klaw" hidden="false" collective="false" targetId="fe00-451f-6735-6fd9" type="selectionEntry"/>
+            <entryLink id="68a5-7150-356b-27ac" name="Big Choppa" hidden="false" collective="false" import="true" targetId="0470-1b47-489b-14c9" type="selectionEntry"/>
+            <entryLink id="3c3f-9c34-43c6-57b2" name="Power Klaw" hidden="false" collective="false" import="true" targetId="fe00-451f-6735-6fd9" type="selectionEntry"/>
           </entryLinks>
         </selectionEntryGroup>
       </selectionEntryGroups>
       <entryLinks>
-        <entryLink id="d77d-b936-9f94-4186" name="Stikkbombs" hidden="false" collective="false" targetId="6df7-0ee7-7e6d-b182" type="selectionEntry"/>
-        <entryLink id="d844-46ed-5bff-dc2c" name="Attack Squig" hidden="false" collective="false" targetId="63f8-210a-c55a-c4c0" type="selectionEntry"/>
-        <entryLink id="61ef-9873-4917-6ce4" name="Warlord" hidden="false" collective="false" targetId="33f6-60da-7b70-5fee" type="selectionEntry"/>
-        <entryLink id="b8f3-eede-0912-b2d9" name="Warlord Traits" hidden="false" collective="false" targetId="c2ce-6759-e009-8c11" type="selectionEntryGroup"/>
-        <entryLink id="d5d7-40bc-9070-fac0" name="Slugga" hidden="false" collective="false" targetId="d13b-ad69-e6a2-d485" type="selectionEntry">
+        <entryLink id="d77d-b936-9f94-4186" name="Stikkbombs" hidden="false" collective="false" import="true" targetId="6df7-0ee7-7e6d-b182" type="selectionEntry"/>
+        <entryLink id="d844-46ed-5bff-dc2c" name="Attack Squig" hidden="false" collective="false" import="true" targetId="63f8-210a-c55a-c4c0" type="selectionEntry"/>
+        <entryLink id="61ef-9873-4917-6ce4" name="Warlord" hidden="false" collective="false" import="true" targetId="33f6-60da-7b70-5fee" type="selectionEntry"/>
+        <entryLink id="b8f3-eede-0912-b2d9" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="c2ce-6759-e009-8c11" type="selectionEntryGroup"/>
+        <entryLink id="d5d7-40bc-9070-fac0" name="Slugga" hidden="false" collective="false" import="true" targetId="d13b-ad69-e6a2-d485" type="selectionEntry">
           <constraints>
             <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d156-b875-eb55-2b9e" type="max"/>
             <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="cac7-c006-c705-7b3d" type="min"/>
           </constraints>
         </entryLink>
-        <entryLink id="8bd0-a14c-6ae0-d0b5" name="Relic Gubbinz" hidden="false" collective="false" targetId="04b0-dab2-123b-df51" type="selectionEntryGroup"/>
-        <entryLink id="4564-0965-b322-2787" name="Is a Custom Character" hidden="false" collective="false" targetId="43c4-8968-c599-ad5f" type="selectionEntry"/>
-        <entryLink id="2131-664c-3bf5-cf05" name="Custom Character Selections" hidden="false" collective="false" targetId="8774-e003-4a50-56c7" type="selectionEntryGroup"/>
-        <entryLink id="ddc6-bed5-4a6a-ff4e" name="Stratagem: Field Commander" hidden="false" collective="false" targetId="d043-3847-e963-fb5d" type="selectionEntry">
+        <entryLink id="8bd0-a14c-6ae0-d0b5" name="Relic Gubbinz" hidden="false" collective="false" import="true" targetId="04b0-dab2-123b-df51" type="selectionEntryGroup"/>
+        <entryLink id="4564-0965-b322-2787" name="Is a Custom Character" hidden="false" collective="false" import="true" targetId="43c4-8968-c599-ad5f" type="selectionEntry"/>
+        <entryLink id="2131-664c-3bf5-cf05" name="Custom Character Selections" hidden="false" collective="false" import="true" targetId="8774-e003-4a50-56c7" type="selectionEntryGroup"/>
+        <entryLink id="ddc6-bed5-4a6a-ff4e" name="Stratagem: Field Commander" hidden="false" collective="false" import="true" targetId="d043-3847-e963-fb5d" type="selectionEntry">
           <modifiers>
             <modifier type="set" field="hidden" value="true">
               <conditions>
@@ -389,7 +385,7 @@
         <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="df47-a9ec-a22e-a2b6" name="Kustom Shoota" hidden="false" collective="false" type="upgrade">
+    <selectionEntry id="df47-a9ec-a22e-a2b6" name="Kustom Shoota" hidden="false" collective="false" import="true" type="upgrade">
       <profiles>
         <profile id="b64b-c2b3-b03f-3297" name="Kustom Shoota" publicationId="11b5-77b9-pubN69765" hidden="false" typeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" typeName="Weapon">
           <characteristics>
@@ -408,7 +404,7 @@
         <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="6008-4737-d8e6-e63b" name="Big Shoota" hidden="false" collective="false" type="upgrade">
+    <selectionEntry id="6008-4737-d8e6-e63b" name="Big Shoota" hidden="false" collective="false" import="true" type="upgrade">
       <infoLinks>
         <infoLink id="84ac-fb93-378c-6567" name="Big Shoota" hidden="false" targetId="674c-6501-898c-16d6" type="profile"/>
       </infoLinks>
@@ -418,7 +414,7 @@
         <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="a8c1-7fb9-7f7b-84c5" name="Rokkit Launcha" hidden="false" collective="false" type="upgrade">
+    <selectionEntry id="a8c1-7fb9-7f7b-84c5" name="Rokkit Launcha" hidden="false" collective="false" import="true" type="upgrade">
       <infoLinks>
         <infoLink id="651a-3b5f-ca9e-7efc" name="Rokkit Launcha" hidden="false" targetId="fa68-4aa1-f708-5aed" type="profile"/>
       </infoLinks>
@@ -428,7 +424,7 @@
         <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="0470-1b47-489b-14c9" name="Big Choppa" hidden="false" collective="false" type="upgrade">
+    <selectionEntry id="0470-1b47-489b-14c9" name="Big Choppa" hidden="false" collective="false" import="true" type="upgrade">
       <profiles>
         <profile id="4f15-a39a-5651-d17a" name="Big Choppa" hidden="false" typeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" typeName="Weapon">
           <characteristics>
@@ -447,7 +443,7 @@
         <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="fe00-451f-6735-6fd9" name="Power Klaw" hidden="false" collective="false" type="upgrade">
+    <selectionEntry id="fe00-451f-6735-6fd9" name="Power Klaw" hidden="false" collective="false" import="true" type="upgrade">
       <profiles>
         <profile id="d81f-f4b2-c989-dd8c" name="Power Klaw" hidden="false" typeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" typeName="Weapon">
           <characteristics>
@@ -466,7 +462,7 @@
         <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="e704-4044-fa55-f75e" name="Shoota" hidden="false" collective="true" type="upgrade">
+    <selectionEntry id="e704-4044-fa55-f75e" name="Shoota" hidden="false" collective="true" import="true" type="upgrade">
       <infoLinks>
         <infoLink id="9f26-75aa-038b-3685" name="New InfoLink" hidden="false" targetId="5a2b-0c64-8aa8-2f3e" type="profile"/>
       </infoLinks>
@@ -476,7 +472,7 @@
         <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="3511-0070-0667-abf2" name="Kombi-Rokkit" hidden="false" collective="false" type="upgrade">
+    <selectionEntry id="3511-0070-0667-abf2" name="Kombi-Rokkit" hidden="false" collective="false" import="true" type="upgrade">
       <profiles>
         <profile id="3bd7-f97a-3df8-7cf6" name="Kombi-Rokkit" hidden="false" typeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" typeName="Abilities">
           <characteristics>
@@ -494,7 +490,7 @@
         <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="b6c7-06c8-b7fb-05a7" name="Kombi-Skorcha" hidden="false" collective="false" type="upgrade">
+    <selectionEntry id="b6c7-06c8-b7fb-05a7" name="Kombi-Skorcha" hidden="false" collective="false" import="true" type="upgrade">
       <profiles>
         <profile id="ed3f-0d3e-14fa-cdfa" name="Kombi-Skorcha" hidden="false" typeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" typeName="Abilities">
           <characteristics>
@@ -512,7 +508,7 @@
         <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="6d70-25a8-b496-2457" name="Kustom Mega-blasta" hidden="false" collective="false" type="upgrade">
+    <selectionEntry id="6d70-25a8-b496-2457" name="Kustom Mega-blasta" hidden="false" collective="false" import="true" type="upgrade">
       <infoLinks>
         <infoLink id="862a-b251-dedb-edb7" name="Kustom Mega-blasta" hidden="false" targetId="ded2-c077-d596-e294" type="profile"/>
       </infoLinks>
@@ -522,7 +518,7 @@
         <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="bbc2-56ce-67ec-5422" name="Kustom Mega-Slugga" hidden="false" collective="false" type="upgrade">
+    <selectionEntry id="bbc2-56ce-67ec-5422" name="Kustom Mega-Slugga" hidden="false" collective="false" import="true" type="upgrade">
       <profiles>
         <profile id="83c2-05d5-d622-bd8c" name="Kustom Mega-Slugga" hidden="false" typeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" typeName="Weapon">
           <characteristics>
@@ -541,7 +537,7 @@
         <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="6df7-0ee7-7e6d-b182" name="Stikkbombs" hidden="false" collective="true" type="upgrade">
+    <selectionEntry id="6df7-0ee7-7e6d-b182" name="Stikkbombs" hidden="false" collective="true" import="true" type="upgrade">
       <constraints>
         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a1fc-a552-2ba3-2add" type="min"/>
         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f5f4-6404-6c35-e009" type="max"/>
@@ -555,7 +551,7 @@
         <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="63f8-210a-c55a-c4c0" name="Attack Squig" hidden="false" collective="false" type="upgrade">
+    <selectionEntry id="63f8-210a-c55a-c4c0" name="Attack Squig" hidden="false" collective="false" import="true" type="upgrade">
       <constraints>
         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="634b-4ecd-6d34-9108" type="max"/>
       </constraints>
@@ -577,7 +573,7 @@
         <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="6a49-f7e4-4c4b-3548" name="Warboss in Mega Armour (index)" hidden="false" collective="false" type="unit">
+    <selectionEntry id="6a49-f7e4-4c4b-3548" name="Warboss in Mega Armour (index)" hidden="false" collective="false" import="true" type="unit">
       <profiles>
         <profile id="c7a3-9368-b6b2-56d1" name="Warboss in Mega Armour" hidden="false" typeId="800f-21d0-4387-c943" typeName="Unit">
           <characteristics>
@@ -609,34 +605,34 @@
         <categoryLink id="b041-3515-b24d-335f" name="New CategoryLink" hidden="false" targetId="0f75-56ae-9b7c-afd9" primary="false"/>
       </categoryLinks>
       <selectionEntryGroups>
-        <selectionEntryGroup id="2013-7bc4-3331-6d24" name="Shoota Arm" hidden="false" collective="false" defaultSelectionEntryId="e28d-14f7-9a6d-4a4e">
+        <selectionEntryGroup id="2013-7bc4-3331-6d24" name="Shoota Arm" hidden="false" collective="false" import="true" defaultSelectionEntryId="e28d-14f7-9a6d-4a4e">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="68bf-aa84-4e43-93d1" type="min"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fa1f-c521-0cfc-26b2" type="max"/>
           </constraints>
           <entryLinks>
-            <entryLink id="eea5-87cf-0e38-4026" name="New EntryLink" hidden="false" collective="false" targetId="f314-b941-342f-289c" type="selectionEntry"/>
-            <entryLink id="8d68-873f-0fae-a2b3" name="New EntryLink" hidden="false" collective="false" targetId="3511-0070-0667-abf2" type="selectionEntry"/>
-            <entryLink id="4491-3a94-1ba2-d36b" name="New EntryLink" hidden="false" collective="false" targetId="b6c7-06c8-b7fb-05a7" type="selectionEntry"/>
-            <entryLink id="e28d-14f7-9a6d-4a4e" name="New EntryLink" hidden="false" collective="false" targetId="df47-a9ec-a22e-a2b6" type="selectionEntry"/>
-            <entryLink id="be3a-ff3a-8487-5ee4" name="Big Choppa" hidden="false" collective="false" targetId="0470-1b47-489b-14c9" type="selectionEntry"/>
-            <entryLink id="b70a-4b7a-5d8d-7dab" name="New EntryLink" hidden="false" collective="false" targetId="fe00-451f-6735-6fd9" type="selectionEntry"/>
+            <entryLink id="eea5-87cf-0e38-4026" name="New EntryLink" hidden="false" collective="false" import="true" targetId="f314-b941-342f-289c" type="selectionEntry"/>
+            <entryLink id="8d68-873f-0fae-a2b3" name="New EntryLink" hidden="false" collective="false" import="true" targetId="3511-0070-0667-abf2" type="selectionEntry"/>
+            <entryLink id="4491-3a94-1ba2-d36b" name="New EntryLink" hidden="false" collective="false" import="true" targetId="b6c7-06c8-b7fb-05a7" type="selectionEntry"/>
+            <entryLink id="e28d-14f7-9a6d-4a4e" name="New EntryLink" hidden="false" collective="false" import="true" targetId="df47-a9ec-a22e-a2b6" type="selectionEntry"/>
+            <entryLink id="be3a-ff3a-8487-5ee4" name="Big Choppa" hidden="false" collective="false" import="true" targetId="0470-1b47-489b-14c9" type="selectionEntry"/>
+            <entryLink id="b70a-4b7a-5d8d-7dab" name="New EntryLink" hidden="false" collective="false" import="true" targetId="fe00-451f-6735-6fd9" type="selectionEntry"/>
           </entryLinks>
         </selectionEntryGroup>
       </selectionEntryGroups>
       <entryLinks>
-        <entryLink id="1261-0e77-d9ab-1712" name="New EntryLink" hidden="false" collective="false" targetId="fe00-451f-6735-6fd9" type="selectionEntry">
+        <entryLink id="1261-0e77-d9ab-1712" name="New EntryLink" hidden="false" collective="false" import="true" targetId="fe00-451f-6735-6fd9" type="selectionEntry">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e41c-ef69-72e9-9fa3" type="min"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6ed7-9383-cc1a-c0d2" type="max"/>
           </constraints>
         </entryLink>
-        <entryLink id="d4b1-b761-0d35-d68c" name="Warlord" hidden="false" collective="false" targetId="33f6-60da-7b70-5fee" type="selectionEntry"/>
-        <entryLink id="664d-9ebc-02b3-bbed" name="Warlord Traits" hidden="false" collective="false" targetId="c2ce-6759-e009-8c11" type="selectionEntryGroup"/>
-        <entryLink id="9e16-58c8-9e23-4459" name="Relic Gubbinz" hidden="false" collective="false" targetId="04b0-dab2-123b-df51" type="selectionEntryGroup"/>
-        <entryLink id="89f5-a991-0d09-6e07" name="Is a Custom Character" hidden="false" collective="false" targetId="43c4-8968-c599-ad5f" type="selectionEntry"/>
-        <entryLink id="3dfe-ac69-5710-e742" name="Custom Character Selections" hidden="false" collective="false" targetId="8774-e003-4a50-56c7" type="selectionEntryGroup"/>
-        <entryLink id="1e0f-456b-20c5-c4fa" name="Stratagem: Field Commander" hidden="false" collective="false" targetId="d043-3847-e963-fb5d" type="selectionEntry">
+        <entryLink id="d4b1-b761-0d35-d68c" name="Warlord" hidden="false" collective="false" import="true" targetId="33f6-60da-7b70-5fee" type="selectionEntry"/>
+        <entryLink id="664d-9ebc-02b3-bbed" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="c2ce-6759-e009-8c11" type="selectionEntryGroup"/>
+        <entryLink id="9e16-58c8-9e23-4459" name="Relic Gubbinz" hidden="false" collective="false" import="true" targetId="04b0-dab2-123b-df51" type="selectionEntryGroup"/>
+        <entryLink id="89f5-a991-0d09-6e07" name="Is a Custom Character" hidden="false" collective="false" import="true" targetId="43c4-8968-c599-ad5f" type="selectionEntry"/>
+        <entryLink id="3dfe-ac69-5710-e742" name="Custom Character Selections" hidden="false" collective="false" import="true" targetId="8774-e003-4a50-56c7" type="selectionEntryGroup"/>
+        <entryLink id="1e0f-456b-20c5-c4fa" name="Stratagem: Field Commander" hidden="false" collective="false" import="true" targetId="d043-3847-e963-fb5d" type="selectionEntry">
           <modifiers>
             <modifier type="set" field="hidden" value="true">
               <conditions>
@@ -652,7 +648,7 @@
         <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="aa39-9f9d-0e78-2f8a" name="Warboss on Warbike (index)" hidden="false" collective="false" type="unit">
+    <selectionEntry id="aa39-9f9d-0e78-2f8a" name="Warboss on Warbike (index)" hidden="false" collective="false" import="true" type="unit">
       <profiles>
         <profile id="6a5c-967d-cd1d-83ce" name="Warboss on Warbike" hidden="false" typeId="800f-21d0-4387-c943" typeName="Unit">
           <characteristics>
@@ -683,26 +679,26 @@
         <categoryLink id="67ec-7906-cd63-9620" name="New CategoryLink" hidden="false" targetId="1c6f-0311-3eba-3180" primary="false"/>
       </categoryLinks>
       <entryLinks>
-        <entryLink id="85ab-9327-83dc-38bc" name="New EntryLink" hidden="false" collective="false" targetId="57f6-c88c-bcaa-1f50" type="selectionEntryGroup">
+        <entryLink id="85ab-9327-83dc-38bc" name="New EntryLink" hidden="false" collective="false" import="true" targetId="57f6-c88c-bcaa-1f50" type="selectionEntryGroup">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="418b-c309-10a5-8ebf" type="min"/>
           </constraints>
         </entryLink>
-        <entryLink id="cbdd-314b-7665-0800" name="New EntryLink" hidden="false" collective="false" targetId="6df7-0ee7-7e6d-b182" type="selectionEntry"/>
-        <entryLink id="0321-840b-7360-101c" name="Attack Squig" hidden="false" collective="false" targetId="63f8-210a-c55a-c4c0" type="selectionEntry"/>
-        <entryLink id="e47c-3ffb-7f28-cd9f" name="New EntryLink" hidden="false" collective="false" targetId="de10-70b3-ab64-990c" type="selectionEntry">
+        <entryLink id="cbdd-314b-7665-0800" name="New EntryLink" hidden="false" collective="false" import="true" targetId="6df7-0ee7-7e6d-b182" type="selectionEntry"/>
+        <entryLink id="0321-840b-7360-101c" name="Attack Squig" hidden="false" collective="false" import="true" targetId="63f8-210a-c55a-c4c0" type="selectionEntry"/>
+        <entryLink id="e47c-3ffb-7f28-cd9f" name="New EntryLink" hidden="false" collective="false" import="true" targetId="de10-70b3-ab64-990c" type="selectionEntry">
           <constraints>
             <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c68b-e2b9-c384-ede2" type="min"/>
             <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="172f-83ea-6138-0303" type="max"/>
           </constraints>
         </entryLink>
-        <entryLink id="8aa0-a7f3-cdd0-3d20" name="New EntryLink" hidden="false" collective="false" targetId="d117-f3ce-54e8-75ba" type="selectionEntryGroup"/>
-        <entryLink id="d2b7-0983-afc6-02ec" name="Warlord Traits" hidden="false" collective="false" targetId="c2ce-6759-e009-8c11" type="selectionEntryGroup"/>
-        <entryLink id="6fa4-cd62-6406-b23f" name="Warlord" hidden="false" collective="false" targetId="33f6-60da-7b70-5fee" type="selectionEntry"/>
-        <entryLink id="de16-1986-6692-ef8b" name="Relic Gubbinz" hidden="false" collective="false" targetId="04b0-dab2-123b-df51" type="selectionEntryGroup"/>
-        <entryLink id="1de1-3d34-4dd1-622a" name="Is a Custom Character" hidden="false" collective="false" targetId="43c4-8968-c599-ad5f" type="selectionEntry"/>
-        <entryLink id="b1de-0a6b-ed5e-1ef5" name="Custom Character Selections" hidden="false" collective="false" targetId="8774-e003-4a50-56c7" type="selectionEntryGroup"/>
-        <entryLink id="78a2-49ae-5252-bb6d" name="Stratagem: Field Commander" hidden="false" collective="false" targetId="d043-3847-e963-fb5d" type="selectionEntry">
+        <entryLink id="8aa0-a7f3-cdd0-3d20" name="New EntryLink" hidden="false" collective="false" import="true" targetId="d117-f3ce-54e8-75ba" type="selectionEntryGroup"/>
+        <entryLink id="d2b7-0983-afc6-02ec" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="c2ce-6759-e009-8c11" type="selectionEntryGroup"/>
+        <entryLink id="6fa4-cd62-6406-b23f" name="Warlord" hidden="false" collective="false" import="true" targetId="33f6-60da-7b70-5fee" type="selectionEntry"/>
+        <entryLink id="de16-1986-6692-ef8b" name="Relic Gubbinz" hidden="false" collective="false" import="true" targetId="04b0-dab2-123b-df51" type="selectionEntryGroup"/>
+        <entryLink id="1de1-3d34-4dd1-622a" name="Is a Custom Character" hidden="false" collective="false" import="true" targetId="43c4-8968-c599-ad5f" type="selectionEntry"/>
+        <entryLink id="b1de-0a6b-ed5e-1ef5" name="Custom Character Selections" hidden="false" collective="false" import="true" targetId="8774-e003-4a50-56c7" type="selectionEntryGroup"/>
+        <entryLink id="78a2-49ae-5252-bb6d" name="Stratagem: Field Commander" hidden="false" collective="false" import="true" targetId="d043-3847-e963-fb5d" type="selectionEntry">
           <modifiers>
             <modifier type="set" field="hidden" value="true">
               <conditions>
@@ -718,7 +714,7 @@
         <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="de10-70b3-ab64-990c" name="Dakkagun" hidden="false" collective="false" type="upgrade">
+    <selectionEntry id="de10-70b3-ab64-990c" name="Dakkagun" hidden="false" collective="false" import="true" type="upgrade">
       <profiles>
         <profile id="fcfb-9f9c-f800-5b9b" name="Dakkagun" hidden="false" typeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" typeName="Weapon">
           <characteristics>
@@ -737,7 +733,7 @@
         <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="4087-8bfc-973a-f88b" name="Weirdboy" hidden="false" collective="false" type="unit">
+    <selectionEntry id="4087-8bfc-973a-f88b" name="Weirdboy" hidden="false" collective="false" import="true" type="unit">
       <profiles>
         <profile id="cd5d-1200-7893-2422" name="Weirdboy" hidden="false" typeId="800f-21d0-4387-c943" typeName="Unit">
           <characteristics>
@@ -799,7 +795,7 @@
         <categoryLink id="0cd2-192a-1fab-0342" name="New CategoryLink" hidden="false" targetId="e480-8b6a-32d0-53cc" primary="false"/>
       </categoryLinks>
       <selectionEntries>
-        <selectionEntry id="3408-1c8a-d44d-d53f" name="Weirdboy Staff" hidden="false" collective="false" type="upgrade">
+        <selectionEntry id="3408-1c8a-d44d-d53f" name="Weirdboy Staff" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9e5d-2ea5-2174-df55" type="min"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3db9-d17a-2ef8-8a22" type="max"/>
@@ -822,7 +818,7 @@
             <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
           </costs>
         </selectionEntry>
-        <selectionEntry id="da96-304a-7719-5147" name="Warphead" hidden="false" collective="false" type="upgrade">
+        <selectionEntry id="da96-304a-7719-5147" name="Warphead" hidden="false" collective="false" import="true" type="upgrade">
           <profiles>
             <profile id="4e8d-6c62-411d-65e6" name="Warphead (1 CP)" hidden="false" typeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" typeName="Abilities">
               <characteristics>
@@ -838,7 +834,7 @@
         </selectionEntry>
       </selectionEntries>
       <entryLinks>
-        <entryLink id="de2a-e364-08ff-f130" name="Power of the WAAAGH!" hidden="false" collective="false" targetId="cb1c-c83b-5adb-5663" type="selectionEntryGroup">
+        <entryLink id="de2a-e364-08ff-f130" name="Power of the WAAAGH!" hidden="false" collective="false" import="true" targetId="cb1c-c83b-5adb-5663" type="selectionEntryGroup">
           <modifiers>
             <modifier type="increment" field="67e7-ee25-0d0b-ccc8" value="1">
               <repeats>
@@ -851,11 +847,11 @@
             <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d68f-c332-bf68-4fc9" type="min"/>
           </constraints>
         </entryLink>
-        <entryLink id="b429-edd0-11d9-b9d5" name="Warlord" hidden="false" collective="false" targetId="33f6-60da-7b70-5fee" type="selectionEntry"/>
-        <entryLink id="931b-47e8-2ecc-bb51" name="Warlord Traits" hidden="false" collective="false" targetId="c2ce-6759-e009-8c11" type="selectionEntryGroup"/>
-        <entryLink id="13a7-9fa9-c990-9310" name="Relic Gubbinz" hidden="false" collective="false" targetId="04b0-dab2-123b-df51" type="selectionEntryGroup"/>
-        <entryLink id="4a33-dc61-9d9a-be2d" name="Is a Custom Character" hidden="false" collective="false" targetId="43c4-8968-c599-ad5f" type="selectionEntry"/>
-        <entryLink id="8da2-6bda-c3d6-f2a7" name="Custom Character Selections" hidden="false" collective="false" targetId="8774-e003-4a50-56c7" type="selectionEntryGroup"/>
+        <entryLink id="b429-edd0-11d9-b9d5" name="Warlord" hidden="false" collective="false" import="true" targetId="33f6-60da-7b70-5fee" type="selectionEntry"/>
+        <entryLink id="931b-47e8-2ecc-bb51" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="c2ce-6759-e009-8c11" type="selectionEntryGroup"/>
+        <entryLink id="13a7-9fa9-c990-9310" name="Relic Gubbinz" hidden="false" collective="false" import="true" targetId="04b0-dab2-123b-df51" type="selectionEntryGroup"/>
+        <entryLink id="4a33-dc61-9d9a-be2d" name="Is a Custom Character" hidden="false" collective="false" import="true" targetId="43c4-8968-c599-ad5f" type="selectionEntry"/>
+        <entryLink id="8da2-6bda-c3d6-f2a7" name="Custom Character Selections" hidden="false" collective="false" import="true" targetId="8774-e003-4a50-56c7" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="points" value="62.0"/>
@@ -863,7 +859,7 @@
         <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="48c5-847b-42a3-54a9" name="Big Mek (Index)" hidden="false" collective="false" type="unit">
+    <selectionEntry id="48c5-847b-42a3-54a9" name="Big Mek (Index)" hidden="false" collective="false" import="true" type="unit">
       <profiles>
         <profile id="046a-a4d4-724b-3141" name="Big Mek" hidden="false" typeId="800f-21d0-4387-c943" typeName="Unit">
           <characteristics>
@@ -893,54 +889,54 @@
         <categoryLink id="272c-bd51-3570-a81b" name="New CategoryLink" hidden="false" targetId="3d52-fccf-10c0-3fae" primary="false"/>
       </categoryLinks>
       <selectionEntryGroups>
-        <selectionEntryGroup id="27ac-9d7b-beff-ea84" name="Slugga Arm" hidden="false" collective="false" defaultSelectionEntryId="aaa2-68b6-9ca4-a7bb">
+        <selectionEntryGroup id="27ac-9d7b-beff-ea84" name="Slugga Arm" hidden="false" collective="false" import="true" defaultSelectionEntryId="aaa2-68b6-9ca4-a7bb">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="aea4-27df-a959-e8f7" type="min"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5236-0d3c-f6e0-fdf5" type="max"/>
           </constraints>
           <entryLinks>
-            <entryLink id="aaa2-68b6-9ca4-a7bb" name="Slugga" hidden="false" collective="false" targetId="d13b-ad69-e6a2-d485" type="selectionEntry"/>
-            <entryLink id="a0a1-5d75-7822-8e0e" name="New EntryLink" hidden="false" collective="false" targetId="fe00-451f-6735-6fd9" type="selectionEntry"/>
-            <entryLink id="3e66-c9d3-f2b7-d210" name="Big Choppa" hidden="false" collective="false" targetId="0470-1b47-489b-14c9" type="selectionEntry"/>
-            <entryLink id="76d6-78ce-3e81-76db" name="New EntryLink" hidden="false" collective="false" targetId="a8c1-7fb9-7f7b-84c5" type="selectionEntry"/>
-            <entryLink id="9c8d-e1fd-84cb-04b3" name="New EntryLink" hidden="false" collective="false" targetId="3511-0070-0667-abf2" type="selectionEntry"/>
-            <entryLink id="7838-1476-9c04-bf05" name="New EntryLink" hidden="false" collective="false" targetId="b6c7-06c8-b7fb-05a7" type="selectionEntry"/>
-            <entryLink id="fbd9-72b5-cfa1-377c" name="New EntryLink" hidden="false" collective="false" targetId="6d70-25a8-b496-2457" type="selectionEntry"/>
-            <entryLink id="3bcb-9804-e5bb-47e7" name="New EntryLink" hidden="false" collective="false" targetId="bbc2-56ce-67ec-5422" type="selectionEntry"/>
-            <entryLink id="e600-5451-3003-c0f0" name="Kustom Force Field" hidden="false" collective="false" targetId="886c-c494-3fbb-e1ec" type="selectionEntry"/>
+            <entryLink id="aaa2-68b6-9ca4-a7bb" name="Slugga" hidden="false" collective="false" import="true" targetId="d13b-ad69-e6a2-d485" type="selectionEntry"/>
+            <entryLink id="a0a1-5d75-7822-8e0e" name="New EntryLink" hidden="false" collective="false" import="true" targetId="fe00-451f-6735-6fd9" type="selectionEntry"/>
+            <entryLink id="3e66-c9d3-f2b7-d210" name="Big Choppa" hidden="false" collective="false" import="true" targetId="0470-1b47-489b-14c9" type="selectionEntry"/>
+            <entryLink id="76d6-78ce-3e81-76db" name="New EntryLink" hidden="false" collective="false" import="true" targetId="a8c1-7fb9-7f7b-84c5" type="selectionEntry"/>
+            <entryLink id="9c8d-e1fd-84cb-04b3" name="New EntryLink" hidden="false" collective="false" import="true" targetId="3511-0070-0667-abf2" type="selectionEntry"/>
+            <entryLink id="7838-1476-9c04-bf05" name="New EntryLink" hidden="false" collective="false" import="true" targetId="b6c7-06c8-b7fb-05a7" type="selectionEntry"/>
+            <entryLink id="fbd9-72b5-cfa1-377c" name="New EntryLink" hidden="false" collective="false" import="true" targetId="6d70-25a8-b496-2457" type="selectionEntry"/>
+            <entryLink id="3bcb-9804-e5bb-47e7" name="New EntryLink" hidden="false" collective="false" import="true" targetId="bbc2-56ce-67ec-5422" type="selectionEntry"/>
+            <entryLink id="e600-5451-3003-c0f0" name="Kustom Force Field" hidden="false" collective="false" import="true" targetId="886c-c494-3fbb-e1ec" type="selectionEntry"/>
           </entryLinks>
         </selectionEntryGroup>
-        <selectionEntryGroup id="c280-f16e-1174-d2d3" name="Choppa Arm" hidden="false" collective="false" defaultSelectionEntryId="ddfc-3d81-7858-305d">
+        <selectionEntryGroup id="c280-f16e-1174-d2d3" name="Choppa Arm" hidden="false" collective="false" import="true" defaultSelectionEntryId="ddfc-3d81-7858-305d">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0caa-8177-8aef-73cd" type="min"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="44cb-b258-c028-32b7" type="max"/>
           </constraints>
           <entryLinks>
-            <entryLink id="ddfc-3d81-7858-305d" name="New EntryLink" hidden="false" collective="false" targetId="c4df-c43d-08a6-18ab" type="selectionEntry"/>
-            <entryLink id="46be-d8ea-480d-829b" name="Big Choppa" hidden="false" collective="false" targetId="0470-1b47-489b-14c9" type="selectionEntry"/>
-            <entryLink id="77c1-10c8-dfd4-f7e5" name="New EntryLink" hidden="false" collective="false" targetId="3511-0070-0667-abf2" type="selectionEntry"/>
-            <entryLink id="f931-e245-74ab-ca24" name="New EntryLink" hidden="false" collective="false" targetId="b6c7-06c8-b7fb-05a7" type="selectionEntry"/>
-            <entryLink id="ddf6-6a04-e48d-8dae" name="New EntryLink" hidden="false" collective="false" targetId="6d70-25a8-b496-2457" type="selectionEntry"/>
-            <entryLink id="7b8a-ef9e-02f7-175c" name="New EntryLink" hidden="false" collective="false" targetId="bbc2-56ce-67ec-5422" type="selectionEntry"/>
-            <entryLink id="1f27-9bdc-3f31-4aef" name="New EntryLink" hidden="false" collective="false" targetId="fe00-451f-6735-6fd9" type="selectionEntry"/>
-            <entryLink id="9816-90d7-dedc-23a0" name="New EntryLink" hidden="false" collective="false" targetId="a8c1-7fb9-7f7b-84c5" type="selectionEntry"/>
-            <entryLink id="0af6-df22-ef9c-47be" name="New EntryLink" hidden="false" collective="false" targetId="f15a-fc8e-65b1-e4b8" type="selectionEntry"/>
+            <entryLink id="ddfc-3d81-7858-305d" name="New EntryLink" hidden="false" collective="false" import="true" targetId="c4df-c43d-08a6-18ab" type="selectionEntry"/>
+            <entryLink id="46be-d8ea-480d-829b" name="Big Choppa" hidden="false" collective="false" import="true" targetId="0470-1b47-489b-14c9" type="selectionEntry"/>
+            <entryLink id="77c1-10c8-dfd4-f7e5" name="New EntryLink" hidden="false" collective="false" import="true" targetId="3511-0070-0667-abf2" type="selectionEntry"/>
+            <entryLink id="f931-e245-74ab-ca24" name="New EntryLink" hidden="false" collective="false" import="true" targetId="b6c7-06c8-b7fb-05a7" type="selectionEntry"/>
+            <entryLink id="ddf6-6a04-e48d-8dae" name="New EntryLink" hidden="false" collective="false" import="true" targetId="6d70-25a8-b496-2457" type="selectionEntry"/>
+            <entryLink id="7b8a-ef9e-02f7-175c" name="New EntryLink" hidden="false" collective="false" import="true" targetId="bbc2-56ce-67ec-5422" type="selectionEntry"/>
+            <entryLink id="1f27-9bdc-3f31-4aef" name="New EntryLink" hidden="false" collective="false" import="true" targetId="fe00-451f-6735-6fd9" type="selectionEntry"/>
+            <entryLink id="9816-90d7-dedc-23a0" name="New EntryLink" hidden="false" collective="false" import="true" targetId="a8c1-7fb9-7f7b-84c5" type="selectionEntry"/>
+            <entryLink id="0af6-df22-ef9c-47be" name="New EntryLink" hidden="false" collective="false" import="true" targetId="f15a-fc8e-65b1-e4b8" type="selectionEntry"/>
           </entryLinks>
         </selectionEntryGroup>
       </selectionEntryGroups>
       <entryLinks>
-        <entryLink id="a8c0-7f55-f1ff-1ae0" name="Stikkbombs" hidden="false" collective="false" targetId="6df7-0ee7-7e6d-b182" type="selectionEntry"/>
-        <entryLink id="7307-e52d-66f8-53dc" name="Grot Oiler" hidden="false" collective="false" targetId="9459-87f3-a9a1-6840" type="selectionEntry">
+        <entryLink id="a8c0-7f55-f1ff-1ae0" name="Stikkbombs" hidden="false" collective="false" import="true" targetId="6df7-0ee7-7e6d-b182" type="selectionEntry"/>
+        <entryLink id="7307-e52d-66f8-53dc" name="Grot Oiler" hidden="false" collective="false" import="true" targetId="9459-87f3-a9a1-6840" type="selectionEntry">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="facd-54e5-736e-b459" type="max"/>
           </constraints>
         </entryLink>
-        <entryLink id="7b68-cc95-980e-d273" name="Warlord Traits" hidden="false" collective="false" targetId="c2ce-6759-e009-8c11" type="selectionEntryGroup"/>
-        <entryLink id="45aa-c748-54d2-c0e9" name="Warlord" hidden="false" collective="false" targetId="33f6-60da-7b70-5fee" type="selectionEntry"/>
-        <entryLink id="4355-1d72-0d95-5457" name="Shiney Gubbinz" hidden="false" collective="false" targetId="04b0-dab2-123b-df51" type="selectionEntryGroup"/>
-        <entryLink id="1908-75ff-d559-9f22" name="Is a Custom Character" hidden="false" collective="false" targetId="43c4-8968-c599-ad5f" type="selectionEntry"/>
-        <entryLink id="cf00-2eb2-8faf-b85e" name="Custom Character Selections" hidden="false" collective="false" targetId="8774-e003-4a50-56c7" type="selectionEntryGroup"/>
-        <entryLink id="9fbb-614a-0a15-99b6" name="Stratagem: Field Commander" hidden="false" collective="false" targetId="d043-3847-e963-fb5d" type="selectionEntry">
+        <entryLink id="7b68-cc95-980e-d273" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="c2ce-6759-e009-8c11" type="selectionEntryGroup"/>
+        <entryLink id="45aa-c748-54d2-c0e9" name="Warlord" hidden="false" collective="false" import="true" targetId="33f6-60da-7b70-5fee" type="selectionEntry"/>
+        <entryLink id="4355-1d72-0d95-5457" name="Shiney Gubbinz" hidden="false" collective="false" import="true" targetId="04b0-dab2-123b-df51" type="selectionEntryGroup"/>
+        <entryLink id="1908-75ff-d559-9f22" name="Is a Custom Character" hidden="false" collective="false" import="true" targetId="43c4-8968-c599-ad5f" type="selectionEntry"/>
+        <entryLink id="cf00-2eb2-8faf-b85e" name="Custom Character Selections" hidden="false" collective="false" import="true" targetId="8774-e003-4a50-56c7" type="selectionEntryGroup"/>
+        <entryLink id="9fbb-614a-0a15-99b6" name="Stratagem: Field Commander" hidden="false" collective="false" import="true" targetId="d043-3847-e963-fb5d" type="selectionEntry">
           <modifiers>
             <modifier type="set" field="hidden" value="true">
               <conditions>
@@ -956,7 +952,7 @@
         <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="1b13-84df-f255-b206" name="Slugga" hidden="false" collective="true" type="upgrade">
+    <selectionEntry id="1b13-84df-f255-b206" name="Slugga" hidden="false" collective="true" import="true" type="upgrade">
       <infoLinks>
         <infoLink id="e303-5e44-7639-b9ac" name="New InfoLink" hidden="false" targetId="597d-56aa-73c4-88bf" type="profile"/>
       </infoLinks>
@@ -966,7 +962,7 @@
         <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="886c-c494-3fbb-e1ec" name="Kustom Force Field" hidden="false" collective="false" type="upgrade">
+    <selectionEntry id="886c-c494-3fbb-e1ec" name="Kustom Force Field" hidden="false" collective="false" import="true" type="upgrade">
       <profiles>
         <profile id="9271-866b-6baf-a9d4" name="Kustom Force Field (Big Mek)" publicationId="11b5-77b9-pubN65537" page="87" hidden="false" typeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" typeName="Abilities">
           <modifiers>
@@ -1010,7 +1006,7 @@
         <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="fe4b-833c-f74e-cce7" name="Shokk Attack Gun" hidden="false" collective="false" type="upgrade">
+    <selectionEntry id="fe4b-833c-f74e-cce7" name="Shokk Attack Gun" hidden="false" collective="false" import="true" type="upgrade">
       <profiles>
         <profile id="1253-3af2-d051-60fe" name="Shokk Attack Gun" hidden="false" typeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" typeName="Weapon">
           <characteristics>
@@ -1029,7 +1025,7 @@
         <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="c025-0c89-05db-fccb" name="Choppa" hidden="false" collective="true" type="upgrade">
+    <selectionEntry id="c025-0c89-05db-fccb" name="Choppa" hidden="false" collective="true" import="true" type="upgrade">
       <infoLinks>
         <infoLink id="7dbb-b3d1-2b94-d3b4" name="New InfoLink" hidden="false" targetId="cc0c-8f69-bf5f-ef51" type="profile"/>
       </infoLinks>
@@ -1039,7 +1035,7 @@
         <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="f15a-fc8e-65b1-e4b8" name="Killsaw" hidden="false" collective="false" type="upgrade">
+    <selectionEntry id="f15a-fc8e-65b1-e4b8" name="Killsaw" hidden="false" collective="false" import="true" type="upgrade">
       <infoLinks>
         <infoLink id="d8da-1e8c-56c6-3861" name="New InfoLink" hidden="false" targetId="4052-b8fd-68d7-3e97" type="profile"/>
       </infoLinks>
@@ -1049,7 +1045,7 @@
         <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="9459-87f3-a9a1-6840" name="Grot Oiler" hidden="false" collective="false" type="model">
+    <selectionEntry id="9459-87f3-a9a1-6840" name="Grot Oiler" hidden="false" collective="false" import="true" type="model">
       <profiles>
         <profile id="360a-c81a-576b-ae39" name="Grot Oiler" hidden="false" typeId="800f-21d0-4387-c943" typeName="Unit">
           <characteristics>
@@ -1083,7 +1079,7 @@
         <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="f517-6aa6-7d19-13c2" name="Big Mek in Mega Armour" publicationId="11b5-77b9-pubN65537" page="87" hidden="false" collective="false" type="unit">
+    <selectionEntry id="f517-6aa6-7d19-13c2" name="Big Mek in Mega Armour" publicationId="11b5-77b9-pubN65537" page="87" hidden="false" collective="false" import="true" type="unit">
       <profiles>
         <profile id="0161-7a1d-d101-2bd6" name="Big Mek in Mega Armour" hidden="false" typeId="800f-21d0-4387-c943" typeName="Unit">
           <characteristics>
@@ -1115,31 +1111,31 @@
         <categoryLink id="a4e9-697b-dac7-3e46" name="New CategoryLink" hidden="false" targetId="0f75-56ae-9b7c-afd9" primary="false"/>
       </categoryLinks>
       <selectionEntryGroups>
-        <selectionEntryGroup id="7f23-9d41-23e2-04d8" name="KMB Arm" hidden="false" collective="false" defaultSelectionEntryId="3cb1-21bc-9090-eb48">
+        <selectionEntryGroup id="7f23-9d41-23e2-04d8" name="KMB Arm" hidden="false" collective="false" import="true" defaultSelectionEntryId="3cb1-21bc-9090-eb48">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="90a6-b424-0424-92d5" type="min"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8b50-460a-7626-22c6" type="max"/>
           </constraints>
           <entryLinks>
-            <entryLink id="3abf-5508-ad44-5fa1" name="Kombi-Rokkit" hidden="false" collective="false" targetId="3511-0070-0667-abf2" type="selectionEntry"/>
-            <entryLink id="0605-edb4-c9c2-2d81" name="New EntryLink" hidden="false" collective="false" targetId="b6c7-06c8-b7fb-05a7" type="selectionEntry"/>
-            <entryLink id="3cb1-21bc-9090-eb48" name="Kustom Mega-blasta" hidden="false" collective="false" targetId="6d70-25a8-b496-2457" type="selectionEntry"/>
-            <entryLink id="0c92-4d85-5f2f-3da3" name="New EntryLink" hidden="false" collective="false" targetId="f15a-fc8e-65b1-e4b8" type="selectionEntry"/>
-            <entryLink id="f236-2298-f86e-add3" name="New EntryLink" hidden="false" collective="false" targetId="df47-a9ec-a22e-a2b6" type="selectionEntry"/>
-            <entryLink id="cf3b-8713-5f44-13f5" name="Shoota (Index)" hidden="false" collective="false" targetId="33fd-f9ce-0809-8a9b" type="selectionEntry"/>
+            <entryLink id="3abf-5508-ad44-5fa1" name="Kombi-Rokkit" hidden="false" collective="false" import="true" targetId="3511-0070-0667-abf2" type="selectionEntry"/>
+            <entryLink id="0605-edb4-c9c2-2d81" name="New EntryLink" hidden="false" collective="false" import="true" targetId="b6c7-06c8-b7fb-05a7" type="selectionEntry"/>
+            <entryLink id="3cb1-21bc-9090-eb48" name="Kustom Mega-blasta" hidden="false" collective="false" import="true" targetId="6d70-25a8-b496-2457" type="selectionEntry"/>
+            <entryLink id="0c92-4d85-5f2f-3da3" name="New EntryLink" hidden="false" collective="false" import="true" targetId="f15a-fc8e-65b1-e4b8" type="selectionEntry"/>
+            <entryLink id="f236-2298-f86e-add3" name="New EntryLink" hidden="false" collective="false" import="true" targetId="df47-a9ec-a22e-a2b6" type="selectionEntry"/>
+            <entryLink id="cf3b-8713-5f44-13f5" name="Shoota (Index)" hidden="false" collective="false" import="true" targetId="33fd-f9ce-0809-8a9b" type="selectionEntry"/>
           </entryLinks>
         </selectionEntryGroup>
-        <selectionEntryGroup id="739f-8937-bd1b-9af0" name="May Take Either" hidden="false" collective="false">
+        <selectionEntryGroup id="739f-8937-bd1b-9af0" name="May Take Either" hidden="false" collective="false" import="true">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b24a-a64d-3bb9-3ead" type="max"/>
           </constraints>
           <entryLinks>
-            <entryLink id="2c23-e80b-260a-0af2" name="Kustom Force Field" hidden="false" collective="false" targetId="886c-c494-3fbb-e1ec" type="selectionEntry">
+            <entryLink id="2c23-e80b-260a-0af2" name="Kustom Force Field" hidden="false" collective="false" import="true" targetId="886c-c494-3fbb-e1ec" type="selectionEntry">
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="102b-fecf-70fb-6dee" type="max"/>
               </constraints>
             </entryLink>
-            <entryLink id="b3e7-eeda-b441-175c" name="Tellyport Blasta" hidden="false" collective="false" targetId="4b5a-eb2a-9f60-d11d" type="selectionEntry">
+            <entryLink id="b3e7-eeda-b441-175c" name="Tellyport Blasta" hidden="false" collective="false" import="true" targetId="4b5a-eb2a-9f60-d11d" type="selectionEntry">
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="58df-953c-a678-6d08" type="max"/>
               </constraints>
@@ -1148,23 +1144,23 @@
         </selectionEntryGroup>
       </selectionEntryGroups>
       <entryLinks>
-        <entryLink id="4c0e-3f90-adca-bb79" name="Grot Oiler" hidden="false" collective="false" targetId="9459-87f3-a9a1-6840" type="selectionEntry">
+        <entryLink id="4c0e-3f90-adca-bb79" name="Grot Oiler" hidden="false" collective="false" import="true" targetId="9459-87f3-a9a1-6840" type="selectionEntry">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b76a-0663-e4aa-d6bd" type="max"/>
           </constraints>
         </entryLink>
-        <entryLink id="dade-82f2-b58f-03de" name="New EntryLink" hidden="false" collective="false" targetId="fe00-451f-6735-6fd9" type="selectionEntry">
+        <entryLink id="dade-82f2-b58f-03de" name="New EntryLink" hidden="false" collective="false" import="true" targetId="fe00-451f-6735-6fd9" type="selectionEntry">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b06c-bfe4-cde9-4b66" type="min"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c829-2ef9-be10-049e" type="max"/>
           </constraints>
         </entryLink>
-        <entryLink id="cad1-5d82-3c96-0400" name="Warlord Traits" hidden="false" collective="false" targetId="c2ce-6759-e009-8c11" type="selectionEntryGroup"/>
-        <entryLink id="dfda-d217-7058-9cf7" name="Warlord" hidden="false" collective="false" targetId="33f6-60da-7b70-5fee" type="selectionEntry"/>
-        <entryLink id="75a0-9f0b-3572-ce48" name="Relic Gubbinz" hidden="false" collective="false" targetId="04b0-dab2-123b-df51" type="selectionEntryGroup"/>
-        <entryLink id="d84c-95e7-36f7-3435" name="Is a Custom Character" hidden="false" collective="false" targetId="43c4-8968-c599-ad5f" type="selectionEntry"/>
-        <entryLink id="4725-fde3-c30a-3978" name="Custom Character Selections" hidden="false" collective="false" targetId="8774-e003-4a50-56c7" type="selectionEntryGroup"/>
-        <entryLink id="a059-edf9-d148-78f4" name="Stratagem: Field Commander" hidden="false" collective="false" targetId="d043-3847-e963-fb5d" type="selectionEntry">
+        <entryLink id="cad1-5d82-3c96-0400" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="c2ce-6759-e009-8c11" type="selectionEntryGroup"/>
+        <entryLink id="dfda-d217-7058-9cf7" name="Warlord" hidden="false" collective="false" import="true" targetId="33f6-60da-7b70-5fee" type="selectionEntry"/>
+        <entryLink id="75a0-9f0b-3572-ce48" name="Relic Gubbinz" hidden="false" collective="false" import="true" targetId="04b0-dab2-123b-df51" type="selectionEntryGroup"/>
+        <entryLink id="d84c-95e7-36f7-3435" name="Is a Custom Character" hidden="false" collective="false" import="true" targetId="43c4-8968-c599-ad5f" type="selectionEntry"/>
+        <entryLink id="4725-fde3-c30a-3978" name="Custom Character Selections" hidden="false" collective="false" import="true" targetId="8774-e003-4a50-56c7" type="selectionEntryGroup"/>
+        <entryLink id="a059-edf9-d148-78f4" name="Stratagem: Field Commander" hidden="false" collective="false" import="true" targetId="d043-3847-e963-fb5d" type="selectionEntry">
           <modifiers>
             <modifier type="set" field="hidden" value="true">
               <conditions>
@@ -1180,7 +1176,7 @@
         <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="4b5a-eb2a-9f60-d11d" name="Tellyport Blasta" hidden="false" collective="false" type="upgrade">
+    <selectionEntry id="4b5a-eb2a-9f60-d11d" name="Tellyport Blasta" hidden="false" collective="false" import="true" type="upgrade">
       <profiles>
         <profile id="8ec8-281c-8e68-cc52" name="Tellyport Blasta" hidden="false" typeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" typeName="Weapon">
           <characteristics>
@@ -1199,7 +1195,7 @@
         <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="1387-57d0-6d81-dbcb" name="Big Mek on Warbike (Index)" hidden="false" collective="false" type="unit">
+    <selectionEntry id="1387-57d0-6d81-dbcb" name="Big Mek on Warbike (Index)" hidden="false" collective="false" import="true" type="unit">
       <profiles>
         <profile id="9a66-28d9-c157-edc5" name="Big Mek on Bike" hidden="false" typeId="800f-21d0-4387-c943" typeName="Unit">
           <characteristics>
@@ -1229,56 +1225,56 @@
         <categoryLink id="6d8c-22fe-1aa1-6e04" name="New CategoryLink" hidden="false" targetId="1c6f-0311-3eba-3180" primary="false"/>
       </categoryLinks>
       <selectionEntryGroups>
-        <selectionEntryGroup id="e33d-38c9-cbe6-ed4f" name="Slugga Arm" hidden="false" collective="false" defaultSelectionEntryId="be57-2a8d-616c-7ed9">
+        <selectionEntryGroup id="e33d-38c9-cbe6-ed4f" name="Slugga Arm" hidden="false" collective="false" import="true" defaultSelectionEntryId="be57-2a8d-616c-7ed9">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="851c-7c94-164c-6bcf" type="min"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6c78-fa8b-0754-346d" type="max"/>
           </constraints>
           <entryLinks>
-            <entryLink id="be57-2a8d-616c-7ed9" name="New EntryLink" hidden="false" collective="false" targetId="d13b-ad69-e6a2-d485" type="selectionEntry"/>
-            <entryLink id="eff1-8889-051c-1d0b" name="New EntryLink" hidden="false" collective="false" targetId="fe00-451f-6735-6fd9" type="selectionEntry"/>
-            <entryLink id="82b3-b3d6-90d2-bfa1" name="Big Choppa" hidden="false" collective="false" targetId="0470-1b47-489b-14c9" type="selectionEntry"/>
-            <entryLink id="4459-ab8f-6b85-eb98" name="New EntryLink" hidden="false" collective="false" targetId="a8c1-7fb9-7f7b-84c5" type="selectionEntry"/>
-            <entryLink id="4b00-30c2-f1f8-adc9" name="New EntryLink" hidden="false" collective="false" targetId="3511-0070-0667-abf2" type="selectionEntry"/>
-            <entryLink id="58d0-a759-9401-5f8c" name="New EntryLink" hidden="false" collective="false" targetId="b6c7-06c8-b7fb-05a7" type="selectionEntry"/>
-            <entryLink id="6144-1986-a610-1af0" name="New EntryLink" hidden="false" collective="false" targetId="6d70-25a8-b496-2457" type="selectionEntry"/>
-            <entryLink id="461b-1abe-8924-883e" name="New EntryLink" hidden="false" collective="false" targetId="bbc2-56ce-67ec-5422" type="selectionEntry"/>
-            <entryLink id="32db-e3cc-a93f-ba54" name="New EntryLink" hidden="false" collective="false" targetId="886c-c494-3fbb-e1ec" type="selectionEntry"/>
-            <entryLink id="1f1b-fc97-1d8f-dff5" name="Shokk Attack Gun" hidden="false" collective="false" targetId="fe4b-833c-f74e-cce7" type="selectionEntry"/>
+            <entryLink id="be57-2a8d-616c-7ed9" name="New EntryLink" hidden="false" collective="false" import="true" targetId="d13b-ad69-e6a2-d485" type="selectionEntry"/>
+            <entryLink id="eff1-8889-051c-1d0b" name="New EntryLink" hidden="false" collective="false" import="true" targetId="fe00-451f-6735-6fd9" type="selectionEntry"/>
+            <entryLink id="82b3-b3d6-90d2-bfa1" name="Big Choppa" hidden="false" collective="false" import="true" targetId="0470-1b47-489b-14c9" type="selectionEntry"/>
+            <entryLink id="4459-ab8f-6b85-eb98" name="New EntryLink" hidden="false" collective="false" import="true" targetId="a8c1-7fb9-7f7b-84c5" type="selectionEntry"/>
+            <entryLink id="4b00-30c2-f1f8-adc9" name="New EntryLink" hidden="false" collective="false" import="true" targetId="3511-0070-0667-abf2" type="selectionEntry"/>
+            <entryLink id="58d0-a759-9401-5f8c" name="New EntryLink" hidden="false" collective="false" import="true" targetId="b6c7-06c8-b7fb-05a7" type="selectionEntry"/>
+            <entryLink id="6144-1986-a610-1af0" name="New EntryLink" hidden="false" collective="false" import="true" targetId="6d70-25a8-b496-2457" type="selectionEntry"/>
+            <entryLink id="461b-1abe-8924-883e" name="New EntryLink" hidden="false" collective="false" import="true" targetId="bbc2-56ce-67ec-5422" type="selectionEntry"/>
+            <entryLink id="32db-e3cc-a93f-ba54" name="New EntryLink" hidden="false" collective="false" import="true" targetId="886c-c494-3fbb-e1ec" type="selectionEntry"/>
+            <entryLink id="1f1b-fc97-1d8f-dff5" name="Shokk Attack Gun" hidden="false" collective="false" import="true" targetId="fe4b-833c-f74e-cce7" type="selectionEntry"/>
           </entryLinks>
         </selectionEntryGroup>
-        <selectionEntryGroup id="404e-5f74-6f84-adbe" name="Choppa Arm" hidden="false" collective="false" defaultSelectionEntryId="0077-9340-8a0e-efcf">
+        <selectionEntryGroup id="404e-5f74-6f84-adbe" name="Choppa Arm" hidden="false" collective="false" import="true" defaultSelectionEntryId="0077-9340-8a0e-efcf">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9730-17d3-0b80-db5e" type="min"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4224-b8f5-089a-aef8" type="max"/>
           </constraints>
           <entryLinks>
-            <entryLink id="0077-9340-8a0e-efcf" name="New EntryLink" hidden="false" collective="false" targetId="c4df-c43d-08a6-18ab" type="selectionEntry"/>
-            <entryLink id="f933-9633-cd6e-4d73" name="Big Choppa" hidden="false" collective="false" targetId="0470-1b47-489b-14c9" type="selectionEntry"/>
-            <entryLink id="b709-4403-aa3c-2f1e" name="New EntryLink" hidden="false" collective="false" targetId="3511-0070-0667-abf2" type="selectionEntry"/>
-            <entryLink id="a844-d8bc-9315-57e1" name="New EntryLink" hidden="false" collective="false" targetId="b6c7-06c8-b7fb-05a7" type="selectionEntry"/>
-            <entryLink id="c9a2-c3d9-1b69-fbe7" name="New EntryLink" hidden="false" collective="false" targetId="6d70-25a8-b496-2457" type="selectionEntry"/>
-            <entryLink id="6411-2ebf-4043-f1dd" name="New EntryLink" hidden="false" collective="false" targetId="bbc2-56ce-67ec-5422" type="selectionEntry"/>
-            <entryLink id="9365-8678-abce-0585" name="New EntryLink" hidden="false" collective="false" targetId="fe00-451f-6735-6fd9" type="selectionEntry"/>
-            <entryLink id="3de1-c22d-6bb2-05ee" name="New EntryLink" hidden="false" collective="false" targetId="a8c1-7fb9-7f7b-84c5" type="selectionEntry"/>
-            <entryLink id="059b-73c7-f70e-af29" name="New EntryLink" hidden="false" collective="false" targetId="f15a-fc8e-65b1-e4b8" type="selectionEntry"/>
+            <entryLink id="0077-9340-8a0e-efcf" name="New EntryLink" hidden="false" collective="false" import="true" targetId="c4df-c43d-08a6-18ab" type="selectionEntry"/>
+            <entryLink id="f933-9633-cd6e-4d73" name="Big Choppa" hidden="false" collective="false" import="true" targetId="0470-1b47-489b-14c9" type="selectionEntry"/>
+            <entryLink id="b709-4403-aa3c-2f1e" name="New EntryLink" hidden="false" collective="false" import="true" targetId="3511-0070-0667-abf2" type="selectionEntry"/>
+            <entryLink id="a844-d8bc-9315-57e1" name="New EntryLink" hidden="false" collective="false" import="true" targetId="b6c7-06c8-b7fb-05a7" type="selectionEntry"/>
+            <entryLink id="c9a2-c3d9-1b69-fbe7" name="New EntryLink" hidden="false" collective="false" import="true" targetId="6d70-25a8-b496-2457" type="selectionEntry"/>
+            <entryLink id="6411-2ebf-4043-f1dd" name="New EntryLink" hidden="false" collective="false" import="true" targetId="bbc2-56ce-67ec-5422" type="selectionEntry"/>
+            <entryLink id="9365-8678-abce-0585" name="New EntryLink" hidden="false" collective="false" import="true" targetId="fe00-451f-6735-6fd9" type="selectionEntry"/>
+            <entryLink id="3de1-c22d-6bb2-05ee" name="New EntryLink" hidden="false" collective="false" import="true" targetId="a8c1-7fb9-7f7b-84c5" type="selectionEntry"/>
+            <entryLink id="059b-73c7-f70e-af29" name="New EntryLink" hidden="false" collective="false" import="true" targetId="f15a-fc8e-65b1-e4b8" type="selectionEntry"/>
           </entryLinks>
         </selectionEntryGroup>
       </selectionEntryGroups>
       <entryLinks>
-        <entryLink id="cc55-03d4-5b04-bc7b" name="New EntryLink" hidden="false" collective="false" targetId="6df7-0ee7-7e6d-b182" type="selectionEntry"/>
-        <entryLink id="0e45-0b00-3066-cc8a" name="New EntryLink" hidden="false" collective="false" targetId="de10-70b3-ab64-990c" type="selectionEntry">
+        <entryLink id="cc55-03d4-5b04-bc7b" name="New EntryLink" hidden="false" collective="false" import="true" targetId="6df7-0ee7-7e6d-b182" type="selectionEntry"/>
+        <entryLink id="0e45-0b00-3066-cc8a" name="New EntryLink" hidden="false" collective="false" import="true" targetId="de10-70b3-ab64-990c" type="selectionEntry">
           <constraints>
             <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e9ff-9be3-ab62-a30a" type="min"/>
             <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3fc8-d5ed-35b7-64d7" type="max"/>
           </constraints>
         </entryLink>
-        <entryLink id="a910-f814-5210-388e" name="Warlord Traits" hidden="false" collective="false" targetId="c2ce-6759-e009-8c11" type="selectionEntryGroup"/>
-        <entryLink id="7de7-b272-0d8c-b860" name="Warlord" hidden="false" collective="false" targetId="33f6-60da-7b70-5fee" type="selectionEntry"/>
-        <entryLink id="ea72-2388-9ce3-b27f" name="Relic Gubbinz" hidden="false" collective="false" targetId="04b0-dab2-123b-df51" type="selectionEntryGroup"/>
-        <entryLink id="825c-f952-db78-8945" name="Is a Custom Character" hidden="false" collective="false" targetId="43c4-8968-c599-ad5f" type="selectionEntry"/>
-        <entryLink id="0c8e-91e5-d3f9-4bf6" name="Custom Character Selections" hidden="false" collective="false" targetId="8774-e003-4a50-56c7" type="selectionEntryGroup"/>
-        <entryLink id="e7f7-e498-bc2d-f908" name="Stratagem: Field Commander" hidden="false" collective="false" targetId="d043-3847-e963-fb5d" type="selectionEntry">
+        <entryLink id="a910-f814-5210-388e" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="c2ce-6759-e009-8c11" type="selectionEntryGroup"/>
+        <entryLink id="7de7-b272-0d8c-b860" name="Warlord" hidden="false" collective="false" import="true" targetId="33f6-60da-7b70-5fee" type="selectionEntry"/>
+        <entryLink id="ea72-2388-9ce3-b27f" name="Relic Gubbinz" hidden="false" collective="false" import="true" targetId="04b0-dab2-123b-df51" type="selectionEntryGroup"/>
+        <entryLink id="825c-f952-db78-8945" name="Is a Custom Character" hidden="false" collective="false" import="true" targetId="43c4-8968-c599-ad5f" type="selectionEntry"/>
+        <entryLink id="0c8e-91e5-d3f9-4bf6" name="Custom Character Selections" hidden="false" collective="false" import="true" targetId="8774-e003-4a50-56c7" type="selectionEntryGroup"/>
+        <entryLink id="e7f7-e498-bc2d-f908" name="Stratagem: Field Commander" hidden="false" collective="false" import="true" targetId="d043-3847-e963-fb5d" type="selectionEntry">
           <modifiers>
             <modifier type="set" field="hidden" value="true">
               <conditions>
@@ -1294,7 +1290,7 @@
         <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="a267-1463-18ed-c330" name="Boss Snikrot" hidden="false" collective="false" type="unit">
+    <selectionEntry id="a267-1463-18ed-c330" name="Boss Snikrot" hidden="false" collective="false" import="true" type="unit">
       <modifiers>
         <modifier type="set" field="hidden" value="true">
           <conditionGroups>
@@ -1370,7 +1366,7 @@
         <categoryLink id="b376-ba63-9f4f-1a29" name="New CategoryLink" hidden="false" targetId="690d-100a-7666-c71c" primary="false"/>
       </categoryLinks>
       <selectionEntries>
-        <selectionEntry id="8068-b9eb-85c6-e1dd" name="Mork&apos;s Teeth" hidden="false" collective="false" type="upgrade">
+        <selectionEntry id="8068-b9eb-85c6-e1dd" name="Mork&apos;s Teeth" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8886-87e6-d376-7b63" type="min"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6a97-4b50-5626-411a" type="max"/>
@@ -1395,8 +1391,8 @@
         </selectionEntry>
       </selectionEntries>
       <entryLinks>
-        <entryLink id="1fad-12dc-5665-cd0c" name="Stikkbombs" hidden="false" collective="false" targetId="6df7-0ee7-7e6d-b182" type="selectionEntry"/>
-        <entryLink id="b215-131c-5719-f656" name="Warlord" hidden="false" collective="false" targetId="33f6-60da-7b70-5fee" type="selectionEntry"/>
+        <entryLink id="1fad-12dc-5665-cd0c" name="Stikkbombs" hidden="false" collective="false" import="true" targetId="6df7-0ee7-7e6d-b182" type="selectionEntry"/>
+        <entryLink id="b215-131c-5719-f656" name="Warlord" hidden="false" collective="false" import="true" targetId="33f6-60da-7b70-5fee" type="selectionEntry"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="points" value="70.0"/>
@@ -1404,7 +1400,7 @@
         <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="3a83-48ec-8a34-1471" name="Mek" hidden="false" collective="false" type="unit">
+    <selectionEntry id="3a83-48ec-8a34-1471" name="Mek" hidden="false" collective="false" import="true" type="unit">
       <profiles>
         <profile id="5046-1e4f-ec19-eeae" name="Mek" hidden="false" typeId="800f-21d0-4387-c943" typeName="Unit">
           <characteristics>
@@ -1435,43 +1431,43 @@
         <categoryLink id="f6b3-e252-f714-81eb" name="New CategoryLink" hidden="false" targetId="2910-1e3f-5c73-48c4" primary="false"/>
       </categoryLinks>
       <selectionEntryGroups>
-        <selectionEntryGroup id="bf5e-072f-dcd8-0cb3" name="Gun Arm" hidden="false" collective="false" defaultSelectionEntryId="7ea7-48c8-2344-e5e7">
+        <selectionEntryGroup id="bf5e-072f-dcd8-0cb3" name="Gun Arm" hidden="false" collective="false" import="true" defaultSelectionEntryId="7ea7-48c8-2344-e5e7">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="af82-4362-180e-7fa9" type="min"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a832-5677-a849-3584" type="max"/>
           </constraints>
           <entryLinks>
-            <entryLink id="dffa-b637-bde1-9682" name="Slugga (Index)" hidden="false" collective="false" targetId="b618-ec7e-d5cd-56ad" type="selectionEntry"/>
-            <entryLink id="0138-1f05-1684-ed30" name="Rokkit Launcha (Index)" hidden="false" collective="false" targetId="5fbe-d76c-183e-3413" type="selectionEntry"/>
-            <entryLink id="973e-a80b-f0db-e961" name="Kombi-Rokkit (Index)" hidden="false" collective="false" targetId="b427-a07f-0027-e062" type="selectionEntry"/>
-            <entryLink id="eb28-5e34-62e6-83e9" name="Kombi-Skorcha (Index)" hidden="false" collective="false" targetId="bb1b-00f0-1da0-824c" type="selectionEntry"/>
-            <entryLink id="e5fa-ddc1-6c9c-ccfb" name="Kustom Mega-blasta (Index)" hidden="false" collective="false" targetId="4cb0-1ccc-7926-6c37" type="selectionEntry"/>
-            <entryLink id="7ea7-48c8-2344-e5e7" name="Kustom Mega-Slugga" hidden="false" collective="false" targetId="bbc2-56ce-67ec-5422" type="selectionEntry"/>
+            <entryLink id="dffa-b637-bde1-9682" name="Slugga (Index)" hidden="false" collective="false" import="true" targetId="b618-ec7e-d5cd-56ad" type="selectionEntry"/>
+            <entryLink id="0138-1f05-1684-ed30" name="Rokkit Launcha (Index)" hidden="false" collective="false" import="true" targetId="5fbe-d76c-183e-3413" type="selectionEntry"/>
+            <entryLink id="973e-a80b-f0db-e961" name="Kombi-Rokkit (Index)" hidden="false" collective="false" import="true" targetId="b427-a07f-0027-e062" type="selectionEntry"/>
+            <entryLink id="eb28-5e34-62e6-83e9" name="Kombi-Skorcha (Index)" hidden="false" collective="false" import="true" targetId="bb1b-00f0-1da0-824c" type="selectionEntry"/>
+            <entryLink id="e5fa-ddc1-6c9c-ccfb" name="Kustom Mega-blasta (Index)" hidden="false" collective="false" import="true" targetId="4cb0-1ccc-7926-6c37" type="selectionEntry"/>
+            <entryLink id="7ea7-48c8-2344-e5e7" name="Kustom Mega-Slugga" hidden="false" collective="false" import="true" targetId="bbc2-56ce-67ec-5422" type="selectionEntry"/>
           </entryLinks>
         </selectionEntryGroup>
-        <selectionEntryGroup id="d2b3-7769-0d34-5965" name="Choppa Arm" hidden="false" collective="false" defaultSelectionEntryId="2170-de53-a1c1-4319">
+        <selectionEntryGroup id="d2b3-7769-0d34-5965" name="Choppa Arm" hidden="false" collective="false" import="true" defaultSelectionEntryId="2170-de53-a1c1-4319">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8f3b-7cc0-7cdd-f77f" type="min"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2933-513d-5450-adae" type="max"/>
           </constraints>
           <entryLinks>
-            <entryLink id="2170-de53-a1c1-4319" name="New EntryLink" hidden="false" collective="false" targetId="c4df-c43d-08a6-18ab" type="selectionEntry"/>
-            <entryLink id="d675-3bee-7b05-780e" name="Killsaw" hidden="false" collective="false" targetId="f15a-fc8e-65b1-e4b8" type="selectionEntry"/>
+            <entryLink id="2170-de53-a1c1-4319" name="New EntryLink" hidden="false" collective="false" import="true" targetId="c4df-c43d-08a6-18ab" type="selectionEntry"/>
+            <entryLink id="d675-3bee-7b05-780e" name="Killsaw" hidden="false" collective="false" import="true" targetId="f15a-fc8e-65b1-e4b8" type="selectionEntry"/>
           </entryLinks>
         </selectionEntryGroup>
       </selectionEntryGroups>
       <entryLinks>
-        <entryLink id="08df-abea-b5ad-1825" name="New EntryLink" hidden="false" collective="false" targetId="6df7-0ee7-7e6d-b182" type="selectionEntry"/>
-        <entryLink id="6247-bec1-1b52-30db" name="Grot Oiler" hidden="false" collective="false" targetId="9459-87f3-a9a1-6840" type="selectionEntry">
+        <entryLink id="08df-abea-b5ad-1825" name="New EntryLink" hidden="false" collective="false" import="true" targetId="6df7-0ee7-7e6d-b182" type="selectionEntry"/>
+        <entryLink id="6247-bec1-1b52-30db" name="Grot Oiler" hidden="false" collective="false" import="true" targetId="9459-87f3-a9a1-6840" type="selectionEntry">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e92f-8ae7-c780-036d" type="max"/>
           </constraints>
         </entryLink>
-        <entryLink id="e70b-a4ed-ee22-e5f1" name="Warlord Traits" hidden="false" collective="false" targetId="c2ce-6759-e009-8c11" type="selectionEntryGroup"/>
-        <entryLink id="ccc9-fd25-0714-9cc2" name="Warlord" hidden="false" collective="false" targetId="33f6-60da-7b70-5fee" type="selectionEntry"/>
-        <entryLink id="1926-58f2-4450-d3b6" name="Shiney Gubbinz" hidden="false" collective="false" targetId="04b0-dab2-123b-df51" type="selectionEntryGroup"/>
-        <entryLink id="d9a5-8a24-12a5-ea5b" name="Is a Custom Character" hidden="false" collective="false" targetId="43c4-8968-c599-ad5f" type="selectionEntry"/>
-        <entryLink id="ef83-72c9-5f76-cb2f" name="Custom Character Selections" hidden="false" collective="false" targetId="8774-e003-4a50-56c7" type="selectionEntryGroup"/>
+        <entryLink id="e70b-a4ed-ee22-e5f1" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="c2ce-6759-e009-8c11" type="selectionEntryGroup"/>
+        <entryLink id="ccc9-fd25-0714-9cc2" name="Warlord" hidden="false" collective="false" import="true" targetId="33f6-60da-7b70-5fee" type="selectionEntry"/>
+        <entryLink id="1926-58f2-4450-d3b6" name="Shiney Gubbinz" hidden="false" collective="false" import="true" targetId="04b0-dab2-123b-df51" type="selectionEntryGroup"/>
+        <entryLink id="d9a5-8a24-12a5-ea5b" name="Is a Custom Character" hidden="false" collective="false" import="true" targetId="43c4-8968-c599-ad5f" type="selectionEntry"/>
+        <entryLink id="ef83-72c9-5f76-cb2f" name="Custom Character Selections" hidden="false" collective="false" import="true" targetId="8774-e003-4a50-56c7" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="points" value="22.0"/>
@@ -1479,7 +1475,7 @@
         <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="2112-88e2-79ed-88b8" name="&apos;Urty Syringe" hidden="false" collective="false" type="upgrade">
+    <selectionEntry id="2112-88e2-79ed-88b8" name="&apos;Urty Syringe" hidden="false" collective="false" import="true" type="upgrade">
       <profiles>
         <profile id="000f-9b2e-7bf9-593c" name="&apos;Urty Syringe" hidden="false" typeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" typeName="Weapon">
           <characteristics>
@@ -1498,7 +1494,7 @@
         <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="1228-3bad-65e7-7add" name="Grot Orderly (Index)" hidden="false" collective="false" type="model">
+    <selectionEntry id="1228-3bad-65e7-7add" name="Grot Orderly (Index)" hidden="false" collective="false" import="true" type="model">
       <profiles>
         <profile id="58bf-16d1-51f5-cee6" name="Grot Orderly" hidden="false" typeId="800f-21d0-4387-c943" typeName="Unit">
           <characteristics>
@@ -1532,7 +1528,7 @@
         <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="f654-3f0e-3775-807c" name="Painboy" hidden="false" collective="false" type="unit">
+    <selectionEntry id="f654-3f0e-3775-807c" name="Painboy" hidden="false" collective="false" import="true" type="unit">
       <profiles>
         <profile id="bc89-9a26-23d5-1e98" name="Painboy" hidden="false" typeId="800f-21d0-4387-c943" typeName="Unit">
           <characteristics>
@@ -1573,38 +1569,38 @@
         <categoryLink id="4ecc-7dad-e11a-a22e" name="New CategoryLink" hidden="false" targetId="7fa5-fda7-c9a6-5f51" primary="false"/>
       </categoryLinks>
       <selectionEntryGroups>
-        <selectionEntryGroup id="817a-ba68-ec47-61c4" name="Klaw Arm" hidden="false" collective="false" defaultSelectionEntryId="afad-66f3-e622-925f">
+        <selectionEntryGroup id="817a-ba68-ec47-61c4" name="Klaw Arm" hidden="false" collective="false" import="true" defaultSelectionEntryId="afad-66f3-e622-925f">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9968-f6d0-ecb3-90e2" type="min"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="53f8-08a9-5f40-0b7c" type="max"/>
           </constraints>
           <entryLinks>
-            <entryLink id="d657-b953-bc1e-973a" name="Killsaw" hidden="false" collective="false" targetId="f15a-fc8e-65b1-e4b8" type="selectionEntry">
+            <entryLink id="d657-b953-bc1e-973a" name="Killsaw" hidden="false" collective="false" import="true" targetId="f15a-fc8e-65b1-e4b8" type="selectionEntry">
               <modifiers>
                 <modifier type="set" field="name" value="Killsaw (Index)"/>
               </modifiers>
             </entryLink>
-            <entryLink id="afad-66f3-e622-925f" name="Power Klaw" hidden="false" collective="false" targetId="fe00-451f-6735-6fd9" type="selectionEntry"/>
+            <entryLink id="afad-66f3-e622-925f" name="Power Klaw" hidden="false" collective="false" import="true" targetId="fe00-451f-6735-6fd9" type="selectionEntry"/>
           </entryLinks>
         </selectionEntryGroup>
       </selectionEntryGroups>
       <entryLinks>
-        <entryLink id="5970-b0a2-e387-7824" name="Grot Orderly (Index)" hidden="false" collective="false" targetId="1228-3bad-65e7-7add" type="selectionEntry">
+        <entryLink id="5970-b0a2-e387-7824" name="Grot Orderly (Index)" hidden="false" collective="false" import="true" targetId="1228-3bad-65e7-7add" type="selectionEntry">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8a87-75d4-4716-b576" type="max"/>
           </constraints>
         </entryLink>
-        <entryLink id="5d19-6671-c7bf-1754" name="&apos;Urty Syringe" hidden="false" collective="false" targetId="2112-88e2-79ed-88b8" type="selectionEntry">
+        <entryLink id="5d19-6671-c7bf-1754" name="&apos;Urty Syringe" hidden="false" collective="false" import="true" targetId="2112-88e2-79ed-88b8" type="selectionEntry">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4c40-204c-b755-e35c" type="min"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="471c-a925-e28c-446e" type="max"/>
           </constraints>
         </entryLink>
-        <entryLink id="fc95-5c63-0d64-307c" name="Warlord Traits" hidden="false" collective="false" targetId="c2ce-6759-e009-8c11" type="selectionEntryGroup"/>
-        <entryLink id="1234-e26a-3837-a0ea" name="Warlord" hidden="false" collective="false" targetId="33f6-60da-7b70-5fee" type="selectionEntry"/>
-        <entryLink id="943b-b032-4837-c04f" name="Relic Gubbinz" hidden="false" collective="false" targetId="04b0-dab2-123b-df51" type="selectionEntryGroup"/>
-        <entryLink id="5a40-41c3-ea8b-695d" name="Is a Custom Character" hidden="false" collective="false" targetId="43c4-8968-c599-ad5f" type="selectionEntry"/>
-        <entryLink id="7dc7-e2a2-ad81-bae0" name="Custom Character Selections" hidden="false" collective="false" targetId="8774-e003-4a50-56c7" type="selectionEntryGroup"/>
+        <entryLink id="fc95-5c63-0d64-307c" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="c2ce-6759-e009-8c11" type="selectionEntryGroup"/>
+        <entryLink id="1234-e26a-3837-a0ea" name="Warlord" hidden="false" collective="false" import="true" targetId="33f6-60da-7b70-5fee" type="selectionEntry"/>
+        <entryLink id="943b-b032-4837-c04f" name="Relic Gubbinz" hidden="false" collective="false" import="true" targetId="04b0-dab2-123b-df51" type="selectionEntryGroup"/>
+        <entryLink id="5a40-41c3-ea8b-695d" name="Is a Custom Character" hidden="false" collective="false" import="true" targetId="43c4-8968-c599-ad5f" type="selectionEntry"/>
+        <entryLink id="7dc7-e2a2-ad81-bae0" name="Custom Character Selections" hidden="false" collective="false" import="true" targetId="8774-e003-4a50-56c7" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="points" value="52.0"/>
@@ -1612,7 +1608,7 @@
         <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="6f08-a7c2-fdc2-9565" name="Painboy on Warbike (Index)" hidden="false" collective="false" type="unit">
+    <selectionEntry id="6f08-a7c2-fdc2-9565" name="Painboy on Warbike (Index)" hidden="false" collective="false" import="true" type="unit">
       <profiles>
         <profile id="dd95-a4dc-95fd-6c7e" name="Painboy on Warbike" hidden="false" typeId="800f-21d0-4387-c943" typeName="Unit">
           <characteristics>
@@ -1642,35 +1638,35 @@
         <categoryLink id="e6ab-fac7-f3d9-8d0d" name="New CategoryLink" hidden="false" targetId="7fa5-fda7-c9a6-5f51" primary="false"/>
       </categoryLinks>
       <selectionEntryGroups>
-        <selectionEntryGroup id="3313-0c23-0fb0-9ae9" name="Klaw Arm" hidden="false" collective="false" defaultSelectionEntryId="b843-d41a-e45e-dd95">
+        <selectionEntryGroup id="3313-0c23-0fb0-9ae9" name="Klaw Arm" hidden="false" collective="false" import="true" defaultSelectionEntryId="b843-d41a-e45e-dd95">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8b4b-dda5-dea4-ab78" type="min"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="be02-d9d5-dd43-1a14" type="max"/>
           </constraints>
           <entryLinks>
-            <entryLink id="b948-6c41-2885-60d1" name="New EntryLink" hidden="false" collective="false" targetId="f15a-fc8e-65b1-e4b8" type="selectionEntry"/>
-            <entryLink id="b843-d41a-e45e-dd95" name="New EntryLink" hidden="false" collective="false" targetId="fe00-451f-6735-6fd9" type="selectionEntry"/>
+            <entryLink id="b948-6c41-2885-60d1" name="New EntryLink" hidden="false" collective="false" import="true" targetId="f15a-fc8e-65b1-e4b8" type="selectionEntry"/>
+            <entryLink id="b843-d41a-e45e-dd95" name="New EntryLink" hidden="false" collective="false" import="true" targetId="fe00-451f-6735-6fd9" type="selectionEntry"/>
           </entryLinks>
         </selectionEntryGroup>
       </selectionEntryGroups>
       <entryLinks>
-        <entryLink id="82a4-f144-d948-d747" name="&apos;Urty Syringe" hidden="false" collective="false" targetId="2112-88e2-79ed-88b8" type="selectionEntry">
+        <entryLink id="82a4-f144-d948-d747" name="&apos;Urty Syringe" hidden="false" collective="false" import="true" targetId="2112-88e2-79ed-88b8" type="selectionEntry">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4ee1-363b-8f8b-f006" type="min"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a9e2-c2a3-12b3-83cc" type="max"/>
           </constraints>
         </entryLink>
-        <entryLink id="6a62-28c1-7174-ad93" name="New EntryLink" hidden="false" collective="false" targetId="de10-70b3-ab64-990c" type="selectionEntry">
+        <entryLink id="6a62-28c1-7174-ad93" name="New EntryLink" hidden="false" collective="false" import="true" targetId="de10-70b3-ab64-990c" type="selectionEntry">
           <constraints>
             <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="10cf-f5a4-4b47-e7ce" type="min"/>
             <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6090-b18a-e883-a199" type="max"/>
           </constraints>
         </entryLink>
-        <entryLink id="d172-089c-9dcf-808c" name="Warlord Traits" hidden="false" collective="false" targetId="c2ce-6759-e009-8c11" type="selectionEntryGroup"/>
-        <entryLink id="13bb-c362-d9cc-d402" name="Warlord" hidden="false" collective="false" targetId="33f6-60da-7b70-5fee" type="selectionEntry"/>
-        <entryLink id="ff73-6d77-700b-84ad" name="Relic Gubbinz" hidden="false" collective="false" targetId="04b0-dab2-123b-df51" type="selectionEntryGroup"/>
-        <entryLink id="cda0-6dc2-0893-93e6" name="Is a Custom Character" hidden="false" collective="false" targetId="43c4-8968-c599-ad5f" type="selectionEntry"/>
-        <entryLink id="71a6-e1a6-0b3a-17b9" name="Custom Character Selections" hidden="false" collective="false" targetId="8774-e003-4a50-56c7" type="selectionEntryGroup"/>
+        <entryLink id="d172-089c-9dcf-808c" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="c2ce-6759-e009-8c11" type="selectionEntryGroup"/>
+        <entryLink id="13bb-c362-d9cc-d402" name="Warlord" hidden="false" collective="false" import="true" targetId="33f6-60da-7b70-5fee" type="selectionEntry"/>
+        <entryLink id="ff73-6d77-700b-84ad" name="Relic Gubbinz" hidden="false" collective="false" import="true" targetId="04b0-dab2-123b-df51" type="selectionEntryGroup"/>
+        <entryLink id="cda0-6dc2-0893-93e6" name="Is a Custom Character" hidden="false" collective="false" import="true" targetId="43c4-8968-c599-ad5f" type="selectionEntry"/>
+        <entryLink id="71a6-e1a6-0b3a-17b9" name="Custom Character Selections" hidden="false" collective="false" import="true" targetId="8774-e003-4a50-56c7" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="points" value="90.0"/>
@@ -1678,7 +1674,7 @@
         <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="06ff-697d-8aa1-2dd0" name="Ghazghkull Thraka" publicationId="11b5-77b9-pubN65537" page="84" hidden="false" collective="false" type="unit">
+    <selectionEntry id="06ff-697d-8aa1-2dd0" name="Ghazghkull Thraka" publicationId="11b5-77b9-pubN65537" page="84" hidden="false" collective="false" import="true" type="unit">
       <modifiers>
         <modifier type="set" field="hidden" value="true">
           <conditionGroups>
@@ -1749,7 +1745,7 @@
         <categoryLink id="e03d-65f0-eea8-9406" name="Faction: Goff" hidden="false" targetId="ec81-3194-7f8e-d2d1" primary="false"/>
       </categoryLinks>
       <selectionEntries>
-        <selectionEntry id="202e-2015-bacf-3c1a" name="Kustom Klaw" hidden="false" collective="false" type="upgrade">
+        <selectionEntry id="202e-2015-bacf-3c1a" name="Kustom Klaw" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="43f3-f259-f17d-f9ad" type="min"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4ea0-2528-ff5f-a225" type="max"/>
@@ -1774,9 +1770,9 @@
         </selectionEntry>
       </selectionEntries>
       <entryLinks>
-        <entryLink id="084c-33c6-25f9-d85d" name="Stikkbombs" hidden="false" collective="false" targetId="6df7-0ee7-7e6d-b182" type="selectionEntry"/>
-        <entryLink id="5d74-022e-9217-72bc" name="Warlord" hidden="false" collective="false" targetId="33f6-60da-7b70-5fee" type="selectionEntry"/>
-        <entryLink id="b939-507b-32d1-48c1" name="Twin Big Shoota" hidden="false" collective="false" targetId="a4f1-6ccb-1c50-405b" type="selectionEntry">
+        <entryLink id="084c-33c6-25f9-d85d" name="Stikkbombs" hidden="false" collective="false" import="true" targetId="6df7-0ee7-7e6d-b182" type="selectionEntry"/>
+        <entryLink id="5d74-022e-9217-72bc" name="Warlord" hidden="false" collective="false" import="true" targetId="33f6-60da-7b70-5fee" type="selectionEntry"/>
+        <entryLink id="b939-507b-32d1-48c1" name="Twin Big Shoota" hidden="false" collective="false" import="true" targetId="a4f1-6ccb-1c50-405b" type="selectionEntry">
           <modifiers>
             <modifier type="set" field="points" value="0.0"/>
           </modifiers>
@@ -1792,7 +1788,7 @@
         <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="c8f6-b38b-637f-3c7c" name="Ammo Runt" hidden="false" collective="false" type="upgrade">
+    <selectionEntry id="c8f6-b38b-637f-3c7c" name="Ammo Runt" hidden="false" collective="false" import="true" type="upgrade">
       <profiles>
         <profile id="74cc-ae42-46a3-d483" name="Ammo Runt" hidden="false" typeId="800f-21d0-4387-c943" typeName="Unit">
           <characteristics>
@@ -1824,7 +1820,7 @@
         <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="8ced-c9f4-249d-0fc3" name="Kaptin Badrukk" publicationId="11b5-77b9-pubN65537" page="90" hidden="false" collective="false" type="unit">
+    <selectionEntry id="8ced-c9f4-249d-0fc3" name="Kaptin Badrukk" publicationId="11b5-77b9-pubN65537" page="90" hidden="false" collective="false" import="true" type="unit">
       <constraints>
         <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="cc95-a479-1a8b-290a" type="max"/>
       </constraints>
@@ -1878,7 +1874,7 @@
         <categoryLink id="06f8-bd28-23c9-f02e" name="Faction: Freebootas" hidden="false" targetId="9202-2837-f931-9163" primary="false"/>
       </categoryLinks>
       <selectionEntries>
-        <selectionEntry id="2097-666f-6589-6ddf" name="Da Rippa" hidden="false" collective="false" type="upgrade">
+        <selectionEntry id="2097-666f-6589-6ddf" name="Da Rippa" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0dbf-9932-cd99-93da" type="min"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a8fa-09f5-0f55-0408" type="max"/>
@@ -1913,30 +1909,30 @@
         </selectionEntry>
       </selectionEntries>
       <entryLinks>
-        <entryLink id="6f51-a1ad-6963-c07d" name="New EntryLink" hidden="false" collective="false" targetId="d13b-ad69-e6a2-d485" type="selectionEntry">
+        <entryLink id="6f51-a1ad-6963-c07d" name="New EntryLink" hidden="false" collective="false" import="true" targetId="d13b-ad69-e6a2-d485" type="selectionEntry">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5c3d-443a-f05b-80eb" type="min"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7939-5f1a-8ba0-e6b4" type="max"/>
           </constraints>
         </entryLink>
-        <entryLink id="9bca-40bc-d957-de06" name="New EntryLink" hidden="false" collective="false" targetId="c4df-c43d-08a6-18ab" type="selectionEntry">
+        <entryLink id="9bca-40bc-d957-de06" name="New EntryLink" hidden="false" collective="false" import="true" targetId="c4df-c43d-08a6-18ab" type="selectionEntry">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d956-1b86-57f1-6730" type="min"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="cddc-d92e-4426-8cb9" type="max"/>
           </constraints>
         </entryLink>
-        <entryLink id="ed1e-b2ad-947d-7770" name="Stikkbombs" hidden="false" collective="false" targetId="6df7-0ee7-7e6d-b182" type="selectionEntry">
+        <entryLink id="ed1e-b2ad-947d-7770" name="Stikkbombs" hidden="false" collective="false" import="true" targetId="6df7-0ee7-7e6d-b182" type="selectionEntry">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="76eb-87f2-e33e-5e80" type="min"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c1ff-c33c-b23b-faa1" type="max"/>
           </constraints>
         </entryLink>
-        <entryLink id="a68c-6045-6751-eb0b" name="Ammo Runt" hidden="false" collective="false" targetId="c8f6-b38b-637f-3c7c" type="selectionEntry">
+        <entryLink id="a68c-6045-6751-eb0b" name="Ammo Runt" hidden="false" collective="false" import="true" targetId="c8f6-b38b-637f-3c7c" type="selectionEntry">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2086-7fad-dcff-71d6" type="max"/>
           </constraints>
         </entryLink>
-        <entryLink id="85fe-aa52-95ff-bd24" name="Warlord" hidden="false" collective="false" targetId="33f6-60da-7b70-5fee" type="selectionEntry"/>
+        <entryLink id="85fe-aa52-95ff-bd24" name="Warlord" hidden="false" collective="false" import="true" targetId="33f6-60da-7b70-5fee" type="selectionEntry"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="points" value="84.0"/>
@@ -1944,7 +1940,7 @@
         <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="0d18-8bfc-b6ac-920e" name="Boss Zagstruk" publicationId="11b5-77b9-pubN65537" page="89" hidden="false" collective="false" type="unit">
+    <selectionEntry id="0d18-8bfc-b6ac-920e" name="Boss Zagstruk" publicationId="11b5-77b9-pubN65537" page="89" hidden="false" collective="false" import="true" type="unit">
       <modifiers>
         <modifier type="set" field="hidden" value="true">
           <conditionGroups>
@@ -2021,7 +2017,7 @@
         <categoryLink id="c56d-7ea6-0333-c271" name="New CategoryLink" hidden="false" targetId="8f60-0af0-2b92-80a8" primary="false"/>
       </categoryLinks>
       <selectionEntries>
-        <selectionEntry id="488f-24fb-38cd-7a52" name="Da Vulcha&apos;s Klaws" hidden="false" collective="false" type="upgrade">
+        <selectionEntry id="488f-24fb-38cd-7a52" name="Da Vulcha&apos;s Klaws" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9614-080f-3f06-0edc" type="min"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8259-628c-bb9e-79ca" type="max"/>
@@ -2044,7 +2040,7 @@
             <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
           </costs>
         </selectionEntry>
-        <selectionEntry id="d3c4-f588-7734-ccd0" name="Blitz Missiles" hidden="false" collective="false" type="upgrade">
+        <selectionEntry id="d3c4-f588-7734-ccd0" name="Blitz Missiles" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6659-266d-fed9-81a0" type="max"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0bca-e82d-66fc-8e1f" type="min"/>
@@ -2069,19 +2065,19 @@
         </selectionEntry>
       </selectionEntries>
       <entryLinks>
-        <entryLink id="eed2-e1ac-aa96-253d" name="New EntryLink" hidden="false" collective="false" targetId="d13b-ad69-e6a2-d485" type="selectionEntry">
+        <entryLink id="eed2-e1ac-aa96-253d" name="New EntryLink" hidden="false" collective="false" import="true" targetId="d13b-ad69-e6a2-d485" type="selectionEntry">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="72cf-1884-7505-f860" type="min"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8eba-2c34-bb56-1411" type="max"/>
           </constraints>
         </entryLink>
-        <entryLink id="e515-e0c6-10ca-dcbf" name="Choppa" hidden="false" collective="false" targetId="c4df-c43d-08a6-18ab" type="selectionEntry">
+        <entryLink id="e515-e0c6-10ca-dcbf" name="Choppa" hidden="false" collective="false" import="true" targetId="c4df-c43d-08a6-18ab" type="selectionEntry">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fd7d-b303-0b97-551b" type="min"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2a48-d8e5-fcd3-f76f" type="max"/>
           </constraints>
         </entryLink>
-        <entryLink id="f6ae-b8c8-c71b-1f30" name="Warlord" hidden="false" collective="false" targetId="33f6-60da-7b70-5fee" type="selectionEntry"/>
+        <entryLink id="f6ae-b8c8-c71b-1f30" name="Warlord" hidden="false" collective="false" import="true" targetId="33f6-60da-7b70-5fee" type="selectionEntry"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="points" value="88.0"/>
@@ -2089,7 +2085,7 @@
         <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="9037-5d51-7e69-51aa" name="Mad Dok Grotsnik" hidden="false" collective="false" type="unit">
+    <selectionEntry id="9037-5d51-7e69-51aa" name="Mad Dok Grotsnik" hidden="false" collective="false" import="true" type="unit">
       <modifiers>
         <modifier type="set" field="hidden" value="true">
           <conditionGroups>
@@ -2164,13 +2160,13 @@
         <categoryLink id="7aa4-fac6-9a69-1ddd" name="New CategoryLink" hidden="false" targetId="38c8-dbcf-febf-2188" primary="false"/>
       </categoryLinks>
       <entryLinks>
-        <entryLink id="6899-4651-a07a-b0c2" name="&apos;Urty Syringe" hidden="false" collective="false" targetId="2112-88e2-79ed-88b8" type="selectionEntry">
+        <entryLink id="6899-4651-a07a-b0c2" name="&apos;Urty Syringe" hidden="false" collective="false" import="true" targetId="2112-88e2-79ed-88b8" type="selectionEntry">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d593-fcf6-8f6a-03de" type="min"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="85a1-c3ad-e9bd-db58" type="max"/>
           </constraints>
         </entryLink>
-        <entryLink id="e271-99e8-24c1-a1cb" name="Power Klaw" hidden="false" collective="false" targetId="fe00-451f-6735-6fd9" type="selectionEntry">
+        <entryLink id="e271-99e8-24c1-a1cb" name="Power Klaw" hidden="false" collective="false" import="true" targetId="fe00-451f-6735-6fd9" type="selectionEntry">
           <modifiers>
             <modifier type="set" field="points" value="0.0"/>
           </modifiers>
@@ -2179,13 +2175,13 @@
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fd92-dc9f-f212-9cba" type="max"/>
           </constraints>
         </entryLink>
-        <entryLink id="57bb-92f9-97e5-5b9f" name="Slugga" hidden="false" collective="false" targetId="d13b-ad69-e6a2-d485" type="selectionEntry">
+        <entryLink id="57bb-92f9-97e5-5b9f" name="Slugga" hidden="false" collective="false" import="true" targetId="d13b-ad69-e6a2-d485" type="selectionEntry">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a052-f51c-05dc-e45d" type="min"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3490-ab5f-2925-78fa" type="max"/>
           </constraints>
         </entryLink>
-        <entryLink id="6dfe-e3df-ad40-fa88" name="Warlord" hidden="false" collective="false" targetId="33f6-60da-7b70-5fee" type="selectionEntry"/>
+        <entryLink id="6dfe-e3df-ad40-fa88" name="Warlord" hidden="false" collective="false" import="true" targetId="33f6-60da-7b70-5fee" type="selectionEntry"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="points" value="86.0"/>
@@ -2193,7 +2189,7 @@
         <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="b816-45d4-dcde-e771" name="Boss Nob" hidden="false" collective="false" type="model">
+    <selectionEntry id="b816-45d4-dcde-e771" name="Boss Nob" hidden="false" collective="false" import="true" type="model">
       <profiles>
         <profile id="8a9a-a79a-b446-72df" name="Boss Nob" hidden="false" typeId="800f-21d0-4387-c943" typeName="Unit">
           <characteristics>
@@ -2210,9 +2206,9 @@
         </profile>
       </profiles>
       <entryLinks>
-        <entryLink id="cb89-babd-80bc-ebfc" name="Stikkbombs" hidden="false" collective="false" targetId="6df7-0ee7-7e6d-b182" type="selectionEntry"/>
-        <entryLink id="9dc2-33b4-3026-0d81" name="Nob Arm1" hidden="false" collective="false" targetId="d4bf-a2d0-e994-1474" type="selectionEntryGroup"/>
-        <entryLink id="0e83-3e62-a938-f56d" name="Nob Arm2" hidden="false" collective="false" targetId="2fe0-1fb8-9268-f604" type="selectionEntryGroup"/>
+        <entryLink id="cb89-babd-80bc-ebfc" name="Stikkbombs" hidden="false" collective="false" import="true" targetId="6df7-0ee7-7e6d-b182" type="selectionEntry"/>
+        <entryLink id="9dc2-33b4-3026-0d81" name="Nob Arm1" hidden="false" collective="false" import="true" targetId="d4bf-a2d0-e994-1474" type="selectionEntryGroup"/>
+        <entryLink id="0e83-3e62-a938-f56d" name="Nob Arm2" hidden="false" collective="false" import="true" targetId="2fe0-1fb8-9268-f604" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="points" value="7.0"/>
@@ -2220,7 +2216,7 @@
         <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="4923-2dbf-7fd5-8828" name="Boyz" hidden="false" collective="false" type="unit">
+    <selectionEntry id="4923-2dbf-7fd5-8828" name="Boyz" hidden="false" collective="false" import="true" type="unit">
       <modifiers>
         <modifier type="increment" field="e356-c769-5920-6e14" value="3">
           <conditions>
@@ -2253,30 +2249,30 @@
         <categoryLink id="28d4-976a-ed63-1c53" name="New CategoryLink" hidden="false" targetId="5d76b6f5-20ae-4d70-8f59-ade72a2add3a" primary="true"/>
       </categoryLinks>
       <selectionEntryGroups>
-        <selectionEntryGroup id="0f35-4e09-6673-45b4" name="Mob" hidden="false" collective="false" defaultSelectionEntryId="c265-7969-10c0-0d77">
+        <selectionEntryGroup id="0f35-4e09-6673-45b4" name="Mob" hidden="false" collective="false" import="true" defaultSelectionEntryId="c265-7969-10c0-0d77">
           <constraints>
             <constraint field="selections" scope="parent" value="10.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a4c9-a20a-2ebc-96ee" type="min"/>
             <constraint field="selections" scope="parent" value="30.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="65b6-bd4a-0f2b-e0d4" type="max"/>
           </constraints>
           <selectionEntries>
-            <selectionEntry id="c265-7969-10c0-0d77" name="Ork Boy W/ Slugga &amp; Choppa" hidden="false" collective="false" type="model">
+            <selectionEntry id="c265-7969-10c0-0d77" name="Ork Boy W/ Slugga &amp; Choppa" hidden="false" collective="false" import="true" type="model">
               <infoLinks>
                 <infoLink id="c638-0ed4-f267-41d3" name="New InfoLink" hidden="false" targetId="4305-daf8-8988-6189" type="profile"/>
               </infoLinks>
               <entryLinks>
-                <entryLink id="532f-c32a-59b4-cebb" name="Choppa" hidden="false" collective="false" targetId="c025-0c89-05db-fccb" type="selectionEntry">
+                <entryLink id="532f-c32a-59b4-cebb" name="Choppa" hidden="false" collective="false" import="true" targetId="c025-0c89-05db-fccb" type="selectionEntry">
                   <constraints>
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b6e1-98b0-9cad-a326" type="min"/>
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="75d7-5efa-4a1a-8596" type="max"/>
                   </constraints>
                 </entryLink>
-                <entryLink id="ff09-e337-e522-0373" name="Slugga" hidden="false" collective="false" targetId="1b13-84df-f255-b206" type="selectionEntry">
+                <entryLink id="ff09-e337-e522-0373" name="Slugga" hidden="false" collective="false" import="true" targetId="1b13-84df-f255-b206" type="selectionEntry">
                   <constraints>
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="57be-f255-e75a-a33c" type="min"/>
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9103-b1fd-6569-a3da" type="max"/>
                   </constraints>
                 </entryLink>
-                <entryLink id="a03e-ff60-e497-de17" name="New EntryLink" hidden="false" collective="false" targetId="6df7-0ee7-7e6d-b182" type="selectionEntry"/>
+                <entryLink id="a03e-ff60-e497-de17" name="New EntryLink" hidden="false" collective="false" import="true" targetId="6df7-0ee7-7e6d-b182" type="selectionEntry"/>
               </entryLinks>
               <costs>
                 <cost name="pts" typeId="points" value="7.0"/>
@@ -2284,13 +2280,13 @@
                 <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
               </costs>
             </selectionEntry>
-            <selectionEntry id="a99b-eb35-3148-7e79" name="Ork Boy W/ Shoota" hidden="false" collective="false" type="model">
+            <selectionEntry id="a99b-eb35-3148-7e79" name="Ork Boy W/ Shoota" hidden="false" collective="false" import="true" type="model">
               <infoLinks>
                 <infoLink id="f4e1-9a43-e678-113d" name="Ork Boy" hidden="false" targetId="4305-daf8-8988-6189" type="profile"/>
               </infoLinks>
               <entryLinks>
-                <entryLink id="b49f-a2b0-8d81-2f06" name="Stikkbombs" hidden="false" collective="false" targetId="6df7-0ee7-7e6d-b182" type="selectionEntry"/>
-                <entryLink id="638d-22c9-d833-20a4" name="New EntryLink" hidden="false" collective="false" targetId="e704-4044-fa55-f75e" type="selectionEntry">
+                <entryLink id="b49f-a2b0-8d81-2f06" name="Stikkbombs" hidden="false" collective="false" import="true" targetId="6df7-0ee7-7e6d-b182" type="selectionEntry"/>
+                <entryLink id="638d-22c9-d833-20a4" name="New EntryLink" hidden="false" collective="false" import="true" targetId="e704-4044-fa55-f75e" type="selectionEntry">
                   <constraints>
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="12a8-0ff4-ec91-d802" type="min"/>
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2990-414f-9d3f-da0d" type="max"/>
@@ -2303,7 +2299,7 @@
                 <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
               </costs>
             </selectionEntry>
-            <selectionEntry id="2aa4-c5ae-56f1-9fd0" name="Ork Boy W/ &apos;Eavy Weapon" hidden="false" collective="false" type="model">
+            <selectionEntry id="2aa4-c5ae-56f1-9fd0" name="Ork Boy W/ &apos;Eavy Weapon" hidden="false" collective="false" import="true" type="model">
               <modifiers>
                 <modifier type="increment" field="0435-0a04-1247-0cea" value="1">
                   <repeats>
@@ -2318,8 +2314,8 @@
                 <infoLink id="eadf-491c-9504-dc77" name="New InfoLink" hidden="false" targetId="4305-daf8-8988-6189" type="profile"/>
               </infoLinks>
               <entryLinks>
-                <entryLink id="8f9b-ac65-0bfb-31be" name="New EntryLink" hidden="false" collective="false" targetId="6df7-0ee7-7e6d-b182" type="selectionEntry"/>
-                <entryLink id="3740-9653-aa95-eb84" name="&apos;Eavy Weapons" hidden="false" collective="false" targetId="41a6-ce08-1467-5bf5" type="selectionEntryGroup">
+                <entryLink id="8f9b-ac65-0bfb-31be" name="New EntryLink" hidden="false" collective="false" import="true" targetId="6df7-0ee7-7e6d-b182" type="selectionEntry"/>
+                <entryLink id="3740-9653-aa95-eb84" name="&apos;Eavy Weapons" hidden="false" collective="false" import="true" targetId="41a6-ce08-1467-5bf5" type="selectionEntryGroup">
                   <constraints>
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d190-6060-5ab0-8645" type="min"/>
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a732-2ef1-8616-eeea" type="max"/>
@@ -2334,19 +2330,19 @@
             </selectionEntry>
           </selectionEntries>
           <entryLinks>
-            <entryLink id="fffc-9253-282a-3f0f" name="Boss Nob" hidden="false" collective="false" targetId="b816-45d4-dcde-e771" type="selectionEntry">
+            <entryLink id="fffc-9253-282a-3f0f" name="Boss Nob" hidden="false" collective="false" import="true" targetId="b816-45d4-dcde-e771" type="selectionEntry">
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4b80-6a79-2d7f-2a7f" type="max"/>
               </constraints>
             </entryLink>
           </entryLinks>
         </selectionEntryGroup>
-        <selectionEntryGroup id="6e0b-d853-b152-0c42" name="Stratagem Upgrade" hidden="false" collective="false">
+        <selectionEntryGroup id="6e0b-d853-b152-0c42" name="Stratagem Upgrade" hidden="false" collective="false" import="true">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ac2f-cd60-4edd-ffd6" type="max"/>
           </constraints>
           <selectionEntries>
-            <selectionEntry id="3a02-99e3-386b-63d8" name="&apos;Ard Boyz (2 CP)" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="3a02-99e3-386b-63d8" name="&apos;Ard Boyz (2 CP)" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4ec2-95e2-488c-0470" type="max"/>
               </constraints>
@@ -2363,7 +2359,7 @@
                 <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
               </costs>
             </selectionEntry>
-            <selectionEntry id="3684-948b-1cf6-2ad2" name="Skarboyz (1 CP)" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="3684-948b-1cf6-2ad2" name="Skarboyz (1 CP)" hidden="false" collective="false" import="true" type="upgrade">
               <modifiers>
                 <modifier type="set" field="hidden" value="true">
                   <conditions>
@@ -2388,7 +2384,7 @@
         </selectionEntryGroup>
       </selectionEntryGroups>
       <entryLinks>
-        <entryLink id="52a1-8a01-0388-dd61" name="Tankbusta Bombs" hidden="false" collective="false" targetId="d4ec-cdd8-004f-a8ab" type="selectionEntry">
+        <entryLink id="52a1-8a01-0388-dd61" name="Tankbusta Bombs" hidden="false" collective="false" import="true" targetId="d4ec-cdd8-004f-a8ab" type="selectionEntry">
           <modifiers>
             <modifier type="increment" field="1390-4ef5-0d88-4ffd" value="1">
               <repeats>
@@ -2400,8 +2396,8 @@
             <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1390-4ef5-0d88-4ffd" type="max"/>
           </constraints>
         </entryLink>
-        <entryLink id="3e09-1295-96c7-d654" name="Has Battle Honours" hidden="false" collective="false" targetId="4763-757f-499f-d998" type="selectionEntry"/>
-        <entryLink id="305a-b08b-6d16-a2c5" name="Battle Honours" hidden="false" collective="false" targetId="5518-d0f5-a880-d71c" type="selectionEntryGroup"/>
+        <entryLink id="3e09-1295-96c7-d654" name="Has Battle Honours" hidden="false" collective="false" import="true" targetId="4763-757f-499f-d998" type="selectionEntry"/>
+        <entryLink id="305a-b08b-6d16-a2c5" name="Battle Honours" hidden="false" collective="false" import="true" targetId="5518-d0f5-a880-d71c" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
         <cost name=" PL" typeId="e356-c769-5920-6e14" value="4.0"/>
@@ -2409,7 +2405,7 @@
         <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="96ec-51fe-cd61-b2c1" name="Gretchin" hidden="false" collective="false" type="unit">
+    <selectionEntry id="96ec-51fe-cd61-b2c1" name="Gretchin" hidden="false" collective="false" import="true" type="unit">
       <modifiers>
         <modifier type="increment" field="e356-c769-5920-6e14" value="1">
           <conditions>
@@ -2448,9 +2444,9 @@
         <categoryLink id="0cb6-66dc-3904-2f9d" name="New CategoryLink" hidden="false" targetId="5d76b6f5-20ae-4d70-8f59-ade72a2add3a" primary="true"/>
       </categoryLinks>
       <selectionEntryGroups>
-        <selectionEntryGroup id="2f60-e906-92f6-e66a" name="Mob" hidden="false" collective="false" defaultSelectionEntryId="768a-467a-24bf-f0fd">
+        <selectionEntryGroup id="2f60-e906-92f6-e66a" name="Mob" hidden="false" collective="false" import="true" defaultSelectionEntryId="768a-467a-24bf-f0fd">
           <selectionEntries>
-            <selectionEntry id="768a-467a-24bf-f0fd" name="Gretchin" hidden="false" collective="false" type="model">
+            <selectionEntry id="768a-467a-24bf-f0fd" name="Gretchin" hidden="false" collective="false" import="true" type="model">
               <constraints>
                 <constraint field="selections" scope="parent" value="30.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e0ae-72c4-f641-85b4" type="max"/>
                 <constraint field="selections" scope="parent" value="10.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="758b-d200-9a9b-fc25" type="min"/>
@@ -2471,7 +2467,7 @@
                 </profile>
               </profiles>
               <entryLinks>
-                <entryLink id="e64f-5e3b-d0a4-c8db" name="Grot Blaster" hidden="false" collective="false" targetId="a8f4-732e-fc64-3577" type="selectionEntry">
+                <entryLink id="e64f-5e3b-d0a4-c8db" name="Grot Blaster" hidden="false" collective="false" import="true" targetId="a8f4-732e-fc64-3577" type="selectionEntry">
                   <constraints>
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="dcb2-c548-d55a-9bf2" type="max"/>
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="40bb-7064-4de7-b7aa" type="min"/>
@@ -2488,8 +2484,8 @@
         </selectionEntryGroup>
       </selectionEntryGroups>
       <entryLinks>
-        <entryLink id="dd4f-98dd-c15a-ed7d" name="Has Battle Honours" hidden="false" collective="false" targetId="4763-757f-499f-d998" type="selectionEntry"/>
-        <entryLink id="2c84-ddf6-8e09-ef66" name="Battle Honours" hidden="false" collective="false" targetId="5518-d0f5-a880-d71c" type="selectionEntryGroup"/>
+        <entryLink id="dd4f-98dd-c15a-ed7d" name="Has Battle Honours" hidden="false" collective="false" import="true" targetId="4763-757f-499f-d998" type="selectionEntry"/>
+        <entryLink id="2c84-ddf6-8e09-ef66" name="Battle Honours" hidden="false" collective="false" import="true" targetId="5518-d0f5-a880-d71c" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
         <cost name=" PL" typeId="e356-c769-5920-6e14" value="1.0"/>
@@ -2497,7 +2493,7 @@
         <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="4a86-9031-67e9-cb27" name="Runtherd" hidden="false" collective="false" type="unit">
+    <selectionEntry id="4a86-9031-67e9-cb27" name="Runtherd" hidden="false" collective="false" import="true" type="unit">
       <profiles>
         <profile id="1afd-2533-77ec-aae8" name="Runtherd" hidden="false" typeId="800f-21d0-4387-c943" typeName="Unit">
           <characteristics>
@@ -2530,12 +2526,12 @@
         <categoryLink id="6b51-0567-d457-534c" name="No Force Org Slot" hidden="false" targetId="ff36a6f3-19bf-4f48-8956-adacfd28fe74" primary="true"/>
       </categoryLinks>
       <selectionEntryGroups>
-        <selectionEntryGroup id="7944-038a-4666-d411" name="Herding Gear" hidden="false" collective="false">
+        <selectionEntryGroup id="7944-038a-4666-d411" name="Herding Gear" hidden="false" collective="false" import="true">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="42db-3dbc-353a-c7f6" type="max"/>
           </constraints>
           <selectionEntries>
-            <selectionEntry id="5c9f-95eb-1ec7-0af2" name="Squig Hound" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="5c9f-95eb-1ec7-0af2" name="Squig Hound" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="261e-9984-8d72-ed81" type="max"/>
               </constraints>
@@ -2552,7 +2548,7 @@
                 <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
               </costs>
             </selectionEntry>
-            <selectionEntry id="6dce-0383-5b0e-b194" name="Grot Lash" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="6dce-0383-5b0e-b194" name="Grot Lash" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="912f-5195-08b9-1322" type="max"/>
               </constraints>
@@ -2571,13 +2567,13 @@
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
-        <selectionEntryGroup id="7dfa-8517-487f-50ec" name="Melee Weapon" hidden="false" collective="false" defaultSelectionEntryId="e9b7-1d44-15d4-8dc5">
+        <selectionEntryGroup id="7dfa-8517-487f-50ec" name="Melee Weapon" hidden="false" collective="false" import="true" defaultSelectionEntryId="e9b7-1d44-15d4-8dc5">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="128b-ddc1-ddcf-4f96" type="min"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e46d-65ce-9787-bbfe" type="max"/>
           </constraints>
           <selectionEntries>
-            <selectionEntry id="e9b7-1d44-15d4-8dc5" name="Grabba Stikk" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="e9b7-1d44-15d4-8dc5" name="Grabba Stikk" hidden="false" collective="false" import="true" type="upgrade">
               <profiles>
                 <profile id="915c-deea-7576-056b" name="Grabba Stikk" hidden="false" typeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" typeName="Weapon">
                   <characteristics>
@@ -2596,7 +2592,7 @@
                 <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
               </costs>
             </selectionEntry>
-            <selectionEntry id="e1e7-f5bb-c9f7-a9ba" name="Grot-Prod" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="e1e7-f5bb-c9f7-a9ba" name="Grot-Prod" hidden="false" collective="false" import="true" type="upgrade">
               <profiles>
                 <profile id="81a7-7f36-3bde-d4af" name="Grot-Prod" hidden="false" typeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" typeName="Weapon">
                   <characteristics>
@@ -2619,14 +2615,14 @@
         </selectionEntryGroup>
       </selectionEntryGroups>
       <entryLinks>
-        <entryLink id="2da7-e98d-c616-73af" name="New EntryLink" hidden="false" collective="false" targetId="d13b-ad69-e6a2-d485" type="selectionEntry">
+        <entryLink id="2da7-e98d-c616-73af" name="New EntryLink" hidden="false" collective="false" import="true" targetId="d13b-ad69-e6a2-d485" type="selectionEntry">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d2b5-5660-bcef-750c" type="min"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="edd0-eb6d-adb0-3fcc" type="max"/>
           </constraints>
         </entryLink>
-        <entryLink id="4a9e-834f-395c-a841" name="Warlord Traits" hidden="false" collective="false" targetId="c2ce-6759-e009-8c11" type="selectionEntryGroup"/>
-        <entryLink id="80cc-76e8-0699-53f5" name="Warlord" hidden="false" collective="false" targetId="33f6-60da-7b70-5fee" type="selectionEntry"/>
+        <entryLink id="4a9e-834f-395c-a841" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="c2ce-6759-e009-8c11" type="selectionEntryGroup"/>
+        <entryLink id="80cc-76e8-0699-53f5" name="Warlord" hidden="false" collective="false" import="true" targetId="33f6-60da-7b70-5fee" type="selectionEntry"/>
       </entryLinks>
       <costs>
         <cost name=" PL" typeId="e356-c769-5920-6e14" value="2.0"/>
@@ -2634,7 +2630,7 @@
         <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="b4f7-fe86-812e-602c" name="Nobz" hidden="false" collective="false" type="unit">
+    <selectionEntry id="b4f7-fe86-812e-602c" name="Nobz" hidden="false" collective="false" import="true" type="unit">
       <modifiers>
         <modifier type="increment" field="e356-c769-5920-6e14" value="7">
           <conditions>
@@ -2656,7 +2652,7 @@
         <categoryLink id="0c36-ef0a-6179-c3d7" name="New CategoryLink" hidden="false" targetId="2592-330f-3727-4018" primary="false"/>
       </categoryLinks>
       <selectionEntries>
-        <selectionEntry id="8f83-b4ca-7280-1a38" name="Boss Nob" hidden="false" collective="false" type="model">
+        <selectionEntry id="8f83-b4ca-7280-1a38" name="Boss Nob" hidden="false" collective="false" import="true" type="model">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0204-276c-67ec-3ca0" type="min"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="344a-fdac-6649-534b" type="max"/>
@@ -2677,9 +2673,9 @@
             </profile>
           </profiles>
           <entryLinks>
-            <entryLink id="f6d4-35d9-7245-04cf" name="Stikkbombs" hidden="false" collective="false" targetId="6df7-0ee7-7e6d-b182" type="selectionEntry"/>
-            <entryLink id="fcff-ca65-3b99-e4da" name="Nob Arm1" hidden="false" collective="false" targetId="d4bf-a2d0-e994-1474" type="selectionEntryGroup"/>
-            <entryLink id="cd5b-8601-06ab-24f8" name="Nob Arm2" hidden="false" collective="false" targetId="2fe0-1fb8-9268-f604" type="selectionEntryGroup"/>
+            <entryLink id="f6d4-35d9-7245-04cf" name="Stikkbombs" hidden="false" collective="false" import="true" targetId="6df7-0ee7-7e6d-b182" type="selectionEntry"/>
+            <entryLink id="fcff-ca65-3b99-e4da" name="Nob Arm1" hidden="false" collective="false" import="true" targetId="d4bf-a2d0-e994-1474" type="selectionEntryGroup"/>
+            <entryLink id="cd5b-8601-06ab-24f8" name="Nob Arm2" hidden="false" collective="false" import="true" targetId="2fe0-1fb8-9268-f604" type="selectionEntryGroup"/>
           </entryLinks>
           <costs>
             <cost name="pts" typeId="points" value="14.0"/>
@@ -2689,13 +2685,13 @@
         </selectionEntry>
       </selectionEntries>
       <selectionEntryGroups>
-        <selectionEntryGroup id="2831-d050-a825-1278" name="Nobz" hidden="false" collective="false" defaultSelectionEntryId="5493-1317-827c-1ac6">
+        <selectionEntryGroup id="2831-d050-a825-1278" name="Nobz" hidden="false" collective="false" import="true" defaultSelectionEntryId="5493-1317-827c-1ac6">
           <constraints>
             <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2d6a-5687-017b-8c2e" type="min"/>
             <constraint field="selections" scope="parent" value="9.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a992-5d71-7837-3d78" type="max"/>
           </constraints>
           <selectionEntries>
-            <selectionEntry id="5493-1317-827c-1ac6" name="Nob" hidden="false" collective="false" type="model">
+            <selectionEntry id="5493-1317-827c-1ac6" name="Nob" hidden="false" collective="false" import="true" type="model">
               <profiles>
                 <profile id="dd8b-892f-9a0b-2759" name="Nob" hidden="false" typeId="800f-21d0-4387-c943" typeName="Unit">
                   <characteristics>
@@ -2712,9 +2708,9 @@
                 </profile>
               </profiles>
               <entryLinks>
-                <entryLink id="73eb-4cd8-a144-7b3f" name="Stikkbombs" hidden="false" collective="false" targetId="6df7-0ee7-7e6d-b182" type="selectionEntry"/>
-                <entryLink id="3907-5310-ecb3-b61a" name="Nob Arm1" hidden="false" collective="false" targetId="d4bf-a2d0-e994-1474" type="selectionEntryGroup"/>
-                <entryLink id="487d-e7f9-1bf3-aadb" name="Nob Arm2" hidden="false" collective="false" targetId="2fe0-1fb8-9268-f604" type="selectionEntryGroup"/>
+                <entryLink id="73eb-4cd8-a144-7b3f" name="Stikkbombs" hidden="false" collective="false" import="true" targetId="6df7-0ee7-7e6d-b182" type="selectionEntry"/>
+                <entryLink id="3907-5310-ecb3-b61a" name="Nob Arm1" hidden="false" collective="false" import="true" targetId="d4bf-a2d0-e994-1474" type="selectionEntryGroup"/>
+                <entryLink id="487d-e7f9-1bf3-aadb" name="Nob Arm2" hidden="false" collective="false" import="true" targetId="2fe0-1fb8-9268-f604" type="selectionEntryGroup"/>
               </entryLinks>
               <costs>
                 <cost name="pts" typeId="points" value="14.0"/>
@@ -2726,7 +2722,7 @@
         </selectionEntryGroup>
       </selectionEntryGroups>
       <entryLinks>
-        <entryLink id="d223-2f12-42f4-347c" name="Cybork Body" hidden="false" collective="false" targetId="a253-7f1e-40fb-a73d" type="selectionEntry">
+        <entryLink id="d223-2f12-42f4-347c" name="Cybork Body" hidden="false" collective="false" import="true" targetId="a253-7f1e-40fb-a73d" type="selectionEntry">
           <modifiers>
             <modifier type="increment" field="6705-18fc-e28f-3706" value="1">
               <repeats>
@@ -2738,7 +2734,7 @@
             <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6705-18fc-e28f-3706" type="max"/>
           </constraints>
         </entryLink>
-        <entryLink id="e8eb-c5f9-5c25-ddce" name="Ammo Runt" hidden="false" collective="false" targetId="c8f6-b38b-637f-3c7c" type="selectionEntry">
+        <entryLink id="e8eb-c5f9-5c25-ddce" name="Ammo Runt" hidden="false" collective="false" import="true" targetId="c8f6-b38b-637f-3c7c" type="selectionEntry">
           <modifiers>
             <modifier type="increment" field="df61-1cdc-ea04-4e88" value="1">
               <repeats>
@@ -2750,8 +2746,8 @@
             <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="df61-1cdc-ea04-4e88" type="max"/>
           </constraints>
         </entryLink>
-        <entryLink id="941d-09a1-dc5a-282c" name="Has Battle Honours" hidden="false" collective="false" targetId="4763-757f-499f-d998" type="selectionEntry"/>
-        <entryLink id="9d56-33fc-97ab-b44f" name="Battle Honours" hidden="false" collective="false" targetId="5518-d0f5-a880-d71c" type="selectionEntryGroup"/>
+        <entryLink id="941d-09a1-dc5a-282c" name="Has Battle Honours" hidden="false" collective="false" import="true" targetId="4763-757f-499f-d998" type="selectionEntry"/>
+        <entryLink id="9d56-33fc-97ab-b44f" name="Battle Honours" hidden="false" collective="false" import="true" targetId="5518-d0f5-a880-d71c" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
         <cost name=" PL" typeId="e356-c769-5920-6e14" value="7.0"/>
@@ -2759,7 +2755,7 @@
         <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="a253-7f1e-40fb-a73d" name="Cybork Body" hidden="false" collective="false" type="upgrade">
+    <selectionEntry id="a253-7f1e-40fb-a73d" name="Cybork Body" hidden="false" collective="false" import="true" type="upgrade">
       <profiles>
         <profile id="daa5-287a-bb53-661d" name="Cybork Body" hidden="false" typeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" typeName="Abilities">
           <characteristics>
@@ -2773,7 +2769,7 @@
         <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="d13b-ad69-e6a2-d485" name="Slugga" hidden="false" collective="false" type="upgrade">
+    <selectionEntry id="d13b-ad69-e6a2-d485" name="Slugga" hidden="false" collective="false" import="true" type="upgrade">
       <infoLinks>
         <infoLink id="fa95-808b-2926-c26c" name="New InfoLink" hidden="false" targetId="597d-56aa-73c4-88bf" type="profile"/>
       </infoLinks>
@@ -2783,7 +2779,7 @@
         <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="f314-b941-342f-289c" name="Shoota" hidden="false" collective="false" type="upgrade">
+    <selectionEntry id="f314-b941-342f-289c" name="Shoota" hidden="false" collective="false" import="true" type="upgrade">
       <infoLinks>
         <infoLink id="b24d-da41-68ab-f35d" name="New InfoLink" hidden="false" targetId="5a2b-0c64-8aa8-2f3e" type="profile"/>
       </infoLinks>
@@ -2793,7 +2789,7 @@
         <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="c4df-c43d-08a6-18ab" name="Choppa" hidden="false" collective="false" type="upgrade">
+    <selectionEntry id="c4df-c43d-08a6-18ab" name="Choppa" hidden="false" collective="false" import="true" type="upgrade">
       <infoLinks>
         <infoLink id="29be-0826-9023-9405" name="New InfoLink" hidden="false" targetId="cc0c-8f69-bf5f-ef51" type="profile"/>
       </infoLinks>
@@ -2803,7 +2799,7 @@
         <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="d134-3bdb-4db3-203e" name="Nob with Waaagh! Banner" hidden="false" collective="false" type="unit">
+    <selectionEntry id="d134-3bdb-4db3-203e" name="Nob with Waaagh! Banner" hidden="false" collective="false" import="true" type="unit">
       <profiles>
         <profile id="8a6b-c1c8-4426-3a6a" name="Nob with Waaagh! Banner" hidden="false" typeId="800f-21d0-4387-c943" typeName="Unit">
           <characteristics>
@@ -2834,7 +2830,7 @@
         <categoryLink id="b8e1-9a90-24ec-c7ae" name="New CategoryLink" hidden="false" targetId="ef18-746a-369f-43a4" primary="false"/>
       </categoryLinks>
       <selectionEntries>
-        <selectionEntry id="b407-1197-baec-6dbc" name="Waaagh! Banner" hidden="false" collective="false" type="upgrade">
+        <selectionEntry id="b407-1197-baec-6dbc" name="Waaagh! Banner" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c8fa-5157-3fca-0431" type="min"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="98ab-7093-9a66-b486" type="max"/>
@@ -2864,29 +2860,29 @@
         </selectionEntry>
       </selectionEntries>
       <entryLinks>
-        <entryLink id="6914-994d-0165-e339" name="Kustom Shoota" hidden="false" collective="false" targetId="df47-a9ec-a22e-a2b6" type="selectionEntry">
+        <entryLink id="6914-994d-0165-e339" name="Kustom Shoota" hidden="false" collective="false" import="true" targetId="df47-a9ec-a22e-a2b6" type="selectionEntry">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="30a3-33c9-3eb4-6e01" type="min"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c881-70e4-4477-0969" type="max"/>
           </constraints>
         </entryLink>
-        <entryLink id="7255-953b-edb7-4a0d" name="New EntryLink" hidden="false" collective="false" targetId="6df7-0ee7-7e6d-b182" type="selectionEntry"/>
-        <entryLink id="6ddc-7334-cc85-ac1b" name="Warlord" hidden="false" collective="false" targetId="33f6-60da-7b70-5fee" type="selectionEntry"/>
-        <entryLink id="d368-affd-c577-b150" name="Warlord Traits" hidden="false" collective="false" targetId="c2ce-6759-e009-8c11" type="selectionEntryGroup"/>
-        <entryLink id="094b-9618-4e96-b723" name="Choppa" hidden="false" collective="false" targetId="c025-0c89-05db-fccb" type="selectionEntry">
+        <entryLink id="7255-953b-edb7-4a0d" name="New EntryLink" hidden="false" collective="false" import="true" targetId="6df7-0ee7-7e6d-b182" type="selectionEntry"/>
+        <entryLink id="6ddc-7334-cc85-ac1b" name="Warlord" hidden="false" collective="false" import="true" targetId="33f6-60da-7b70-5fee" type="selectionEntry"/>
+        <entryLink id="d368-affd-c577-b150" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="c2ce-6759-e009-8c11" type="selectionEntryGroup"/>
+        <entryLink id="094b-9618-4e96-b723" name="Choppa" hidden="false" collective="false" import="true" targetId="c025-0c89-05db-fccb" type="selectionEntry">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e230-65f8-2547-c263" type="min"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6e46-667f-196a-baa5" type="max"/>
           </constraints>
         </entryLink>
-        <entryLink id="c6a3-f73b-65f0-0da4" name="Relic Gubbinz" hidden="false" collective="false" targetId="04b0-dab2-123b-df51" type="selectionEntryGroup"/>
-        <entryLink id="a3c7-db86-4964-50af" name="Power Klaw" hidden="false" collective="false" targetId="fe00-451f-6735-6fd9" type="selectionEntry">
+        <entryLink id="c6a3-f73b-65f0-0da4" name="Relic Gubbinz" hidden="false" collective="false" import="true" targetId="04b0-dab2-123b-df51" type="selectionEntryGroup"/>
+        <entryLink id="a3c7-db86-4964-50af" name="Power Klaw" hidden="false" collective="false" import="true" targetId="fe00-451f-6735-6fd9" type="selectionEntry">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="49b5-cef4-e6e4-4710" type="max"/>
           </constraints>
         </entryLink>
-        <entryLink id="e107-30fe-9202-82de" name="Is a Custom Character" hidden="false" collective="false" targetId="43c4-8968-c599-ad5f" type="selectionEntry"/>
-        <entryLink id="5d85-dad4-c55f-9946" name="Custom Character Selections" hidden="false" collective="false" targetId="8774-e003-4a50-56c7" type="selectionEntryGroup"/>
+        <entryLink id="e107-30fe-9202-82de" name="Is a Custom Character" hidden="false" collective="false" import="true" targetId="43c4-8968-c599-ad5f" type="selectionEntry"/>
+        <entryLink id="5d85-dad4-c55f-9946" name="Custom Character Selections" hidden="false" collective="false" import="true" targetId="8774-e003-4a50-56c7" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="points" value="75.0"/>
@@ -2894,7 +2890,7 @@
         <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="50bb-821a-aaac-4b0f" name="Nobz on Warbikes" hidden="false" collective="false" type="unit">
+    <selectionEntry id="50bb-821a-aaac-4b0f" name="Nobz on Warbikes" hidden="false" collective="false" import="true" type="unit">
       <modifiers>
         <modifier type="increment" field="e356-c769-5920-6e14" value="5">
           <conditions>
@@ -2922,7 +2918,7 @@
         <categoryLink id="90ad-f00f-73ee-2e65" name="Speed Freeks" hidden="false" targetId="258d-e4cb-6f35-fe20" primary="false"/>
       </categoryLinks>
       <selectionEntries>
-        <selectionEntry id="2233-8fb9-8e15-cb48" name="Boss Nob on Warbike" hidden="false" collective="false" type="model">
+        <selectionEntry id="2233-8fb9-8e15-cb48" name="Boss Nob on Warbike" hidden="false" collective="false" import="true" type="model">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="22f6-b9b1-e430-1421" type="min"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1484-ce84-84bf-7da0" type="max"/>
@@ -2943,15 +2939,15 @@
             </profile>
           </profiles>
           <entryLinks>
-            <entryLink id="eb1b-ead6-c204-b9b9" name="Stikkbombs" hidden="false" collective="false" targetId="6df7-0ee7-7e6d-b182" type="selectionEntry"/>
-            <entryLink id="6cc3-b535-affe-34bf" name="Dakkagun" hidden="false" collective="false" targetId="de10-70b3-ab64-990c" type="selectionEntry">
+            <entryLink id="eb1b-ead6-c204-b9b9" name="Stikkbombs" hidden="false" collective="false" import="true" targetId="6df7-0ee7-7e6d-b182" type="selectionEntry"/>
+            <entryLink id="6cc3-b535-affe-34bf" name="Dakkagun" hidden="false" collective="false" import="true" targetId="de10-70b3-ab64-990c" type="selectionEntry">
               <constraints>
                 <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d9d9-509e-b4c8-a402" type="min"/>
                 <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b8c4-4280-43c1-ed4a" type="max"/>
               </constraints>
             </entryLink>
-            <entryLink id="6b4d-bfd2-823c-5391" name="Nob Arm1" hidden="false" collective="false" targetId="d4bf-a2d0-e994-1474" type="selectionEntryGroup"/>
-            <entryLink id="7659-d1e8-2f20-0812" name="Nob Arm2" hidden="false" collective="false" targetId="2fe0-1fb8-9268-f604" type="selectionEntryGroup"/>
+            <entryLink id="6b4d-bfd2-823c-5391" name="Nob Arm1" hidden="false" collective="false" import="true" targetId="d4bf-a2d0-e994-1474" type="selectionEntryGroup"/>
+            <entryLink id="7659-d1e8-2f20-0812" name="Nob Arm2" hidden="false" collective="false" import="true" targetId="2fe0-1fb8-9268-f604" type="selectionEntryGroup"/>
           </entryLinks>
           <costs>
             <cost name="pts" typeId="points" value="38.0"/>
@@ -2961,13 +2957,13 @@
         </selectionEntry>
       </selectionEntries>
       <selectionEntryGroups>
-        <selectionEntryGroup id="d66a-ba17-1247-d12f" name="Nobz" hidden="false" collective="false" defaultSelectionEntryId="04ed-04b2-3590-ad29">
+        <selectionEntryGroup id="d66a-ba17-1247-d12f" name="Nobz" hidden="false" collective="false" import="true" defaultSelectionEntryId="04ed-04b2-3590-ad29">
           <constraints>
             <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2059-9171-804b-21d8" type="min"/>
             <constraint field="selections" scope="parent" value="8.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e6a3-4fe9-99fc-8612" type="max"/>
           </constraints>
           <selectionEntries>
-            <selectionEntry id="04ed-04b2-3590-ad29" name="Nob on Warbike" hidden="false" collective="false" type="model">
+            <selectionEntry id="04ed-04b2-3590-ad29" name="Nob on Warbike" hidden="false" collective="false" import="true" type="model">
               <profiles>
                 <profile id="1153-f861-a007-2e5d" name="Nob on Warbike" hidden="false" typeId="800f-21d0-4387-c943" typeName="Unit">
                   <characteristics>
@@ -2984,15 +2980,15 @@
                 </profile>
               </profiles>
               <entryLinks>
-                <entryLink id="a885-61f1-1988-4e01" name="Stikkbombs" hidden="false" collective="false" targetId="6df7-0ee7-7e6d-b182" type="selectionEntry"/>
-                <entryLink id="733d-c452-e4c3-0676" name="Dakkagun" hidden="false" collective="false" targetId="de10-70b3-ab64-990c" type="selectionEntry">
+                <entryLink id="a885-61f1-1988-4e01" name="Stikkbombs" hidden="false" collective="false" import="true" targetId="6df7-0ee7-7e6d-b182" type="selectionEntry"/>
+                <entryLink id="733d-c452-e4c3-0676" name="Dakkagun" hidden="false" collective="false" import="true" targetId="de10-70b3-ab64-990c" type="selectionEntry">
                   <constraints>
                     <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4fae-784a-9eab-31e1" type="min"/>
                     <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c638-acc1-0af6-5546" type="max"/>
                   </constraints>
                 </entryLink>
-                <entryLink id="47bd-8ebe-4945-e2ab" name="Nob Arm1" hidden="false" collective="false" targetId="d4bf-a2d0-e994-1474" type="selectionEntryGroup"/>
-                <entryLink id="8884-4c05-95e3-3d30" name="Nob Arm2" hidden="false" collective="false" targetId="2fe0-1fb8-9268-f604" type="selectionEntryGroup"/>
+                <entryLink id="47bd-8ebe-4945-e2ab" name="Nob Arm1" hidden="false" collective="false" import="true" targetId="d4bf-a2d0-e994-1474" type="selectionEntryGroup"/>
+                <entryLink id="8884-4c05-95e3-3d30" name="Nob Arm2" hidden="false" collective="false" import="true" targetId="2fe0-1fb8-9268-f604" type="selectionEntryGroup"/>
               </entryLinks>
               <costs>
                 <cost name="pts" typeId="points" value="38.0"/>
@@ -3004,8 +3000,8 @@
         </selectionEntryGroup>
       </selectionEntryGroups>
       <entryLinks>
-        <entryLink id="095d-1a2a-124f-18b5" name="Has Battle Honours" hidden="false" collective="false" targetId="4763-757f-499f-d998" type="selectionEntry"/>
-        <entryLink id="ec52-7c70-ba67-4f28" name="Battle Honours" hidden="false" collective="false" targetId="5518-d0f5-a880-d71c" type="selectionEntryGroup"/>
+        <entryLink id="095d-1a2a-124f-18b5" name="Has Battle Honours" hidden="false" collective="false" import="true" targetId="4763-757f-499f-d998" type="selectionEntry"/>
+        <entryLink id="ec52-7c70-ba67-4f28" name="Battle Honours" hidden="false" collective="false" import="true" targetId="5518-d0f5-a880-d71c" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
         <cost name=" PL" typeId="e356-c769-5920-6e14" value="7.0"/>
@@ -3013,7 +3009,7 @@
         <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="7bd1-520c-ad45-f566" name="Burna" hidden="false" collective="true" type="upgrade">
+    <selectionEntry id="7bd1-520c-ad45-f566" name="Burna" hidden="false" collective="true" import="true" type="upgrade">
       <profiles>
         <profile id="be17-6dfc-1754-fd78" name="Burna (Shooting)" hidden="false" typeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" typeName="Weapon">
           <characteristics>
@@ -3042,7 +3038,7 @@
         <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="0d17-9ee8-267d-9824" name="Burna Boyz" hidden="false" collective="false" type="upgrade">
+    <selectionEntry id="0d17-9ee8-267d-9824" name="Burna Boyz" hidden="false" collective="false" import="true" type="upgrade">
       <modifiers>
         <modifier type="increment" field="e356-c769-5920-6e14" value="3">
           <conditions>
@@ -3075,13 +3071,13 @@
         <categoryLink id="783f-c7b5-49da-30d9" name="New CategoryLink" hidden="false" targetId="3d52-fccf-10c0-3fae" primary="false"/>
       </categoryLinks>
       <selectionEntryGroups>
-        <selectionEntryGroup id="a256-7254-b108-e19d" name="Mob" hidden="false" collective="false" defaultSelectionEntryId="a414-4fb9-c38c-09e4">
+        <selectionEntryGroup id="a256-7254-b108-e19d" name="Mob" hidden="false" collective="false" import="true" defaultSelectionEntryId="a414-4fb9-c38c-09e4">
           <constraints>
             <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9724-6cd0-dce1-70ee" type="min"/>
             <constraint field="selections" scope="parent" value="15.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="44da-aced-1711-f848" type="max"/>
           </constraints>
           <selectionEntries>
-            <selectionEntry id="a414-4fb9-c38c-09e4" name="Burna Boy" hidden="false" collective="false" type="model">
+            <selectionEntry id="a414-4fb9-c38c-09e4" name="Burna Boy" hidden="false" collective="false" import="true" type="model">
               <profiles>
                 <profile id="9228-6aba-6bb4-552a" name="Burna Boy" hidden="false" typeId="800f-21d0-4387-c943" typeName="Unit">
                   <characteristics>
@@ -3098,13 +3094,13 @@
                 </profile>
               </profiles>
               <entryLinks>
-                <entryLink id="3061-b17e-1d31-758e" name="New EntryLink" hidden="false" collective="false" targetId="7bd1-520c-ad45-f566" type="selectionEntry">
+                <entryLink id="3061-b17e-1d31-758e" name="New EntryLink" hidden="false" collective="false" import="true" targetId="7bd1-520c-ad45-f566" type="selectionEntry">
                   <constraints>
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c560-0d66-af6c-e1b5" type="min"/>
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f084-3700-8d70-d86a" type="max"/>
                   </constraints>
                 </entryLink>
-                <entryLink id="a630-3170-f229-0114" name="New EntryLink" hidden="false" collective="false" targetId="6df7-0ee7-7e6d-b182" type="selectionEntry"/>
+                <entryLink id="a630-3170-f229-0114" name="New EntryLink" hidden="false" collective="false" import="true" targetId="6df7-0ee7-7e6d-b182" type="selectionEntry"/>
               </entryLinks>
               <costs>
                 <cost name="pts" typeId="points" value="12.0"/>
@@ -3112,7 +3108,7 @@
                 <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
               </costs>
             </selectionEntry>
-            <selectionEntry id="09d8-2a77-2b7c-5dbe" name="Spanner" hidden="false" collective="false" type="model">
+            <selectionEntry id="09d8-2a77-2b7c-5dbe" name="Spanner" hidden="false" collective="false" import="true" type="model">
               <modifiers>
                 <modifier type="increment" field="652f-a9e3-0185-f12b" value="1">
                   <repeats>
@@ -3142,34 +3138,34 @@
                 <infoLink id="43a9-9999-9d7a-17f9" name="New InfoLink" hidden="false" targetId="e5ad-516c-ad0a-54a1" type="profile"/>
               </infoLinks>
               <selectionEntryGroups>
-                <selectionEntryGroup id="19fe-7aaf-3a08-75c8" name="Arm 1 (Index)" hidden="false" collective="false">
+                <selectionEntryGroup id="19fe-7aaf-3a08-75c8" name="Arm 1 (Index)" hidden="false" collective="false" import="true">
                   <constraints>
                     <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1256-b6e1-2402-d982" type="min"/>
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="72b4-ff0d-b639-7a9d" type="max"/>
                   </constraints>
                   <entryLinks>
-                    <entryLink id="3771-04f9-64a1-3fc3" name="New EntryLink" hidden="false" collective="false" targetId="c4df-c43d-08a6-18ab" type="selectionEntry"/>
-                    <entryLink id="911b-2f9b-c062-a810" name="Killsaw" hidden="false" collective="false" targetId="f15a-fc8e-65b1-e4b8" type="selectionEntry"/>
+                    <entryLink id="3771-04f9-64a1-3fc3" name="New EntryLink" hidden="false" collective="false" import="true" targetId="c4df-c43d-08a6-18ab" type="selectionEntry"/>
+                    <entryLink id="911b-2f9b-c062-a810" name="Killsaw" hidden="false" collective="false" import="true" targetId="f15a-fc8e-65b1-e4b8" type="selectionEntry"/>
                   </entryLinks>
                 </selectionEntryGroup>
-                <selectionEntryGroup id="d06c-7a8d-fe75-8e5e" name="Arm 2" hidden="false" collective="false" defaultSelectionEntryId="4ce1-7bdb-66ab-d94a">
+                <selectionEntryGroup id="d06c-7a8d-fe75-8e5e" name="Arm 2" hidden="false" collective="false" import="true" defaultSelectionEntryId="4ce1-7bdb-66ab-d94a">
                   <constraints>
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="521d-ca69-8d8d-9e03" type="min"/>
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0281-e31a-6535-5331" type="max"/>
                   </constraints>
                   <entryLinks>
-                    <entryLink id="5c8c-da34-3366-e1fb" name="Slugga (Index)" hidden="false" collective="false" targetId="b618-ec7e-d5cd-56ad" type="selectionEntry"/>
-                    <entryLink id="20a1-157b-2e57-6f0b" name="Kombi-Rokkit (Index)" hidden="false" collective="false" targetId="b427-a07f-0027-e062" type="selectionEntry"/>
-                    <entryLink id="a294-3a38-b526-f258" name="Kombi-Skorcha (Index)" hidden="false" collective="false" targetId="bb1b-00f0-1da0-824c" type="selectionEntry"/>
-                    <entryLink id="4ce1-7bdb-66ab-d94a" name="Kustom Mega-blasta" hidden="false" collective="false" targetId="6d70-25a8-b496-2457" type="selectionEntry"/>
-                    <entryLink id="7692-550d-3159-e087" name="Kustom Mega-Slugga (Index)" hidden="false" collective="false" targetId="f0cf-1bde-c442-378a" type="selectionEntry"/>
-                    <entryLink id="a2ec-451d-94de-a0c7" name="Rokkit Launcha" hidden="false" collective="false" targetId="a8c1-7fb9-7f7b-84c5" type="selectionEntry"/>
-                    <entryLink id="c2b7-d181-cd6f-4b5e" name="Big Shoota" hidden="false" collective="false" targetId="6008-4737-d8e6-e63b" type="selectionEntry"/>
+                    <entryLink id="5c8c-da34-3366-e1fb" name="Slugga (Index)" hidden="false" collective="false" import="true" targetId="b618-ec7e-d5cd-56ad" type="selectionEntry"/>
+                    <entryLink id="20a1-157b-2e57-6f0b" name="Kombi-Rokkit (Index)" hidden="false" collective="false" import="true" targetId="b427-a07f-0027-e062" type="selectionEntry"/>
+                    <entryLink id="a294-3a38-b526-f258" name="Kombi-Skorcha (Index)" hidden="false" collective="false" import="true" targetId="bb1b-00f0-1da0-824c" type="selectionEntry"/>
+                    <entryLink id="4ce1-7bdb-66ab-d94a" name="Kustom Mega-blasta" hidden="false" collective="false" import="true" targetId="6d70-25a8-b496-2457" type="selectionEntry"/>
+                    <entryLink id="7692-550d-3159-e087" name="Kustom Mega-Slugga (Index)" hidden="false" collective="false" import="true" targetId="f0cf-1bde-c442-378a" type="selectionEntry"/>
+                    <entryLink id="a2ec-451d-94de-a0c7" name="Rokkit Launcha" hidden="false" collective="false" import="true" targetId="a8c1-7fb9-7f7b-84c5" type="selectionEntry"/>
+                    <entryLink id="c2b7-d181-cd6f-4b5e" name="Big Shoota" hidden="false" collective="false" import="true" targetId="6008-4737-d8e6-e63b" type="selectionEntry"/>
                   </entryLinks>
                 </selectionEntryGroup>
               </selectionEntryGroups>
               <entryLinks>
-                <entryLink id="b879-efce-8c9b-1564" name="Stikkbombs" hidden="false" collective="false" targetId="6df7-0ee7-7e6d-b182" type="selectionEntry">
+                <entryLink id="b879-efce-8c9b-1564" name="Stikkbombs" hidden="false" collective="false" import="true" targetId="6df7-0ee7-7e6d-b182" type="selectionEntry">
                   <constraints>
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a84b-8c94-d37c-b92b" type="max"/>
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0a2a-0ef4-4121-4ff2" type="min"/>
@@ -3186,8 +3182,8 @@
         </selectionEntryGroup>
       </selectionEntryGroups>
       <entryLinks>
-        <entryLink id="9bc1-5ee5-5254-7c1a" name="Has Battle Honours" hidden="false" collective="false" targetId="4763-757f-499f-d998" type="selectionEntry"/>
-        <entryLink id="1ce6-b0ab-4395-3b7f" name="Battle Honours" hidden="false" collective="false" targetId="5518-d0f5-a880-d71c" type="selectionEntryGroup"/>
+        <entryLink id="9bc1-5ee5-5254-7c1a" name="Has Battle Honours" hidden="false" collective="false" import="true" targetId="4763-757f-499f-d998" type="selectionEntry"/>
+        <entryLink id="1ce6-b0ab-4395-3b7f" name="Battle Honours" hidden="false" collective="false" import="true" targetId="5518-d0f5-a880-d71c" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
         <cost name=" PL" typeId="e356-c769-5920-6e14" value="3.0"/>
@@ -3195,7 +3191,7 @@
         <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="0572-1c5b-45dc-ceed" name="Killsaws (Pair)" hidden="false" collective="false" type="upgrade">
+    <selectionEntry id="0572-1c5b-45dc-ceed" name="Killsaws (Pair)" hidden="false" collective="false" import="true" type="upgrade">
       <profiles>
         <profile id="8c31-4c49-4e90-e14d" name="Killsaws (Pair)" hidden="false" typeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" typeName="Weapon">
           <characteristics>
@@ -3214,7 +3210,7 @@
         <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="271f-ceb6-0cde-d108" name="Meganobz" hidden="false" collective="false" type="unit">
+    <selectionEntry id="271f-ceb6-0cde-d108" name="Meganobz" hidden="false" collective="false" import="true" type="unit">
       <infoLinks>
         <infoLink id="6120-2d58-23fb-6677" name="New InfoLink" hidden="false" targetId="de72-9941-3d27-44e9" type="rule"/>
         <infoLink id="e84d-0f11-335a-c22d" name="New InfoLink" hidden="false" targetId="ad32-a248-a392-3d4a" type="rule"/>
@@ -3231,13 +3227,13 @@
         <categoryLink id="720c-27cc-7328-b4a8" name="New CategoryLink" hidden="false" targetId="2592-330f-3727-4018" primary="false"/>
       </categoryLinks>
       <selectionEntryGroups>
-        <selectionEntryGroup id="37ed-62d1-3693-f1fa" name="Meganobz" hidden="false" collective="false" defaultSelectionEntryId="4229-c829-f56d-ba35">
+        <selectionEntryGroup id="37ed-62d1-3693-f1fa" name="Meganobz" hidden="false" collective="false" import="true" defaultSelectionEntryId="4229-c829-f56d-ba35">
           <constraints>
             <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0543-0178-cc16-fa0e" type="min"/>
             <constraint field="selections" scope="parent" value="9.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f31a-acba-7eb3-4ee7" type="max"/>
           </constraints>
           <selectionEntries>
-            <selectionEntry id="4229-c829-f56d-ba35" name="Meganob W/ PK" hidden="false" collective="false" type="model">
+            <selectionEntry id="4229-c829-f56d-ba35" name="Meganob W/ PK" hidden="false" collective="false" import="true" type="model">
               <profiles>
                 <profile id="7d31-2105-f6f1-0df4" name="Meganob" hidden="false" typeId="800f-21d0-4387-c943" typeName="Unit">
                   <characteristics>
@@ -3254,21 +3250,21 @@
                 </profile>
               </profiles>
               <selectionEntryGroups>
-                <selectionEntryGroup id="b86f-7d08-3b16-ea98" name="Shoota Arm" hidden="false" collective="false" defaultSelectionEntryId="96e8-8eb4-a488-e1a0">
+                <selectionEntryGroup id="b86f-7d08-3b16-ea98" name="Shoota Arm" hidden="false" collective="false" import="true" defaultSelectionEntryId="96e8-8eb4-a488-e1a0">
                   <constraints>
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3bbf-c443-07e9-7c6d" type="min"/>
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4ef6-b1f0-fc27-8610" type="max"/>
                   </constraints>
                   <entryLinks>
-                    <entryLink id="96e8-8eb4-a488-e1a0" name="Kustom Shoota" hidden="false" collective="false" targetId="df47-a9ec-a22e-a2b6" type="selectionEntry"/>
-                    <entryLink id="4cfd-9ac0-9622-111c" name="New EntryLink" hidden="false" collective="false" targetId="3511-0070-0667-abf2" type="selectionEntry"/>
-                    <entryLink id="bfbf-9d12-bf91-34ad" name="New EntryLink" hidden="false" collective="false" targetId="b6c7-06c8-b7fb-05a7" type="selectionEntry"/>
+                    <entryLink id="96e8-8eb4-a488-e1a0" name="Kustom Shoota" hidden="false" collective="false" import="true" targetId="df47-a9ec-a22e-a2b6" type="selectionEntry"/>
+                    <entryLink id="4cfd-9ac0-9622-111c" name="New EntryLink" hidden="false" collective="false" import="true" targetId="3511-0070-0667-abf2" type="selectionEntry"/>
+                    <entryLink id="bfbf-9d12-bf91-34ad" name="New EntryLink" hidden="false" collective="false" import="true" targetId="b6c7-06c8-b7fb-05a7" type="selectionEntry"/>
                   </entryLinks>
                 </selectionEntryGroup>
               </selectionEntryGroups>
               <entryLinks>
-                <entryLink id="e3ac-3133-7664-d106" name="New EntryLink" hidden="false" collective="false" targetId="6df7-0ee7-7e6d-b182" type="selectionEntry"/>
-                <entryLink id="423c-d862-05af-92f3" name="New EntryLink" hidden="false" collective="false" targetId="fe00-451f-6735-6fd9" type="selectionEntry">
+                <entryLink id="e3ac-3133-7664-d106" name="New EntryLink" hidden="false" collective="false" import="true" targetId="6df7-0ee7-7e6d-b182" type="selectionEntry"/>
+                <entryLink id="423c-d862-05af-92f3" name="New EntryLink" hidden="false" collective="false" import="true" targetId="fe00-451f-6735-6fd9" type="selectionEntry">
                   <constraints>
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="49f5-a22c-ec31-dd50" type="min"/>
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7723-127b-2899-41bd" type="max"/>
@@ -3281,7 +3277,7 @@
                 <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
               </costs>
             </selectionEntry>
-            <selectionEntry id="90dc-635e-f0e5-8309" name="Meganob w/ Saws" hidden="false" collective="false" type="model">
+            <selectionEntry id="90dc-635e-f0e5-8309" name="Meganob w/ Saws" hidden="false" collective="false" import="true" type="model">
               <profiles>
                 <profile id="f919-b30e-b70e-a2b3" name="Meganob" hidden="false" typeId="800f-21d0-4387-c943" typeName="Unit">
                   <characteristics>
@@ -3298,8 +3294,8 @@
                 </profile>
               </profiles>
               <entryLinks>
-                <entryLink id="5f69-10a0-cc82-82e2" name="New EntryLink" hidden="false" collective="false" targetId="6df7-0ee7-7e6d-b182" type="selectionEntry"/>
-                <entryLink id="0ecd-0926-bac5-c052" name="Killsaws (Pair)" hidden="false" collective="false" targetId="0572-1c5b-45dc-ceed" type="selectionEntry">
+                <entryLink id="5f69-10a0-cc82-82e2" name="New EntryLink" hidden="false" collective="false" import="true" targetId="6df7-0ee7-7e6d-b182" type="selectionEntry"/>
+                <entryLink id="0ecd-0926-bac5-c052" name="Killsaws (Pair)" hidden="false" collective="false" import="true" targetId="0572-1c5b-45dc-ceed" type="selectionEntry">
                   <constraints>
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0c7b-fa48-5718-6882" type="min"/>
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="598b-5d91-7bd7-e966" type="max"/>
@@ -3314,13 +3310,13 @@
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
-        <selectionEntryGroup id="afa0-14cf-b0ea-02c4" name="Boss" hidden="false" collective="false" defaultSelectionEntryId="24d7-2d05-fcf7-f383">
+        <selectionEntryGroup id="afa0-14cf-b0ea-02c4" name="Boss" hidden="false" collective="false" import="true" defaultSelectionEntryId="24d7-2d05-fcf7-f383">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ce34-95ac-196b-b6e5" type="min"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5ad7-346d-da87-68f3" type="max"/>
           </constraints>
           <selectionEntries>
-            <selectionEntry id="24d7-2d05-fcf7-f383" name="Boss Meganob w/ PK" hidden="false" collective="false" type="model">
+            <selectionEntry id="24d7-2d05-fcf7-f383" name="Boss Meganob w/ PK" hidden="false" collective="false" import="true" type="model">
               <profiles>
                 <profile id="d2d7-6a8a-207b-cd6a" name="Boss Meganob" hidden="false" typeId="800f-21d0-4387-c943" typeName="Unit">
                   <characteristics>
@@ -3337,21 +3333,21 @@
                 </profile>
               </profiles>
               <selectionEntryGroups>
-                <selectionEntryGroup id="7a58-ec01-70d7-bbbc" name="Shoota Arm" hidden="false" collective="false" defaultSelectionEntryId="7e94-cc31-c643-dba7">
+                <selectionEntryGroup id="7a58-ec01-70d7-bbbc" name="Shoota Arm" hidden="false" collective="false" import="true" defaultSelectionEntryId="7e94-cc31-c643-dba7">
                   <constraints>
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="26f5-732c-a257-6c4b" type="min"/>
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="af20-6740-0966-30b4" type="max"/>
                   </constraints>
                   <entryLinks>
-                    <entryLink id="7e94-cc31-c643-dba7" name="New EntryLink" hidden="false" collective="false" targetId="df47-a9ec-a22e-a2b6" type="selectionEntry"/>
-                    <entryLink id="2e82-e685-84ab-31ef" name="New EntryLink" hidden="false" collective="false" targetId="3511-0070-0667-abf2" type="selectionEntry"/>
-                    <entryLink id="4442-0ac8-4b88-7cb0" name="New EntryLink" hidden="false" collective="false" targetId="b6c7-06c8-b7fb-05a7" type="selectionEntry"/>
+                    <entryLink id="7e94-cc31-c643-dba7" name="New EntryLink" hidden="false" collective="false" import="true" targetId="df47-a9ec-a22e-a2b6" type="selectionEntry"/>
+                    <entryLink id="2e82-e685-84ab-31ef" name="New EntryLink" hidden="false" collective="false" import="true" targetId="3511-0070-0667-abf2" type="selectionEntry"/>
+                    <entryLink id="4442-0ac8-4b88-7cb0" name="New EntryLink" hidden="false" collective="false" import="true" targetId="b6c7-06c8-b7fb-05a7" type="selectionEntry"/>
                   </entryLinks>
                 </selectionEntryGroup>
               </selectionEntryGroups>
               <entryLinks>
-                <entryLink id="088c-8c82-81fa-6b1f" name="New EntryLink" hidden="false" collective="false" targetId="6df7-0ee7-7e6d-b182" type="selectionEntry"/>
-                <entryLink id="44ca-04e9-871b-8104" name="New EntryLink" hidden="false" collective="false" targetId="fe00-451f-6735-6fd9" type="selectionEntry">
+                <entryLink id="088c-8c82-81fa-6b1f" name="New EntryLink" hidden="false" collective="false" import="true" targetId="6df7-0ee7-7e6d-b182" type="selectionEntry"/>
+                <entryLink id="44ca-04e9-871b-8104" name="New EntryLink" hidden="false" collective="false" import="true" targetId="fe00-451f-6735-6fd9" type="selectionEntry">
                   <constraints>
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="423a-2744-63b4-83db" type="min"/>
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6095-ea18-7bd5-82f1" type="max"/>
@@ -3364,7 +3360,7 @@
                 <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
               </costs>
             </selectionEntry>
-            <selectionEntry id="8699-0767-b30c-d829" name="Boss Meganob w/ Saws" hidden="false" collective="false" type="model">
+            <selectionEntry id="8699-0767-b30c-d829" name="Boss Meganob w/ Saws" hidden="false" collective="false" import="true" type="model">
               <profiles>
                 <profile id="4a09-f5a3-7e19-3af7" name="Boss Meganob" hidden="false" typeId="800f-21d0-4387-c943" typeName="Unit">
                   <characteristics>
@@ -3381,8 +3377,8 @@
                 </profile>
               </profiles>
               <entryLinks>
-                <entryLink id="aac5-54f6-835a-02ed" name="New EntryLink" hidden="false" collective="false" targetId="6df7-0ee7-7e6d-b182" type="selectionEntry"/>
-                <entryLink id="6aa8-abdd-16ed-feea" name="New EntryLink" hidden="false" collective="false" targetId="0572-1c5b-45dc-ceed" type="selectionEntry">
+                <entryLink id="aac5-54f6-835a-02ed" name="New EntryLink" hidden="false" collective="false" import="true" targetId="6df7-0ee7-7e6d-b182" type="selectionEntry"/>
+                <entryLink id="6aa8-abdd-16ed-feea" name="New EntryLink" hidden="false" collective="false" import="true" targetId="0572-1c5b-45dc-ceed" type="selectionEntry">
                   <constraints>
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9baa-0e46-c777-e80f" type="min"/>
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="590c-4161-f9ac-9ff4" type="max"/>
@@ -3399,8 +3395,8 @@
         </selectionEntryGroup>
       </selectionEntryGroups>
       <entryLinks>
-        <entryLink id="ce0a-7b92-d0ed-88d2" name="Has Battle Honours" hidden="false" collective="false" targetId="4763-757f-499f-d998" type="selectionEntry"/>
-        <entryLink id="24c4-b55a-dd33-cfad" name="Battle Honours" hidden="false" collective="false" targetId="5518-d0f5-a880-d71c" type="selectionEntryGroup"/>
+        <entryLink id="ce0a-7b92-d0ed-88d2" name="Has Battle Honours" hidden="false" collective="false" import="true" targetId="4763-757f-499f-d998" type="selectionEntry"/>
+        <entryLink id="24c4-b55a-dd33-cfad" name="Battle Honours" hidden="false" collective="false" import="true" targetId="5518-d0f5-a880-d71c" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
@@ -3408,7 +3404,7 @@
         <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="2056-01cf-da87-974d" name="Kommandos" hidden="false" collective="false" type="unit">
+    <selectionEntry id="2056-01cf-da87-974d" name="Kommandos" hidden="false" collective="false" import="true" type="unit">
       <modifiers>
         <modifier type="increment" field="e356-c769-5920-6e14" value="2">
           <conditions>
@@ -3447,30 +3443,30 @@
         <categoryLink id="b441-4189-819e-64ba" name="New CategoryLink" hidden="false" targetId="690d-100a-7666-c71c" primary="false"/>
       </categoryLinks>
       <selectionEntryGroups>
-        <selectionEntryGroup id="bada-a6fc-96ea-3b1b" name="Mob" hidden="false" collective="false" defaultSelectionEntryId="b855-41f8-85b0-a5fe">
+        <selectionEntryGroup id="bada-a6fc-96ea-3b1b" name="Mob" hidden="false" collective="false" import="true" defaultSelectionEntryId="b855-41f8-85b0-a5fe">
           <constraints>
             <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f6e2-620a-345d-3d6a" type="min"/>
             <constraint field="selections" scope="parent" value="15.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1db8-996c-4b07-b963" type="max"/>
           </constraints>
           <selectionEntries>
-            <selectionEntry id="b855-41f8-85b0-a5fe" name="Kommando" hidden="false" collective="false" type="model">
+            <selectionEntry id="b855-41f8-85b0-a5fe" name="Kommando" hidden="false" collective="false" import="true" type="model">
               <infoLinks>
                 <infoLink id="5a3a-7c71-586d-1a83" name="New InfoLink" hidden="false" targetId="196e-c57d-35ed-3755" type="profile"/>
               </infoLinks>
               <entryLinks>
-                <entryLink id="36b4-50b7-73eb-3459" name="New EntryLink" hidden="false" collective="false" targetId="c025-0c89-05db-fccb" type="selectionEntry">
+                <entryLink id="36b4-50b7-73eb-3459" name="New EntryLink" hidden="false" collective="false" import="true" targetId="c025-0c89-05db-fccb" type="selectionEntry">
                   <constraints>
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="af32-2825-10ad-aa2a" type="min"/>
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8169-9f8f-c9df-969b" type="max"/>
                   </constraints>
                 </entryLink>
-                <entryLink id="cc25-b97f-445e-f9ac" name="Slugga" hidden="false" collective="false" targetId="1b13-84df-f255-b206" type="selectionEntry">
+                <entryLink id="cc25-b97f-445e-f9ac" name="Slugga" hidden="false" collective="false" import="true" targetId="1b13-84df-f255-b206" type="selectionEntry">
                   <constraints>
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="df0a-7c01-904c-57ee" type="min"/>
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="97e3-dca0-c712-65d9" type="max"/>
                   </constraints>
                 </entryLink>
-                <entryLink id="c613-af7e-a647-045d" name="Stikkbombs" hidden="false" collective="false" targetId="6df7-0ee7-7e6d-b182" type="selectionEntry">
+                <entryLink id="c613-af7e-a647-045d" name="Stikkbombs" hidden="false" collective="false" import="true" targetId="6df7-0ee7-7e6d-b182" type="selectionEntry">
                   <constraints>
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="856f-6564-d984-e3f8" type="max"/>
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c870-df28-f064-43fa" type="min"/>
@@ -3483,7 +3479,7 @@
                 <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
               </costs>
             </selectionEntry>
-            <selectionEntry id="8945-e2c6-cece-13fd" name="Kommando W/ &apos;Eavy Weapon (Index)" hidden="false" collective="false" type="model">
+            <selectionEntry id="8945-e2c6-cece-13fd" name="Kommando W/ &apos;Eavy Weapon (Index)" hidden="false" collective="false" import="true" type="model">
               <constraints>
                 <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c821-1eb9-e0fc-906f" type="max"/>
               </constraints>
@@ -3491,21 +3487,21 @@
                 <infoLink id="e35b-5979-13be-16ad" name="New InfoLink" hidden="false" targetId="196e-c57d-35ed-3755" type="profile"/>
               </infoLinks>
               <selectionEntryGroups>
-                <selectionEntryGroup id="d6b1-0fd6-c79a-63b1" name="&apos;Eavy Weapon" hidden="false" collective="false" defaultSelectionEntryId="61ab-643c-23e6-0057">
+                <selectionEntryGroup id="d6b1-0fd6-c79a-63b1" name="&apos;Eavy Weapon" hidden="false" collective="false" import="true" defaultSelectionEntryId="61ab-643c-23e6-0057">
                   <constraints>
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4edd-c8a4-9498-7acf" type="min"/>
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8f54-b875-3be6-d903" type="max"/>
                   </constraints>
                   <entryLinks>
-                    <entryLink id="61ab-643c-23e6-0057" name="New EntryLink" hidden="false" collective="false" targetId="2278-28c8-44bf-e10a" type="selectionEntry"/>
-                    <entryLink id="5b3a-4049-c870-ca8d" name="New EntryLink" hidden="false" collective="false" targetId="6008-4737-d8e6-e63b" type="selectionEntry"/>
-                    <entryLink id="111b-4ca8-4862-fff7" name="New EntryLink" hidden="false" collective="false" targetId="a8c1-7fb9-7f7b-84c5" type="selectionEntry"/>
+                    <entryLink id="61ab-643c-23e6-0057" name="New EntryLink" hidden="false" collective="false" import="true" targetId="2278-28c8-44bf-e10a" type="selectionEntry"/>
+                    <entryLink id="5b3a-4049-c870-ca8d" name="New EntryLink" hidden="false" collective="false" import="true" targetId="6008-4737-d8e6-e63b" type="selectionEntry"/>
+                    <entryLink id="111b-4ca8-4862-fff7" name="New EntryLink" hidden="false" collective="false" import="true" targetId="a8c1-7fb9-7f7b-84c5" type="selectionEntry"/>
                   </entryLinks>
                 </selectionEntryGroup>
               </selectionEntryGroups>
               <entryLinks>
-                <entryLink id="fe57-477e-5eab-b5f9" name="Stikkbombs" hidden="false" collective="false" targetId="6df7-0ee7-7e6d-b182" type="selectionEntry"/>
-                <entryLink id="919c-e4c5-7a99-4785" name="New EntryLink" hidden="false" collective="false" targetId="c025-0c89-05db-fccb" type="selectionEntry">
+                <entryLink id="fe57-477e-5eab-b5f9" name="Stikkbombs" hidden="false" collective="false" import="true" targetId="6df7-0ee7-7e6d-b182" type="selectionEntry"/>
+                <entryLink id="919c-e4c5-7a99-4785" name="New EntryLink" hidden="false" collective="false" import="true" targetId="c025-0c89-05db-fccb" type="selectionEntry">
                   <constraints>
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="905f-a711-0867-92dd" type="min"/>
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6d67-d2df-eefb-e410" type="max"/>
@@ -3518,7 +3514,7 @@
                 <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
               </costs>
             </selectionEntry>
-            <selectionEntry id="f495-e644-d09a-aff1" name="Boss Nob" hidden="false" collective="false" type="model">
+            <selectionEntry id="f495-e644-d09a-aff1" name="Boss Nob" hidden="false" collective="false" import="true" type="model">
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6119-0e0a-df9d-be8d" type="max"/>
               </constraints>
@@ -3538,21 +3534,21 @@
                 </profile>
               </profiles>
               <selectionEntryGroups>
-                <selectionEntryGroup id="8077-ac94-dcdd-4d66" name="Choppa Arm (Index)" hidden="false" collective="false" defaultSelectionEntryId="7aff-b7ac-bd18-c981">
+                <selectionEntryGroup id="8077-ac94-dcdd-4d66" name="Choppa Arm (Index)" hidden="false" collective="false" import="true" defaultSelectionEntryId="7aff-b7ac-bd18-c981">
                   <constraints>
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="00d3-92d6-6921-9331" type="max"/>
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5f3c-1b2c-0da2-436b" type="min"/>
                   </constraints>
                   <entryLinks>
-                    <entryLink id="e4f7-e4f1-e412-f4f2" name="New EntryLink" hidden="false" collective="false" targetId="c4df-c43d-08a6-18ab" type="selectionEntry"/>
-                    <entryLink id="9913-6083-0ea5-1986" name="New EntryLink" hidden="false" collective="false" targetId="0470-1b47-489b-14c9" type="selectionEntry"/>
-                    <entryLink id="7aff-b7ac-bd18-c981" name="New EntryLink" hidden="false" collective="false" targetId="fe00-451f-6735-6fd9" type="selectionEntry"/>
+                    <entryLink id="e4f7-e4f1-e412-f4f2" name="New EntryLink" hidden="false" collective="false" import="true" targetId="c4df-c43d-08a6-18ab" type="selectionEntry"/>
+                    <entryLink id="9913-6083-0ea5-1986" name="New EntryLink" hidden="false" collective="false" import="true" targetId="0470-1b47-489b-14c9" type="selectionEntry"/>
+                    <entryLink id="7aff-b7ac-bd18-c981" name="New EntryLink" hidden="false" collective="false" import="true" targetId="fe00-451f-6735-6fd9" type="selectionEntry"/>
                   </entryLinks>
                 </selectionEntryGroup>
               </selectionEntryGroups>
               <entryLinks>
-                <entryLink id="4cc7-5754-566b-1e31" name="New EntryLink" hidden="false" collective="false" targetId="6df7-0ee7-7e6d-b182" type="selectionEntry"/>
-                <entryLink id="6576-ebf9-47c0-3fb0" name="New EntryLink" hidden="false" collective="false" targetId="1b13-84df-f255-b206" type="selectionEntry">
+                <entryLink id="4cc7-5754-566b-1e31" name="New EntryLink" hidden="false" collective="false" import="true" targetId="6df7-0ee7-7e6d-b182" type="selectionEntry"/>
+                <entryLink id="6576-ebf9-47c0-3fb0" name="New EntryLink" hidden="false" collective="false" import="true" targetId="1b13-84df-f255-b206" type="selectionEntry">
                   <constraints>
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="90eb-e029-adc0-0212" type="min"/>
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d676-40b2-6607-522d" type="max"/>
@@ -3569,7 +3565,7 @@
         </selectionEntryGroup>
       </selectionEntryGroups>
       <entryLinks>
-        <entryLink id="d1cb-8f0c-abf8-327a" name="Tankbusta Bombs" hidden="false" collective="false" targetId="d4ec-cdd8-004f-a8ab" type="selectionEntry">
+        <entryLink id="d1cb-8f0c-abf8-327a" name="Tankbusta Bombs" hidden="false" collective="false" import="true" targetId="d4ec-cdd8-004f-a8ab" type="selectionEntry">
           <modifiers>
             <modifier type="increment" field="f720-5f33-ad30-aef8" value="1">
               <repeats>
@@ -3581,8 +3577,8 @@
             <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f720-5f33-ad30-aef8" type="max"/>
           </constraints>
         </entryLink>
-        <entryLink id="d983-8bd4-6153-a8bd" name="Has Battle Honours" hidden="false" collective="false" targetId="4763-757f-499f-d998" type="selectionEntry"/>
-        <entryLink id="75e7-8c02-d7b4-aa46" name="Battle Honours" hidden="false" collective="false" targetId="5518-d0f5-a880-d71c" type="selectionEntryGroup"/>
+        <entryLink id="d983-8bd4-6153-a8bd" name="Has Battle Honours" hidden="false" collective="false" import="true" targetId="4763-757f-499f-d998" type="selectionEntry"/>
+        <entryLink id="75e7-8c02-d7b4-aa46" name="Battle Honours" hidden="false" collective="false" import="true" targetId="5518-d0f5-a880-d71c" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
         <cost name=" PL" typeId="e356-c769-5920-6e14" value="2.0"/>
@@ -3590,7 +3586,7 @@
         <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="2278-28c8-44bf-e10a" name="Burna" hidden="false" collective="false" type="upgrade">
+    <selectionEntry id="2278-28c8-44bf-e10a" name="Burna" hidden="false" collective="false" import="true" type="upgrade">
       <profiles>
         <profile id="aac2-183a-c727-7247" name="Burna (Shooting)" hidden="false" typeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" typeName="Weapon">
           <characteristics>
@@ -3619,7 +3615,7 @@
         <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="7945-13e5-5ad9-1667" name="Trukk" hidden="false" collective="false" type="unit">
+    <selectionEntry id="7945-13e5-5ad9-1667" name="Trukk" hidden="false" collective="false" import="true" type="unit">
       <profiles>
         <profile id="b531-fbbd-a5c5-a83c" name="Trukk" hidden="false" typeId="800f-21d0-4387-c943" typeName="Unit">
           <characteristics>
@@ -3683,7 +3679,7 @@
         <categoryLink id="6c58-1e96-7a1f-64f7" name="New CategoryLink" hidden="false" targetId="1b66-3f5f-6705-079a" primary="true"/>
       </categoryLinks>
       <selectionEntries>
-        <selectionEntry id="863d-1d45-a29f-eece" name="Stickbomb Chucka" hidden="false" collective="false" type="upgrade">
+        <selectionEntry id="863d-1d45-a29f-eece" name="Stickbomb Chucka" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="985c-bdfd-dca9-797a" type="max"/>
           </constraints>
@@ -3707,22 +3703,22 @@
         </selectionEntry>
       </selectionEntries>
       <selectionEntryGroups>
-        <selectionEntryGroup id="c416-3868-fde9-5ac2" name="Gun" hidden="false" collective="false" defaultSelectionEntryId="5e5f-5957-318f-4583">
+        <selectionEntryGroup id="c416-3868-fde9-5ac2" name="Gun" hidden="false" collective="false" import="true" defaultSelectionEntryId="5e5f-5957-318f-4583">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4197-1156-f427-6d12" type="min"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d0d6-6504-baf6-c32b" type="max"/>
           </constraints>
           <entryLinks>
-            <entryLink id="5e5f-5957-318f-4583" name="Big Shoota" hidden="false" collective="false" targetId="6008-4737-d8e6-e63b" type="selectionEntry"/>
-            <entryLink id="a7e2-a13f-92ae-154b" name="Rokkit Launcha (Index)" hidden="false" collective="false" targetId="5fbe-d76c-183e-3413" type="selectionEntry"/>
+            <entryLink id="5e5f-5957-318f-4583" name="Big Shoota" hidden="false" collective="false" import="true" targetId="6008-4737-d8e6-e63b" type="selectionEntry"/>
+            <entryLink id="a7e2-a13f-92ae-154b" name="Rokkit Launcha (Index)" hidden="false" collective="false" import="true" targetId="5fbe-d76c-183e-3413" type="selectionEntry"/>
           </entryLinks>
         </selectionEntryGroup>
-        <selectionEntryGroup id="c44e-6a3f-62f6-8866" name="CC Weapon" hidden="false" collective="false">
+        <selectionEntryGroup id="c44e-6a3f-62f6-8866" name="CC Weapon" hidden="false" collective="false" import="true">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7a59-47d2-3503-21bf" type="max"/>
           </constraints>
           <selectionEntries>
-            <selectionEntry id="452b-8498-fcfe-ddc6" name="Grabbin&apos; Klaw" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="452b-8498-fcfe-ddc6" name="Grabbin&apos; Klaw" hidden="false" collective="false" import="true" type="upgrade">
               <profiles>
                 <profile id="e99f-0abd-4820-3283" name="Grabbin&apos; Klaw" hidden="false" typeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" typeName="Weapon">
                   <characteristics>
@@ -3743,13 +3739,13 @@
             </selectionEntry>
           </selectionEntries>
           <entryLinks>
-            <entryLink id="41b0-b1db-f897-e9ad" name="Wreckin&apos; Ball" hidden="false" collective="false" targetId="afdc-8903-044a-a42e" type="selectionEntry"/>
+            <entryLink id="41b0-b1db-f897-e9ad" name="Wreckin&apos; Ball" hidden="false" collective="false" import="true" targetId="afdc-8903-044a-a42e" type="selectionEntry"/>
           </entryLinks>
         </selectionEntryGroup>
       </selectionEntryGroups>
       <entryLinks>
-        <entryLink id="1196-c06f-962d-f304" name="Has Battle Honours" hidden="false" collective="false" targetId="4763-757f-499f-d998" type="selectionEntry"/>
-        <entryLink id="5f2a-a8a3-4b2f-f831" name="Battle Honours" hidden="false" collective="false" targetId="5518-d0f5-a880-d71c" type="selectionEntryGroup"/>
+        <entryLink id="1196-c06f-962d-f304" name="Has Battle Honours" hidden="false" collective="false" import="true" targetId="4763-757f-499f-d998" type="selectionEntry"/>
+        <entryLink id="5f2a-a8a3-4b2f-f831" name="Battle Honours" hidden="false" collective="false" import="true" targetId="5518-d0f5-a880-d71c" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="points" value="59.0"/>
@@ -3757,7 +3753,7 @@
         <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="28e9-a883-f67f-ff5a" name="Stormboyz" hidden="false" collective="false" type="unit">
+    <selectionEntry id="28e9-a883-f67f-ff5a" name="Stormboyz" hidden="false" collective="false" import="true" type="unit">
       <modifiers>
         <modifier type="increment" field="e356-c769-5920-6e14" value="2">
           <conditions>
@@ -3802,13 +3798,13 @@
         <categoryLink id="a370-dda1-f4b0-d785" name="New CategoryLink" hidden="false" targetId="3117-16d8-fcef-4f56" primary="false"/>
       </categoryLinks>
       <selectionEntryGroups>
-        <selectionEntryGroup id="9239-8718-104d-ec83" name="Mob" hidden="false" collective="false" defaultSelectionEntryId="5358-c411-cbcf-9fe0">
+        <selectionEntryGroup id="9239-8718-104d-ec83" name="Mob" hidden="false" collective="false" import="true" defaultSelectionEntryId="5358-c411-cbcf-9fe0">
           <constraints>
             <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4b99-1b2d-740b-332b" type="min"/>
             <constraint field="selections" scope="parent" value="30.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="80f0-4268-8465-e5fb" type="max"/>
           </constraints>
           <selectionEntries>
-            <selectionEntry id="5358-c411-cbcf-9fe0" name="Stormboy" hidden="false" collective="false" type="model">
+            <selectionEntry id="5358-c411-cbcf-9fe0" name="Stormboy" hidden="false" collective="false" import="true" type="model">
               <profiles>
                 <profile id="7687-8344-80ec-c319" name="Stormboy" hidden="false" typeId="800f-21d0-4387-c943" typeName="Unit">
                   <characteristics>
@@ -3825,19 +3821,19 @@
                 </profile>
               </profiles>
               <entryLinks>
-                <entryLink id="d886-da94-306b-7643" name="New EntryLink" hidden="false" collective="false" targetId="c025-0c89-05db-fccb" type="selectionEntry">
+                <entryLink id="d886-da94-306b-7643" name="New EntryLink" hidden="false" collective="false" import="true" targetId="c025-0c89-05db-fccb" type="selectionEntry">
                   <constraints>
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a321-f75d-5fac-d708" type="min"/>
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="eda8-11c2-0f11-d196" type="max"/>
                   </constraints>
                 </entryLink>
-                <entryLink id="b30b-27fa-8de2-8f13" name="New EntryLink" hidden="false" collective="false" targetId="1b13-84df-f255-b206" type="selectionEntry">
+                <entryLink id="b30b-27fa-8de2-8f13" name="New EntryLink" hidden="false" collective="false" import="true" targetId="1b13-84df-f255-b206" type="selectionEntry">
                   <constraints>
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f3b2-0f95-69e2-fb80" type="min"/>
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="098e-8fa4-7b72-bfb5" type="max"/>
                   </constraints>
                 </entryLink>
-                <entryLink id="7a63-347b-830b-6140" name="New EntryLink" hidden="false" collective="false" targetId="6df7-0ee7-7e6d-b182" type="selectionEntry"/>
+                <entryLink id="7a63-347b-830b-6140" name="New EntryLink" hidden="false" collective="false" import="true" targetId="6df7-0ee7-7e6d-b182" type="selectionEntry"/>
               </entryLinks>
               <costs>
                 <cost name="pts" typeId="points" value="9.0"/>
@@ -3845,7 +3841,7 @@
                 <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
               </costs>
             </selectionEntry>
-            <selectionEntry id="6192-d02e-3e9e-6f3a" name="Boss Nob" hidden="false" collective="false" type="model">
+            <selectionEntry id="6192-d02e-3e9e-6f3a" name="Boss Nob" hidden="false" collective="false" import="true" type="model">
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b9a0-9b33-d3ff-5a64" type="max"/>
               </constraints>
@@ -3865,9 +3861,9 @@
                 </profile>
               </profiles>
               <entryLinks>
-                <entryLink id="2b25-f636-4f6e-8ab4" name="Stikkbombs" hidden="false" collective="false" targetId="6df7-0ee7-7e6d-b182" type="selectionEntry"/>
-                <entryLink id="a5b9-c053-187e-25d7" name="Nob Arm1" hidden="false" collective="false" targetId="d4bf-a2d0-e994-1474" type="selectionEntryGroup"/>
-                <entryLink id="8cb5-635d-48cc-7d86" name="Nob Arm2" hidden="false" collective="false" targetId="2fe0-1fb8-9268-f604" type="selectionEntryGroup"/>
+                <entryLink id="2b25-f636-4f6e-8ab4" name="Stikkbombs" hidden="false" collective="false" import="true" targetId="6df7-0ee7-7e6d-b182" type="selectionEntry"/>
+                <entryLink id="a5b9-c053-187e-25d7" name="Nob Arm1" hidden="false" collective="false" import="true" targetId="d4bf-a2d0-e994-1474" type="selectionEntryGroup"/>
+                <entryLink id="8cb5-635d-48cc-7d86" name="Nob Arm2" hidden="false" collective="false" import="true" targetId="2fe0-1fb8-9268-f604" type="selectionEntryGroup"/>
               </entryLinks>
               <costs>
                 <cost name="pts" typeId="points" value="9.0"/>
@@ -3879,8 +3875,8 @@
         </selectionEntryGroup>
       </selectionEntryGroups>
       <entryLinks>
-        <entryLink id="1f28-1dba-9efd-5584" name="Has Battle Honours" hidden="false" collective="false" targetId="4763-757f-499f-d998" type="selectionEntry"/>
-        <entryLink id="fbc1-9a3b-74ef-10b3" name="Battle Honours" hidden="false" collective="false" targetId="5518-d0f5-a880-d71c" type="selectionEntryGroup"/>
+        <entryLink id="1f28-1dba-9efd-5584" name="Has Battle Honours" hidden="false" collective="false" import="true" targetId="4763-757f-499f-d998" type="selectionEntry"/>
+        <entryLink id="fbc1-9a3b-74ef-10b3" name="Battle Honours" hidden="false" collective="false" import="true" targetId="5518-d0f5-a880-d71c" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
         <cost name=" PL" typeId="e356-c769-5920-6e14" value="3.0"/>
@@ -3888,7 +3884,7 @@
         <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="d28d-7a82-0ac3-9391" name="Deff Kopta" hidden="false" collective="false" type="unit">
+    <selectionEntry id="d28d-7a82-0ac3-9391" name="Deff Kopta" hidden="false" collective="false" import="true" type="unit">
       <modifiers>
         <modifier type="increment" field="e356-c769-5920-6e14" value="3">
           <conditions>
@@ -3928,13 +3924,13 @@
         <categoryLink id="165e-e73b-3206-4b99" name="Vehicle" hidden="false" targetId="c8fd-783f-3230-493e" primary="false"/>
       </categoryLinks>
       <selectionEntryGroups>
-        <selectionEntryGroup id="d037-8abd-6869-031e" name="Mob" hidden="false" collective="false" defaultSelectionEntryId="8dde-f5ad-2a3c-f2aa">
+        <selectionEntryGroup id="d037-8abd-6869-031e" name="Mob" hidden="false" collective="false" import="true" defaultSelectionEntryId="8dde-f5ad-2a3c-f2aa">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e82a-0742-6791-95f4" type="min"/>
             <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e7b7-8b8e-42bb-ad8d" type="max"/>
           </constraints>
           <selectionEntries>
-            <selectionEntry id="8dde-f5ad-2a3c-f2aa" name="DeffKopta" hidden="false" collective="false" type="model">
+            <selectionEntry id="8dde-f5ad-2a3c-f2aa" name="DeffKopta" hidden="false" collective="false" import="true" type="model">
               <profiles>
                 <profile id="f5ee-1ed7-4dac-75ae" name="Deff Kopta" hidden="false" typeId="800f-21d0-4387-c943" typeName="Unit">
                   <characteristics>
@@ -3951,7 +3947,7 @@
                 </profile>
               </profiles>
               <selectionEntries>
-                <selectionEntry id="bac8-bc01-53f2-e4b1" name="Spinnin&apos; Blades" hidden="false" collective="false" type="upgrade">
+                <selectionEntry id="bac8-bc01-53f2-e4b1" name="Spinnin&apos; Blades" hidden="false" collective="false" import="true" type="upgrade">
                   <constraints>
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0ab5-ba93-0478-fb11" type="min"/>
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8a66-69b0-d23c-2f40" type="max"/>
@@ -3976,13 +3972,13 @@
                 </selectionEntry>
               </selectionEntries>
               <selectionEntryGroups>
-                <selectionEntryGroup id="a2b1-bd9e-0536-ba33" name="Shooting Weapon" hidden="false" collective="false" defaultSelectionEntryId="b36f-a611-5be0-f8e1">
+                <selectionEntryGroup id="a2b1-bd9e-0536-ba33" name="Shooting Weapon" hidden="false" collective="false" import="true" defaultSelectionEntryId="b36f-a611-5be0-f8e1">
                   <constraints>
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="db7f-39dd-e840-248d" type="min"/>
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="58ca-60e5-a80c-6dd5" type="max"/>
                   </constraints>
                   <selectionEntries>
-                    <selectionEntry id="8057-a5bb-fe7b-fdcb" name="Kopta Rokkits" hidden="false" collective="false" type="upgrade">
+                    <selectionEntry id="8057-a5bb-fe7b-fdcb" name="Kopta Rokkits" hidden="false" collective="false" import="true" type="upgrade">
                       <profiles>
                         <profile id="c8e3-c2a7-4253-46f7" name="Kopta Rokkits" hidden="false" typeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" typeName="Weapon">
                           <characteristics>
@@ -4003,30 +3999,30 @@
                     </selectionEntry>
                   </selectionEntries>
                   <entryLinks>
-                    <entryLink id="d8b8-6e95-33c4-ca71" name="Kustom Mega-blasta" hidden="false" collective="false" targetId="6d70-25a8-b496-2457" type="selectionEntry"/>
-                    <entryLink id="b36f-a611-5be0-f8e1" name="Twin Big Shoota" hidden="false" collective="false" targetId="a4f1-6ccb-1c50-405b" type="selectionEntry"/>
+                    <entryLink id="d8b8-6e95-33c4-ca71" name="Kustom Mega-blasta" hidden="false" collective="false" import="true" targetId="6d70-25a8-b496-2457" type="selectionEntry"/>
+                    <entryLink id="b36f-a611-5be0-f8e1" name="Twin Big Shoota" hidden="false" collective="false" import="true" targetId="a4f1-6ccb-1c50-405b" type="selectionEntry"/>
                   </entryLinks>
                 </selectionEntryGroup>
               </selectionEntryGroups>
               <entryLinks>
-                <entryLink id="4717-a3ef-ea05-7673" name="Bigbomm" hidden="false" collective="false" targetId="c8a1-49f7-f886-4447" type="selectionEntry">
+                <entryLink id="4717-a3ef-ea05-7673" name="Bigbomm" hidden="false" collective="false" import="true" targetId="c8a1-49f7-f886-4447" type="selectionEntry">
                   <constraints>
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ad7e-5851-7cc3-bb91" type="max"/>
                   </constraints>
                 </entryLink>
-                <entryLink id="f928-dea0-b5a7-fe2e" name="Killsaw" hidden="false" collective="false" targetId="f15a-fc8e-65b1-e4b8" type="selectionEntry">
+                <entryLink id="f928-dea0-b5a7-fe2e" name="Killsaw" hidden="false" collective="false" import="true" targetId="f15a-fc8e-65b1-e4b8" type="selectionEntry">
                   <constraints>
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c5e3-47e9-7352-9c33" type="max"/>
                   </constraints>
                 </entryLink>
-                <entryLink id="64ba-880b-b436-fa46" name="Slugga" hidden="false" collective="false" targetId="1b13-84df-f255-b206" type="selectionEntry">
+                <entryLink id="64ba-880b-b436-fa46" name="Slugga" hidden="false" collective="false" import="true" targetId="1b13-84df-f255-b206" type="selectionEntry">
                   <constraints>
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="157b-6d97-e307-4cdc" type="min"/>
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="54ef-35d5-50d5-a407" type="max"/>
                   </constraints>
                 </entryLink>
-                <entryLink id="6176-ccc3-be89-4953" name="Has Battle Honours" hidden="false" collective="false" targetId="4763-757f-499f-d998" type="selectionEntry"/>
-                <entryLink id="3aa5-532b-ce2f-3501" name="Battle Honours" hidden="false" collective="false" targetId="5518-d0f5-a880-d71c" type="selectionEntryGroup"/>
+                <entryLink id="6176-ccc3-be89-4953" name="Has Battle Honours" hidden="false" collective="false" import="true" targetId="4763-757f-499f-d998" type="selectionEntry"/>
+                <entryLink id="3aa5-532b-ce2f-3501" name="Battle Honours" hidden="false" collective="false" import="true" targetId="5518-d0f5-a880-d71c" type="selectionEntryGroup"/>
               </entryLinks>
               <costs>
                 <cost name="pts" typeId="points" value="30.0"/>
@@ -4043,7 +4039,7 @@
         <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="a4f1-6ccb-1c50-405b" name="Twin Big Shoota" hidden="false" collective="false" type="upgrade">
+    <selectionEntry id="a4f1-6ccb-1c50-405b" name="Twin Big Shoota" hidden="false" collective="false" import="true" type="upgrade">
       <profiles>
         <profile id="f817-f45c-1644-75df" name="Twin Big Shoota" hidden="false" typeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" typeName="Weapon">
           <characteristics>
@@ -4062,7 +4058,7 @@
         <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="c8a1-49f7-f886-4447" name="Bigbomm (Index)" hidden="false" collective="false" type="upgrade">
+    <selectionEntry id="c8a1-49f7-f886-4447" name="Bigbomm (Index)" hidden="false" collective="false" import="true" type="upgrade">
       <profiles>
         <profile id="cb9b-5f98-297b-a048" name="Bigbomm" hidden="false" typeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" typeName="Abilities">
           <characteristics>
@@ -4076,7 +4072,7 @@
         <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="826d-99ed-ff5d-7082" name="Dakkajet" hidden="false" collective="false" type="unit">
+    <selectionEntry id="826d-99ed-ff5d-7082" name="Dakkajet" hidden="false" collective="false" import="true" type="unit">
       <profiles>
         <profile id="926c-6fb3-869d-dd62" name="Dakkajet" hidden="false" typeId="800f-21d0-4387-c943" typeName="Unit">
           <characteristics>
@@ -4138,14 +4134,14 @@
         <categoryLink id="7d7e-e472-83b1-b398" name="Aircraft" hidden="false" targetId="d569-3d56-cd24-6a31" primary="false"/>
       </categoryLinks>
       <entryLinks>
-        <entryLink id="c3b4-6148-01b7-10e9" name="Supa Shoota" hidden="false" collective="false" targetId="18ea-ccd9-37ee-7cc6" type="selectionEntry">
+        <entryLink id="c3b4-6148-01b7-10e9" name="Supa Shoota" hidden="false" collective="false" import="true" targetId="18ea-ccd9-37ee-7cc6" type="selectionEntry">
           <constraints>
             <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="512c-8d80-6e69-591c" type="min"/>
             <constraint field="selections" scope="parent" value="6.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="21ea-ad2a-75ee-2339" type="max"/>
           </constraints>
         </entryLink>
-        <entryLink id="62f9-2b19-aed2-8af9" name="Has Battle Honours" hidden="false" collective="false" targetId="4763-757f-499f-d998" type="selectionEntry"/>
-        <entryLink id="51d7-43ee-0c5f-0fae" name="Battle Honours" hidden="false" collective="false" targetId="5518-d0f5-a880-d71c" type="selectionEntryGroup"/>
+        <entryLink id="62f9-2b19-aed2-8af9" name="Has Battle Honours" hidden="false" collective="false" import="true" targetId="4763-757f-499f-d998" type="selectionEntry"/>
+        <entryLink id="51d7-43ee-0c5f-0fae" name="Battle Honours" hidden="false" collective="false" import="true" targetId="5518-d0f5-a880-d71c" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="points" value="88.0"/>
@@ -4153,7 +4149,7 @@
         <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="18ea-ccd9-37ee-7cc6" name="Supa Shoota" hidden="false" collective="false" type="upgrade">
+    <selectionEntry id="18ea-ccd9-37ee-7cc6" name="Supa Shoota" hidden="false" collective="false" import="true" type="upgrade">
       <profiles>
         <profile id="04ed-2e17-9318-ae9c" name="Supa Shoota" hidden="false" typeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" typeName="Weapon">
           <characteristics>
@@ -4172,7 +4168,7 @@
         <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="a5bc-9929-50fa-c7fb" name="Burna-bommer" hidden="false" collective="false" type="unit">
+    <selectionEntry id="a5bc-9929-50fa-c7fb" name="Burna-bommer" hidden="false" collective="false" import="true" type="unit">
       <profiles>
         <profile id="1ac5-3970-e2a3-9360" name="Burna-bommer" hidden="false" typeId="800f-21d0-4387-c943" typeName="Unit">
           <characteristics>
@@ -4238,7 +4234,7 @@
         <categoryLink id="10c0-31e8-3880-768f" name="Aircraft" hidden="false" targetId="d569-3d56-cd24-6a31" primary="false"/>
       </categoryLinks>
       <selectionEntries>
-        <selectionEntry id="30db-1629-85ae-a462" name="Burna Bomb" hidden="false" collective="false" type="upgrade">
+        <selectionEntry id="30db-1629-85ae-a462" name="Burna Bomb" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
             <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fda2-950f-1b06-20f7" type="min"/>
             <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2557-e6a5-333c-5416" type="max"/>
@@ -4256,7 +4252,7 @@
             <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
           </costs>
         </selectionEntry>
-        <selectionEntry id="e2fb-13f7-01fc-81b6" name="Skorcha Missiles" hidden="false" collective="false" type="upgrade">
+        <selectionEntry id="e2fb-13f7-01fc-81b6" name="Skorcha Missiles" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a2a6-0702-576e-9feb" type="max"/>
           </constraints>
@@ -4280,20 +4276,20 @@
         </selectionEntry>
       </selectionEntries>
       <entryLinks>
-        <entryLink id="c0b8-46f3-871c-12fc" name="Supa Shoota" hidden="false" collective="false" targetId="18ea-ccd9-37ee-7cc6" type="selectionEntry">
+        <entryLink id="c0b8-46f3-871c-12fc" name="Supa Shoota" hidden="false" collective="false" import="true" targetId="18ea-ccd9-37ee-7cc6" type="selectionEntry">
           <constraints>
             <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8358-d86f-b874-059c" type="min"/>
             <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="20e5-f0db-1f05-3749" type="max"/>
           </constraints>
         </entryLink>
-        <entryLink id="382e-819a-4873-31a5" name="Twin Big Shoota" hidden="false" collective="false" targetId="a4f1-6ccb-1c50-405b" type="selectionEntry">
+        <entryLink id="382e-819a-4873-31a5" name="Twin Big Shoota" hidden="false" collective="false" import="true" targetId="a4f1-6ccb-1c50-405b" type="selectionEntry">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5380-a921-04f5-c7e2" type="min"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5056-91a3-1343-db50" type="max"/>
           </constraints>
         </entryLink>
-        <entryLink id="0467-5672-f57a-0e08" name="Has Battle Honours" hidden="false" collective="false" targetId="4763-757f-499f-d998" type="selectionEntry"/>
-        <entryLink id="88f5-28db-8ebe-41c0" name="Battle Honours" hidden="false" collective="false" targetId="5518-d0f5-a880-d71c" type="selectionEntryGroup"/>
+        <entryLink id="0467-5672-f57a-0e08" name="Has Battle Honours" hidden="false" collective="false" import="true" targetId="4763-757f-499f-d998" type="selectionEntry"/>
+        <entryLink id="88f5-28db-8ebe-41c0" name="Battle Honours" hidden="false" collective="false" import="true" targetId="5518-d0f5-a880-d71c" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="points" value="102.0"/>
@@ -4301,7 +4297,7 @@
         <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="73ba-a086-3038-c166" name="Blitza-bommer" hidden="false" collective="false" type="unit">
+    <selectionEntry id="73ba-a086-3038-c166" name="Blitza-bommer" hidden="false" collective="false" import="true" type="unit">
       <profiles>
         <profile id="74dd-d089-7250-9367" name="Blitza-bommer" hidden="false" typeId="800f-21d0-4387-c943" typeName="Unit">
           <characteristics>
@@ -4363,7 +4359,7 @@
         <categoryLink id="2067-8c8c-652e-6c17" name="Aircraft" hidden="false" targetId="d569-3d56-cd24-6a31" primary="false"/>
       </categoryLinks>
       <selectionEntries>
-        <selectionEntry id="639e-17ea-57ae-3d8d" name="Boom Bomb" hidden="false" collective="false" type="upgrade">
+        <selectionEntry id="639e-17ea-57ae-3d8d" name="Boom Bomb" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
             <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3334-36e5-6b75-66c2" type="min"/>
             <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f91b-a807-d4e1-7f5f" type="max"/>
@@ -4383,20 +4379,20 @@
         </selectionEntry>
       </selectionEntries>
       <entryLinks>
-        <entryLink id="bb10-907f-c8eb-daa0" name="Supa Shoota" hidden="false" collective="false" targetId="18ea-ccd9-37ee-7cc6" type="selectionEntry">
+        <entryLink id="bb10-907f-c8eb-daa0" name="Supa Shoota" hidden="false" collective="false" import="true" targetId="18ea-ccd9-37ee-7cc6" type="selectionEntry">
           <constraints>
             <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="99d3-46e6-cfd1-cd31" type="min"/>
             <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="339c-0b53-5d18-fddb" type="max"/>
           </constraints>
         </entryLink>
-        <entryLink id="4f2f-0a11-3a29-86f4" name="Big Shoota" hidden="false" collective="false" targetId="6008-4737-d8e6-e63b" type="selectionEntry">
+        <entryLink id="4f2f-0a11-3a29-86f4" name="Big Shoota" hidden="false" collective="false" import="true" targetId="6008-4737-d8e6-e63b" type="selectionEntry">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="34dc-72da-0928-486a" type="min"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2dd4-ba12-3f58-333b" type="max"/>
           </constraints>
         </entryLink>
-        <entryLink id="4ac5-c5d4-ac1f-32f5" name="Has Battle Honours" hidden="false" collective="false" targetId="4763-757f-499f-d998" type="selectionEntry"/>
-        <entryLink id="747d-144e-6da6-9ce0" name="Battle Honours" hidden="false" collective="false" targetId="5518-d0f5-a880-d71c" type="selectionEntryGroup"/>
+        <entryLink id="4ac5-c5d4-ac1f-32f5" name="Has Battle Honours" hidden="false" collective="false" import="true" targetId="4763-757f-499f-d998" type="selectionEntry"/>
+        <entryLink id="747d-144e-6da6-9ce0" name="Battle Honours" hidden="false" collective="false" import="true" targetId="5518-d0f5-a880-d71c" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="points" value="108.0"/>
@@ -4404,7 +4400,7 @@
         <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="0cd2-fd7c-2b53-78f0" name="Wazbom Blastajet" hidden="false" collective="false" type="unit">
+    <selectionEntry id="0cd2-fd7c-2b53-78f0" name="Wazbom Blastajet" hidden="false" collective="false" import="true" type="unit">
       <profiles>
         <profile id="3868-d323-9a4c-dac6" name="Wazbom Blastajet" hidden="false" typeId="800f-21d0-4387-c943" typeName="Unit">
           <characteristics>
@@ -4466,13 +4462,13 @@
         <categoryLink id="9e4e-eec4-ffa1-8b33" name="Aircraft" hidden="false" targetId="d569-3d56-cd24-6a31" primary="false"/>
       </categoryLinks>
       <selectionEntryGroups>
-        <selectionEntryGroup id="da0b-f755-a77d-df4f" name="Main Guns" hidden="false" collective="false" defaultSelectionEntryId="35b1-2600-1851-a43c">
+        <selectionEntryGroup id="da0b-f755-a77d-df4f" name="Main Guns" hidden="false" collective="false" import="true" defaultSelectionEntryId="35b1-2600-1851-a43c">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ed8f-0945-6831-c019" type="min"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ef88-7bb0-a033-f94e" type="max"/>
           </constraints>
           <selectionEntries>
-            <selectionEntry id="35b1-2600-1851-a43c" name="2x Wazbom Mega-Kannons" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="35b1-2600-1851-a43c" name="2x Wazbom Mega-Kannons" hidden="false" collective="false" import="true" type="upgrade">
               <profiles>
                 <profile id="ea24-31f9-c2ad-b730" name="Wazbom Mega-Kannon" hidden="false" typeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" typeName="Weapon">
                   <characteristics>
@@ -4491,7 +4487,7 @@
                 <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
               </costs>
             </selectionEntry>
-            <selectionEntry id="e194-664a-b46b-c575" name="2x Teleport Mega-Blasta" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="e194-664a-b46b-c575" name="2x Teleport Mega-Blasta" hidden="false" collective="false" import="true" type="upgrade">
               <profiles>
                 <profile id="ee9e-9cb3-dc65-4453" name="Teleport Mega-Blasta" hidden="false" typeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" typeName="Weapon">
                   <characteristics>
@@ -4512,13 +4508,13 @@
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
-        <selectionEntryGroup id="ad2c-d2fe-c1b0-fb2e" name="Other" hidden="false" collective="false" defaultSelectionEntryId="f742-bcd5-5178-0022">
+        <selectionEntryGroup id="ad2c-d2fe-c1b0-fb2e" name="Other" hidden="false" collective="false" import="true" defaultSelectionEntryId="f742-bcd5-5178-0022">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bcfb-d4d2-7def-c9b1" type="min"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="13b1-0c34-def6-23f4" type="max"/>
           </constraints>
           <selectionEntries>
-            <selectionEntry id="f742-bcd5-5178-0022" name="Stikkbomb Flinga" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="f742-bcd5-5178-0022" name="Stikkbomb Flinga" hidden="false" collective="false" import="true" type="upgrade">
               <profiles>
                 <profile id="17a0-de0d-d6ac-154b" name="Stikkbomb Flinga" hidden="false" typeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" typeName="Weapon">
                   <characteristics>
@@ -4539,25 +4535,25 @@
             </selectionEntry>
           </selectionEntries>
           <entryLinks>
-            <entryLink id="059a-1401-80ec-01d9" name="Kustom Force Field" hidden="false" collective="false" targetId="886c-c494-3fbb-e1ec" type="selectionEntry"/>
+            <entryLink id="059a-1401-80ec-01d9" name="Kustom Force Field" hidden="false" collective="false" import="true" targetId="886c-c494-3fbb-e1ec" type="selectionEntry"/>
           </entryLinks>
         </selectionEntryGroup>
       </selectionEntryGroups>
       <entryLinks>
-        <entryLink id="52ec-775e-7974-ac2c" name="Supa Shoota" hidden="false" collective="false" targetId="18ea-ccd9-37ee-7cc6" type="selectionEntry">
+        <entryLink id="52ec-775e-7974-ac2c" name="Supa Shoota" hidden="false" collective="false" import="true" targetId="18ea-ccd9-37ee-7cc6" type="selectionEntry">
           <constraints>
             <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a390-0398-9c83-e6b6" type="min"/>
             <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f23e-b2f7-1fb2-69e0" type="max"/>
           </constraints>
         </entryLink>
-        <entryLink id="f051-4853-90d7-77a6" name="Smasha Gun" hidden="false" collective="false" targetId="cfb8-105d-eea1-850f" type="selectionEntry">
+        <entryLink id="f051-4853-90d7-77a6" name="Smasha Gun" hidden="false" collective="false" import="true" targetId="cfb8-105d-eea1-850f" type="selectionEntry">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="cec4-9f95-c960-1aaa" type="min"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7959-fc3f-d94e-daee" type="max"/>
           </constraints>
         </entryLink>
-        <entryLink id="8c92-541e-7243-08cf" name="Has Battle Honours" hidden="false" collective="false" targetId="4763-757f-499f-d998" type="selectionEntry"/>
-        <entryLink id="c3ff-33b2-c442-d1ee" name="Battle Honours" hidden="false" collective="false" targetId="5518-d0f5-a880-d71c" type="selectionEntryGroup"/>
+        <entryLink id="8c92-541e-7243-08cf" name="Has Battle Honours" hidden="false" collective="false" import="true" targetId="4763-757f-499f-d998" type="selectionEntry"/>
+        <entryLink id="c3ff-33b2-c442-d1ee" name="Battle Honours" hidden="false" collective="false" import="true" targetId="5518-d0f5-a880-d71c" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="points" value="99.0"/>
@@ -4565,7 +4561,7 @@
         <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="88f3-f1da-0592-9755" name="Warbikers" hidden="false" collective="false" type="unit">
+    <selectionEntry id="88f3-f1da-0592-9755" name="Warbikers" hidden="false" collective="false" import="true" type="unit">
       <modifiers>
         <modifier type="increment" field="e356-c769-5920-6e14" value="3">
           <conditions>
@@ -4597,13 +4593,13 @@
         <categoryLink id="a768-c365-ab8c-c423" name="Speed Freeks" hidden="false" targetId="258d-e4cb-6f35-fe20" primary="false"/>
       </categoryLinks>
       <selectionEntryGroups>
-        <selectionEntryGroup id="f3bc-646a-81aa-36f1" name="Warbikers" hidden="false" collective="false" defaultSelectionEntryId="ad79-481a-c2af-e402">
+        <selectionEntryGroup id="f3bc-646a-81aa-36f1" name="Warbikers" hidden="false" collective="false" import="true" defaultSelectionEntryId="ad79-481a-c2af-e402">
           <constraints>
             <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ecfb-22ea-f29b-8a1c" type="min"/>
             <constraint field="selections" scope="parent" value="12.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4f35-e8ed-9213-5a1e" type="max"/>
           </constraints>
           <selectionEntries>
-            <selectionEntry id="ad79-481a-c2af-e402" name="Warbiker" hidden="false" collective="false" type="model">
+            <selectionEntry id="ad79-481a-c2af-e402" name="Warbiker" hidden="false" collective="false" import="true" type="model">
               <constraints>
                 <constraint field="selections" scope="parent" value="12.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2034-f11d-94a0-2015" type="max"/>
               </constraints>
@@ -4623,7 +4619,7 @@
                 </profile>
               </profiles>
               <selectionEntries>
-                <selectionEntry id="9f8f-d767-6486-63aa" name="Dakkagun" hidden="false" collective="true" type="upgrade">
+                <selectionEntry id="9f8f-d767-6486-63aa" name="Dakkagun" hidden="false" collective="true" import="true" type="upgrade">
                   <constraints>
                     <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="87de-ef80-2512-3676" type="min"/>
                     <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="36ee-57c3-f854-0b13" type="max"/>
@@ -4648,18 +4644,18 @@
                 </selectionEntry>
               </selectionEntries>
               <entryLinks>
-                <entryLink id="757e-1356-3f3c-ecda" name="Stikkbombs" hidden="false" collective="false" targetId="6df7-0ee7-7e6d-b182" type="selectionEntry">
+                <entryLink id="757e-1356-3f3c-ecda" name="Stikkbombs" hidden="false" collective="false" import="true" targetId="6df7-0ee7-7e6d-b182" type="selectionEntry">
                   <modifiers>
                     <modifier type="set" field="a1fc-a552-2ba3-2add" value="0.0"/>
                   </modifiers>
                 </entryLink>
-                <entryLink id="dc38-afcd-0db5-f191" name="Choppa" hidden="false" collective="false" targetId="c025-0c89-05db-fccb" type="selectionEntry">
+                <entryLink id="dc38-afcd-0db5-f191" name="Choppa" hidden="false" collective="false" import="true" targetId="c025-0c89-05db-fccb" type="selectionEntry">
                   <constraints>
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="80d0-8208-a624-9215" type="max"/>
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5130-cc18-905f-4b95" type="min"/>
                   </constraints>
                 </entryLink>
-                <entryLink id="1731-8d07-0703-8285" name="Slugga" hidden="false" collective="false" targetId="1b13-84df-f255-b206" type="selectionEntry">
+                <entryLink id="1731-8d07-0703-8285" name="Slugga" hidden="false" collective="false" import="true" targetId="1b13-84df-f255-b206" type="selectionEntry">
                   <constraints>
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8f8d-7f3b-5258-a6cf" type="max"/>
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1247-80c4-af8f-3e8f" type="min"/>
@@ -4672,7 +4668,7 @@
                 <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
               </costs>
             </selectionEntry>
-            <selectionEntry id="8684-f400-5f0c-321e" name="Boss Nob" hidden="false" collective="false" type="model">
+            <selectionEntry id="8684-f400-5f0c-321e" name="Boss Nob" hidden="false" collective="false" import="true" type="model">
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="13c7-a998-a1d5-b026" type="max"/>
               </constraints>
@@ -4692,19 +4688,19 @@
                 </profile>
               </profiles>
               <entryLinks>
-                <entryLink id="17db-b7f6-7c97-f77b" name="Stikkbombs" hidden="false" collective="false" targetId="6df7-0ee7-7e6d-b182" type="selectionEntry"/>
-                <entryLink id="8d31-c909-5937-339f" name="Dakkagun" hidden="false" collective="false" targetId="de10-70b3-ab64-990c" type="selectionEntry">
+                <entryLink id="17db-b7f6-7c97-f77b" name="Stikkbombs" hidden="false" collective="false" import="true" targetId="6df7-0ee7-7e6d-b182" type="selectionEntry"/>
+                <entryLink id="8d31-c909-5937-339f" name="Dakkagun" hidden="false" collective="false" import="true" targetId="de10-70b3-ab64-990c" type="selectionEntry">
                   <constraints>
                     <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="cfd4-2cb3-242c-711d" type="min"/>
                     <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="05e2-68b4-e81a-609b" type="max"/>
                   </constraints>
                 </entryLink>
-                <entryLink id="6c13-f458-0875-177a" name="Nob Arm1" hidden="false" collective="false" targetId="d4bf-a2d0-e994-1474" type="selectionEntryGroup">
+                <entryLink id="6c13-f458-0875-177a" name="Nob Arm1" hidden="false" collective="false" import="true" targetId="d4bf-a2d0-e994-1474" type="selectionEntryGroup">
                   <modifiers>
                     <modifier type="set" field="6659-1c5f-8a39-1a36" value="0.0"/>
                   </modifiers>
                 </entryLink>
-                <entryLink id="e7c8-5d38-a217-006a" name="Nob Arm2" hidden="false" collective="false" targetId="2fe0-1fb8-9268-f604" type="selectionEntryGroup">
+                <entryLink id="e7c8-5d38-a217-006a" name="Nob Arm2" hidden="false" collective="false" import="true" targetId="2fe0-1fb8-9268-f604" type="selectionEntryGroup">
                   <modifiers>
                     <modifier type="set" field="56c7-0e9e-b1fb-b769" value="0.0"/>
                   </modifiers>
@@ -4720,8 +4716,8 @@
         </selectionEntryGroup>
       </selectionEntryGroups>
       <entryLinks>
-        <entryLink id="6f69-45b3-1972-b9dc" name="Has Battle Honours" hidden="false" collective="false" targetId="4763-757f-499f-d998" type="selectionEntry"/>
-        <entryLink id="4afc-8625-64a2-cd04" name="Battle Honours" hidden="false" collective="false" targetId="5518-d0f5-a880-d71c" type="selectionEntryGroup"/>
+        <entryLink id="6f69-45b3-1972-b9dc" name="Has Battle Honours" hidden="false" collective="false" import="true" targetId="4763-757f-499f-d998" type="selectionEntry"/>
+        <entryLink id="4afc-8625-64a2-cd04" name="Battle Honours" hidden="false" collective="false" import="true" targetId="5518-d0f5-a880-d71c" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
         <cost name=" PL" typeId="e356-c769-5920-6e14" value="4.0"/>
@@ -4729,7 +4725,7 @@
         <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="98a5-e209-f687-1ee6" name="Wartrakk (Index)" hidden="false" collective="false" type="unit">
+    <selectionEntry id="98a5-e209-f687-1ee6" name="Wartrakk (Index)" hidden="false" collective="false" import="true" type="unit">
       <modifiers>
         <modifier type="increment" field="e356-c769-5920-6e14" value="6">
           <conditions>
@@ -4761,13 +4757,13 @@
         <categoryLink id="a29e-5ffc-0b5f-8dae" name="New CategoryLink" hidden="false" targetId="c274d0b0-5866-44bc-9810-91c136ae7438" primary="true"/>
       </categoryLinks>
       <selectionEntryGroups>
-        <selectionEntryGroup id="b871-a41e-c3e7-9f90" name="Mob" hidden="false" collective="false" defaultSelectionEntryId="35b1-3b1a-3721-9466">
+        <selectionEntryGroup id="b871-a41e-c3e7-9f90" name="Mob" hidden="false" collective="false" import="true" defaultSelectionEntryId="35b1-3b1a-3721-9466">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6b8d-e2b7-0f5c-377d" type="min"/>
             <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="dc67-9b8b-78ae-08a8" type="max"/>
           </constraints>
           <selectionEntries>
-            <selectionEntry id="35b1-3b1a-3721-9466" name="Wartrakk" hidden="false" collective="false" type="model">
+            <selectionEntry id="35b1-3b1a-3721-9466" name="Wartrakk" hidden="false" collective="false" import="true" type="model">
               <profiles>
                 <profile id="5fb2-2a34-e596-c0ed" name="Wartrakk" hidden="false" typeId="800f-21d0-4387-c943" typeName="Unit">
                   <characteristics>
@@ -4784,20 +4780,20 @@
                 </profile>
               </profiles>
               <selectionEntryGroups>
-                <selectionEntryGroup id="ff2c-1bb5-cb65-baea" name="Gun" hidden="false" collective="false" defaultSelectionEntryId="5c2f-231a-0173-8afc">
+                <selectionEntryGroup id="ff2c-1bb5-cb65-baea" name="Gun" hidden="false" collective="false" import="true" defaultSelectionEntryId="5c2f-231a-0173-8afc">
                   <constraints>
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5f66-4a1c-af6d-3725" type="min"/>
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ce14-251f-fa05-d0f1" type="max"/>
                   </constraints>
                   <entryLinks>
-                    <entryLink id="5c2f-231a-0173-8afc" name="New EntryLink" hidden="false" collective="false" targetId="a4f1-6ccb-1c50-405b" type="selectionEntry"/>
-                    <entryLink id="e8b0-f4bf-898c-f39e" name="New EntryLink" hidden="false" collective="false" targetId="17f9-fccd-55db-b80a" type="selectionEntry"/>
+                    <entryLink id="5c2f-231a-0173-8afc" name="New EntryLink" hidden="false" collective="false" import="true" targetId="a4f1-6ccb-1c50-405b" type="selectionEntry"/>
+                    <entryLink id="e8b0-f4bf-898c-f39e" name="New EntryLink" hidden="false" collective="false" import="true" targetId="17f9-fccd-55db-b80a" type="selectionEntry"/>
                   </entryLinks>
                 </selectionEntryGroup>
               </selectionEntryGroups>
               <entryLinks>
-                <entryLink id="29ac-5d5d-5efe-e3c2" name="Has Battle Honours" hidden="false" collective="false" targetId="4763-757f-499f-d998" type="selectionEntry"/>
-                <entryLink id="38cc-ae1e-5bb9-3589" name="Battle Honours" hidden="false" collective="false" targetId="5518-d0f5-a880-d71c" type="selectionEntryGroup"/>
+                <entryLink id="29ac-5d5d-5efe-e3c2" name="Has Battle Honours" hidden="false" collective="false" import="true" targetId="4763-757f-499f-d998" type="selectionEntry"/>
+                <entryLink id="38cc-ae1e-5bb9-3589" name="Battle Honours" hidden="false" collective="false" import="true" targetId="5518-d0f5-a880-d71c" type="selectionEntryGroup"/>
               </entryLinks>
               <costs>
                 <cost name="pts" typeId="points" value="37.0"/>
@@ -4814,7 +4810,7 @@
         <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="17f9-fccd-55db-b80a" name="Rack of Rokkits" hidden="false" collective="false" type="upgrade">
+    <selectionEntry id="17f9-fccd-55db-b80a" name="Rack of Rokkits" hidden="false" collective="false" import="true" type="upgrade">
       <profiles>
         <profile id="0ced-33ae-ecd4-7871" name="Rack of Rokkits" hidden="false" typeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" typeName="Weapon">
           <characteristics>
@@ -4833,7 +4829,7 @@
         <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="d5f1-6fff-d11b-0091" name="Skorchas (Index)" hidden="false" collective="false" type="unit">
+    <selectionEntry id="d5f1-6fff-d11b-0091" name="Skorchas (Index)" hidden="false" collective="false" import="true" type="unit">
       <modifiers>
         <modifier type="increment" field="e356-c769-5920-6e14" value="6">
           <conditions>
@@ -4865,13 +4861,13 @@
         <categoryLink id="89e4-b54f-1716-7f19" name="New CategoryLink" hidden="false" targetId="4d7c-1d39-0e3b-719a" primary="false"/>
       </categoryLinks>
       <selectionEntryGroups>
-        <selectionEntryGroup id="6d3d-6016-23c8-b959" name="1 - 5 Skorchas" hidden="false" collective="false" defaultSelectionEntryId="9e60-5bb2-a31f-a764">
+        <selectionEntryGroup id="6d3d-6016-23c8-b959" name="1 - 5 Skorchas" hidden="false" collective="false" import="true" defaultSelectionEntryId="9e60-5bb2-a31f-a764">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a21c-c575-da5c-d885" type="min"/>
             <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="dce1-1f7e-313c-579e" type="max"/>
           </constraints>
           <selectionEntries>
-            <selectionEntry id="9e60-5bb2-a31f-a764" name="Skorcha" hidden="false" collective="false" type="model">
+            <selectionEntry id="9e60-5bb2-a31f-a764" name="Skorcha" hidden="false" collective="false" import="true" type="model">
               <profiles>
                 <profile id="7f88-fcc1-6943-e16f" name="Skorcha" hidden="false" typeId="800f-21d0-4387-c943" typeName="Unit">
                   <characteristics>
@@ -4888,7 +4884,7 @@
                 </profile>
               </profiles>
               <selectionEntries>
-                <selectionEntry id="cfe7-0211-4582-6a3f" name="Skorcha" hidden="false" collective="true" type="upgrade">
+                <selectionEntry id="cfe7-0211-4582-6a3f" name="Skorcha" hidden="false" collective="true" import="true" type="upgrade">
                   <constraints>
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f83b-478f-903f-2387" type="min"/>
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a7ec-5a53-5d33-d444" type="max"/>
@@ -4904,8 +4900,8 @@
                 </selectionEntry>
               </selectionEntries>
               <entryLinks>
-                <entryLink id="16c0-f148-df32-2fd2" name="Has Battle Honours" hidden="false" collective="false" targetId="4763-757f-499f-d998" type="selectionEntry"/>
-                <entryLink id="5e10-5374-57e0-da1a" name="Battle Honours" hidden="false" collective="false" targetId="5518-d0f5-a880-d71c" type="selectionEntryGroup"/>
+                <entryLink id="16c0-f148-df32-2fd2" name="Has Battle Honours" hidden="false" collective="false" import="true" targetId="4763-757f-499f-d998" type="selectionEntry"/>
+                <entryLink id="5e10-5374-57e0-da1a" name="Battle Honours" hidden="false" collective="false" import="true" targetId="5518-d0f5-a880-d71c" type="selectionEntryGroup"/>
               </entryLinks>
               <costs>
                 <cost name="pts" typeId="points" value="37.0"/>
@@ -4922,7 +4918,7 @@
         <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="f7ee-37e2-efd6-a351" name="Warbuggies (Index)" hidden="false" collective="false" type="unit">
+    <selectionEntry id="f7ee-37e2-efd6-a351" name="Warbuggies (Index)" hidden="false" collective="false" import="true" type="unit">
       <modifiers>
         <modifier type="increment" field="e356-c769-5920-6e14" value="6">
           <conditions>
@@ -4954,13 +4950,13 @@
         <categoryLink id="7c59-71ed-6d2b-eab6" name="New CategoryLink" hidden="false" targetId="88a5-92ca-69c3-d345" primary="false"/>
       </categoryLinks>
       <selectionEntryGroups>
-        <selectionEntryGroup id="31ec-b292-fa23-406d" name="Mob" hidden="false" collective="false" defaultSelectionEntryId="5b74-eb94-2f07-51d7">
+        <selectionEntryGroup id="31ec-b292-fa23-406d" name="Mob" hidden="false" collective="false" import="true" defaultSelectionEntryId="5b74-eb94-2f07-51d7">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="81c9-f4fd-fc6b-e1af" type="min"/>
             <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bc6c-11f7-0241-4588" type="max"/>
           </constraints>
           <selectionEntries>
-            <selectionEntry id="5b74-eb94-2f07-51d7" name="Warbuggy" hidden="false" collective="false" type="model">
+            <selectionEntry id="5b74-eb94-2f07-51d7" name="Warbuggy" hidden="false" collective="false" import="true" type="model">
               <profiles>
                 <profile id="f825-9156-6fdf-8b0c" name="Warbuggy" hidden="false" typeId="800f-21d0-4387-c943" typeName="Unit">
                   <characteristics>
@@ -4977,20 +4973,20 @@
                 </profile>
               </profiles>
               <selectionEntryGroups>
-                <selectionEntryGroup id="3058-3fa4-108c-c1f6" name="Gun" hidden="false" collective="false" defaultSelectionEntryId="e4b1-f1b5-d036-5c9d">
+                <selectionEntryGroup id="3058-3fa4-108c-c1f6" name="Gun" hidden="false" collective="false" import="true" defaultSelectionEntryId="e4b1-f1b5-d036-5c9d">
                   <constraints>
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="66d0-8565-a94a-bfbd" type="min"/>
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ccf9-5775-c9df-fb00" type="max"/>
                   </constraints>
                   <entryLinks>
-                    <entryLink id="e4b1-f1b5-d036-5c9d" name="New EntryLink" hidden="false" collective="false" targetId="a4f1-6ccb-1c50-405b" type="selectionEntry"/>
-                    <entryLink id="f97d-0019-f5db-ae23" name="New EntryLink" hidden="false" collective="false" targetId="17f9-fccd-55db-b80a" type="selectionEntry"/>
+                    <entryLink id="e4b1-f1b5-d036-5c9d" name="New EntryLink" hidden="false" collective="false" import="true" targetId="a4f1-6ccb-1c50-405b" type="selectionEntry"/>
+                    <entryLink id="f97d-0019-f5db-ae23" name="New EntryLink" hidden="false" collective="false" import="true" targetId="17f9-fccd-55db-b80a" type="selectionEntry"/>
                   </entryLinks>
                 </selectionEntryGroup>
               </selectionEntryGroups>
               <entryLinks>
-                <entryLink id="4d47-35ba-2a3a-7308" name="Has Battle Honours" hidden="false" collective="false" targetId="4763-757f-499f-d998" type="selectionEntry"/>
-                <entryLink id="3b43-e013-2b2a-010c" name="Battle Honours" hidden="false" collective="false" targetId="5518-d0f5-a880-d71c" type="selectionEntryGroup"/>
+                <entryLink id="4d47-35ba-2a3a-7308" name="Has Battle Honours" hidden="false" collective="false" import="true" targetId="4763-757f-499f-d998" type="selectionEntry"/>
+                <entryLink id="3b43-e013-2b2a-010c" name="Battle Honours" hidden="false" collective="false" import="true" targetId="5518-d0f5-a880-d71c" type="selectionEntryGroup"/>
               </entryLinks>
               <costs>
                 <cost name="pts" typeId="points" value="33.0"/>
@@ -5007,7 +5003,7 @@
         <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="d4e3-d08f-af6f-53d5" name="Grot Gunner" hidden="false" collective="false" type="model">
+    <selectionEntry id="d4e3-d08f-af6f-53d5" name="Grot Gunner" hidden="false" collective="false" import="true" type="model">
       <profiles>
         <profile id="fb80-8644-3236-1d25" name="Grot Gunner" hidden="false" typeId="800f-21d0-4387-c943" typeName="Unit">
           <characteristics>
@@ -5044,7 +5040,7 @@
         <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="b3d8-73ff-d4fc-c2ac" name="Kannon" hidden="false" collective="false" type="upgrade">
+    <selectionEntry id="b3d8-73ff-d4fc-c2ac" name="Kannon" hidden="false" collective="false" import="true" type="upgrade">
       <profiles>
         <profile id="261b-591f-8c70-1b4e" name="Kannon (Frag)" hidden="false" typeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" typeName="Weapon">
           <characteristics>
@@ -5073,7 +5069,7 @@
         <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="b25a-5184-36ce-d147" name="Lobba" hidden="false" collective="false" type="upgrade">
+    <selectionEntry id="b25a-5184-36ce-d147" name="Lobba" hidden="false" collective="false" import="true" type="upgrade">
       <profiles>
         <profile id="2aa4-a02f-7ecf-b01e" name="Lobba" hidden="false" typeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" typeName="Weapon">
           <characteristics>
@@ -5092,7 +5088,7 @@
         <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="b390-deb9-6d7e-d632" name="Zzap gun" hidden="false" collective="false" type="upgrade">
+    <selectionEntry id="b390-deb9-6d7e-d632" name="Zzap gun" hidden="false" collective="false" import="true" type="upgrade">
       <profiles>
         <profile id="52d0-3697-1ea3-5ee0" name="Zzap gun" hidden="false" typeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" typeName="Weapon">
           <characteristics>
@@ -5111,7 +5107,7 @@
         <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="5002-4d47-db8c-d39f" name="Big Gunz (Index)" hidden="false" collective="false" type="unit">
+    <selectionEntry id="5002-4d47-db8c-d39f" name="Big Gunz (Index)" hidden="false" collective="false" import="true" type="unit">
       <infoLinks>
         <infoLink id="d020-5dcb-911d-1baa" name="Artillery" hidden="false" targetId="0358-d920-32c7-3e8c" type="profile"/>
       </infoLinks>
@@ -5125,7 +5121,7 @@
         <categoryLink id="d08b-bc76-7aa9-95db" name="Gretchin" hidden="false" targetId="0b2c-1505-90c2-24ed" primary="false"/>
       </categoryLinks>
       <selectionEntries>
-        <selectionEntry id="a520-79f2-6e07-d62c" name="Gun" hidden="false" collective="false" type="model">
+        <selectionEntry id="a520-79f2-6e07-d62c" name="Gun" hidden="false" collective="false" import="true" type="model">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b0b9-a523-101b-4a22" type="min"/>
             <constraint field="selections" scope="parent" value="6.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="15a5-b9fc-52e5-5763" type="max"/>
@@ -5146,27 +5142,27 @@
             </profile>
           </profiles>
           <selectionEntryGroups>
-            <selectionEntryGroup id="e1bc-c706-7fe0-720c" name="Big Gun" hidden="false" collective="false" defaultSelectionEntryId="1ea7-db31-911c-67d0">
+            <selectionEntryGroup id="e1bc-c706-7fe0-720c" name="Big Gun" hidden="false" collective="false" import="true" defaultSelectionEntryId="1ea7-db31-911c-67d0">
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c6a3-cb9d-0065-b78a" type="min"/>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a1e5-10d7-a996-3d12" type="max"/>
               </constraints>
               <entryLinks>
-                <entryLink id="7268-b2a6-a399-4c6b" name="New EntryLink" hidden="false" collective="false" targetId="b25a-5184-36ce-d147" type="selectionEntry"/>
-                <entryLink id="1ea7-db31-911c-67d0" name="New EntryLink" hidden="false" collective="false" targetId="b3d8-73ff-d4fc-c2ac" type="selectionEntry"/>
-                <entryLink id="0964-a95b-6939-70f9" name="New EntryLink" hidden="false" collective="false" targetId="b390-deb9-6d7e-d632" type="selectionEntry"/>
+                <entryLink id="7268-b2a6-a399-4c6b" name="New EntryLink" hidden="false" collective="false" import="true" targetId="b25a-5184-36ce-d147" type="selectionEntry"/>
+                <entryLink id="1ea7-db31-911c-67d0" name="New EntryLink" hidden="false" collective="false" import="true" targetId="b3d8-73ff-d4fc-c2ac" type="selectionEntry"/>
+                <entryLink id="0964-a95b-6939-70f9" name="New EntryLink" hidden="false" collective="false" import="true" targetId="b390-deb9-6d7e-d632" type="selectionEntry"/>
               </entryLinks>
             </selectionEntryGroup>
           </selectionEntryGroups>
           <entryLinks>
-            <entryLink id="f4b0-18d8-9571-a3b7" name="New EntryLink" hidden="false" collective="false" targetId="d4e3-d08f-af6f-53d5" type="selectionEntry">
+            <entryLink id="f4b0-18d8-9571-a3b7" name="New EntryLink" hidden="false" collective="false" import="true" targetId="d4e3-d08f-af6f-53d5" type="selectionEntry">
               <constraints>
                 <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bc29-dc17-aef5-1088" type="min"/>
                 <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7ef2-0fe0-5fe1-d1f6" type="max"/>
               </constraints>
             </entryLink>
-            <entryLink id="1b51-a78e-34e4-464b" name="Has Battle Honours" hidden="false" collective="false" targetId="4763-757f-499f-d998" type="selectionEntry"/>
-            <entryLink id="8875-6afa-6ab2-9bcc" name="Battle Honours" hidden="false" collective="false" targetId="5518-d0f5-a880-d71c" type="selectionEntryGroup"/>
+            <entryLink id="1b51-a78e-34e4-464b" name="Has Battle Honours" hidden="false" collective="false" import="true" targetId="4763-757f-499f-d998" type="selectionEntry"/>
+            <entryLink id="8875-6afa-6ab2-9bcc" name="Battle Honours" hidden="false" collective="false" import="true" targetId="5518-d0f5-a880-d71c" type="selectionEntryGroup"/>
           </entryLinks>
           <costs>
             <cost name="pts" typeId="points" value="8.0"/>
@@ -5181,7 +5177,7 @@
         <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="8383-113c-08bc-3f40" name="Mek Gunz" hidden="false" collective="false" type="unit">
+    <selectionEntry id="8383-113c-08bc-3f40" name="Mek Gunz" hidden="false" collective="false" import="true" type="unit">
       <profiles>
         <profile id="f77b-3d95-b2c5-e3be" name="Mek Gunz" hidden="false" typeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" typeName="Abilities">
           <characteristics>
@@ -5208,7 +5204,7 @@
         <categoryLink id="fac9-9c4c-5797-40d7" name="Gretchin" hidden="false" targetId="0b2c-1505-90c2-24ed" primary="false"/>
       </categoryLinks>
       <selectionEntries>
-        <selectionEntry id="3b77-09ba-b680-0c65" name="Gun" hidden="false" collective="false" type="model">
+        <selectionEntry id="3b77-09ba-b680-0c65" name="Gun" hidden="false" collective="false" import="true" type="model">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ad08-9f95-0d4e-44f9" type="min"/>
             <constraint field="selections" scope="parent" value="6.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4914-7ba9-1fe1-de77" type="max"/>
@@ -5229,13 +5225,13 @@
             </profile>
           </profiles>
           <selectionEntryGroups>
-            <selectionEntryGroup id="80c8-34b2-1bc5-1124" name="Gun" hidden="false" collective="false">
+            <selectionEntryGroup id="80c8-34b2-1bc5-1124" name="Gun" hidden="false" collective="false" import="true">
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d64d-2529-e1bc-207d" type="min"/>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d551-9dc0-bfbe-268a" type="max"/>
               </constraints>
               <selectionEntries>
-                <selectionEntry id="926c-a57d-dfd1-d7d2" name="Bubblechukka" hidden="false" collective="false" type="upgrade">
+                <selectionEntry id="926c-a57d-dfd1-d7d2" name="Bubblechukka" hidden="false" collective="false" import="true" type="upgrade">
                   <profiles>
                     <profile id="1516-cf10-2a27-2ecb" name="Bubblechukka" hidden="false" typeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" typeName="Weapon">
                       <characteristics>
@@ -5254,7 +5250,7 @@
                     <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
                   </costs>
                 </selectionEntry>
-                <selectionEntry id="d06c-923d-de0e-ac5c" name="Traktor Kannon" hidden="false" collective="false" type="upgrade">
+                <selectionEntry id="d06c-923d-de0e-ac5c" name="Traktor Kannon" hidden="false" collective="false" import="true" type="upgrade">
                   <profiles>
                     <profile id="ebe6-3ac6-33a8-6c51" name="Traktor Kannon" hidden="false" typeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" typeName="Weapon">
                       <characteristics>
@@ -5275,14 +5271,14 @@
                 </selectionEntry>
               </selectionEntries>
               <entryLinks>
-                <entryLink id="6317-a314-e64d-a7e3" name="Smasha Gun" hidden="false" collective="false" targetId="cfb8-105d-eea1-850f" type="selectionEntry"/>
-                <entryLink id="78d9-10dc-f0fd-8f11" name="Kustom Mega Kannon" hidden="false" collective="false" targetId="b37c-86e3-6303-3825" type="selectionEntry"/>
+                <entryLink id="6317-a314-e64d-a7e3" name="Smasha Gun" hidden="false" collective="false" import="true" targetId="cfb8-105d-eea1-850f" type="selectionEntry"/>
+                <entryLink id="78d9-10dc-f0fd-8f11" name="Kustom Mega Kannon" hidden="false" collective="false" import="true" targetId="b37c-86e3-6303-3825" type="selectionEntry"/>
               </entryLinks>
             </selectionEntryGroup>
           </selectionEntryGroups>
           <entryLinks>
-            <entryLink id="8f41-c3eb-2e84-0a41" name="Has Battle Honours" hidden="false" collective="false" targetId="4763-757f-499f-d998" type="selectionEntry"/>
-            <entryLink id="42b0-b6d9-1f98-ae07" name="Battle Honours" hidden="false" collective="false" targetId="5518-d0f5-a880-d71c" type="selectionEntryGroup"/>
+            <entryLink id="8f41-c3eb-2e84-0a41" name="Has Battle Honours" hidden="false" collective="false" import="true" targetId="4763-757f-499f-d998" type="selectionEntry"/>
+            <entryLink id="42b0-b6d9-1f98-ae07" name="Battle Honours" hidden="false" collective="false" import="true" targetId="5518-d0f5-a880-d71c" type="selectionEntryGroup"/>
           </entryLinks>
           <costs>
             <cost name="pts" typeId="points" value="15.0"/>
@@ -5297,7 +5293,7 @@
         <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="cfb8-105d-eea1-850f" name="Smasha Gun" hidden="false" collective="false" type="upgrade">
+    <selectionEntry id="cfb8-105d-eea1-850f" name="Smasha Gun" hidden="false" collective="false" import="true" type="upgrade">
       <profiles>
         <profile id="059a-a600-4a13-bfa8" name="Smasha Gun" hidden="false" typeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" typeName="Weapon">
           <characteristics>
@@ -5316,7 +5312,7 @@
         <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="f0b4-c759-e809-424e" name="Battlewagon" hidden="false" collective="false" type="unit">
+    <selectionEntry id="f0b4-c759-e809-424e" name="Battlewagon" hidden="false" collective="false" import="true" type="unit">
       <profiles>
         <profile id="9612-4b85-c6d9-2c94" name="Battlewagon" hidden="false" typeId="800f-21d0-4387-c943" typeName="Unit">
           <modifiers>
@@ -5391,7 +5387,7 @@
         <categoryLink id="ba20-8570-c748-3e8a" name="New CategoryLink" hidden="false" targetId="abf5fd55-9ac7-4263-8bc1-a9fb0a8fa6a6" primary="true"/>
       </categoryLinks>
       <selectionEntries>
-        <selectionEntry id="b428-b799-c9c5-cab9" name="&apos;ard Case" hidden="false" collective="false" type="upgrade">
+        <selectionEntry id="b428-b799-c9c5-cab9" name="&apos;ard Case" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="088d-371e-8d7c-492e" type="max"/>
           </constraints>
@@ -5410,32 +5406,32 @@
         </selectionEntry>
       </selectionEntries>
       <selectionEntryGroups>
-        <selectionEntryGroup id="4ed2-8ff0-8895-44f3" name="Other Guns (0-4)" hidden="false" collective="false">
+        <selectionEntryGroup id="4ed2-8ff0-8895-44f3" name="Other Guns (0-4)" hidden="false" collective="false" import="true">
           <constraints>
             <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7f30-a4f0-0173-617e" type="min"/>
             <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2914-c6a6-9510-a1eb" type="max"/>
           </constraints>
           <entryLinks>
-            <entryLink id="3093-4a47-856d-0db8" name="Big Shoota" hidden="false" collective="false" targetId="6008-4737-d8e6-e63b" type="selectionEntry"/>
-            <entryLink id="9b72-0493-473b-5dc3" name="Rokkit Launcha (Index)" hidden="false" collective="false" targetId="5fbe-d76c-183e-3413" type="selectionEntry"/>
+            <entryLink id="3093-4a47-856d-0db8" name="Big Shoota" hidden="false" collective="false" import="true" targetId="6008-4737-d8e6-e63b" type="selectionEntry"/>
+            <entryLink id="9b72-0493-473b-5dc3" name="Rokkit Launcha (Index)" hidden="false" collective="false" import="true" targetId="5fbe-d76c-183e-3413" type="selectionEntry"/>
           </entryLinks>
         </selectionEntryGroup>
-        <selectionEntryGroup id="c62f-f76a-8065-c6a5" name="Big Gun" hidden="false" collective="false">
+        <selectionEntryGroup id="c62f-f76a-8065-c6a5" name="Big Gun" hidden="false" collective="false" import="true">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="55a8-8765-9945-9d63" type="max"/>
           </constraints>
           <entryLinks>
-            <entryLink id="698b-b05b-b32e-e759" name="New EntryLink" hidden="false" collective="false" targetId="b3d8-73ff-d4fc-c2ac" type="selectionEntry"/>
-            <entryLink id="2879-8ec2-d6da-d775" name="Zzap gun" hidden="false" collective="false" targetId="b390-deb9-6d7e-d632" type="selectionEntry"/>
-            <entryLink id="ec3e-c53e-e637-75a3" name="Killkannon" hidden="false" collective="false" targetId="44ac-f70b-3b79-6eb8" type="selectionEntry"/>
+            <entryLink id="698b-b05b-b32e-e759" name="New EntryLink" hidden="false" collective="false" import="true" targetId="b3d8-73ff-d4fc-c2ac" type="selectionEntry"/>
+            <entryLink id="2879-8ec2-d6da-d775" name="Zzap gun" hidden="false" collective="false" import="true" targetId="b390-deb9-6d7e-d632" type="selectionEntry"/>
+            <entryLink id="ec3e-c53e-e637-75a3" name="Killkannon" hidden="false" collective="false" import="true" targetId="44ac-f70b-3b79-6eb8" type="selectionEntry"/>
           </entryLinks>
         </selectionEntryGroup>
       </selectionEntryGroups>
       <entryLinks>
-        <entryLink id="d00e-cf27-eb01-12af" name="Battlewagon Gubbins" hidden="false" collective="false" targetId="51e5-322a-ca81-946b" type="selectionEntryGroup"/>
-        <entryLink id="40c2-9483-2e0e-d31c" name="Deff Rolla" hidden="false" collective="false" targetId="a29c-7f2f-9a36-79bb" type="selectionEntry"/>
-        <entryLink id="bf86-417e-d5b6-7ab0" name="Has Battle Honours" hidden="false" collective="false" targetId="4763-757f-499f-d998" type="selectionEntry"/>
-        <entryLink id="d5d3-ca32-cc96-700e" name="Battle Honours" hidden="false" collective="false" targetId="5518-d0f5-a880-d71c" type="selectionEntryGroup"/>
+        <entryLink id="d00e-cf27-eb01-12af" name="Battlewagon Gubbins" hidden="false" collective="false" import="true" targetId="51e5-322a-ca81-946b" type="selectionEntryGroup"/>
+        <entryLink id="40c2-9483-2e0e-d31c" name="Deff Rolla" hidden="false" collective="false" import="true" targetId="a29c-7f2f-9a36-79bb" type="selectionEntry"/>
+        <entryLink id="bf86-417e-d5b6-7ab0" name="Has Battle Honours" hidden="false" collective="false" import="true" targetId="4763-757f-499f-d998" type="selectionEntry"/>
+        <entryLink id="d5d3-ca32-cc96-700e" name="Battle Honours" hidden="false" collective="false" import="true" targetId="5518-d0f5-a880-d71c" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="points" value="120.0"/>
@@ -5443,7 +5439,7 @@
         <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="afdc-8903-044a-a42e" name="Wreckin&apos; Ball" hidden="false" collective="false" type="upgrade">
+    <selectionEntry id="afdc-8903-044a-a42e" name="Wreckin&apos; Ball" hidden="false" collective="false" import="true" type="upgrade">
       <constraints>
         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="240c-f005-a107-1441" type="max"/>
       </constraints>
@@ -5465,7 +5461,7 @@
         <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="7e8f-2745-5160-1161" name="Deff Dread" hidden="false" collective="false" type="unit">
+    <selectionEntry id="7e8f-2745-5160-1161" name="Deff Dread" hidden="false" collective="false" import="true" type="unit">
       <modifiers>
         <modifier type="increment" field="e356-c769-5920-6e14" value="1">
           <conditions>
@@ -5493,13 +5489,13 @@
         <categoryLink id="9883-e990-61a4-3671" name="New CategoryLink" hidden="false" targetId="abf5fd55-9ac7-4263-8bc1-a9fb0a8fa6a6" primary="true"/>
       </categoryLinks>
       <selectionEntryGroups>
-        <selectionEntryGroup id="a71f-8578-b3fe-12fc" name="Mob" hidden="false" collective="false" defaultSelectionEntryId="9848-ee90-ac63-4c00">
+        <selectionEntryGroup id="a71f-8578-b3fe-12fc" name="Mob" hidden="false" collective="false" import="true" defaultSelectionEntryId="9848-ee90-ac63-4c00">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bc19-9f23-4331-b4ed" type="min"/>
             <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="018e-2e54-44cb-4f46" type="max"/>
           </constraints>
           <selectionEntries>
-            <selectionEntry id="9848-ee90-ac63-4c00" name="Deff Dread" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="9848-ee90-ac63-4c00" name="Deff Dread" hidden="false" collective="false" import="true" type="upgrade">
               <profiles>
                 <profile id="b5d3-df10-d1a9-4e53" name="Deff Dread" hidden="false" typeId="800f-21d0-4387-c943" typeName="Unit">
                   <characteristics>
@@ -5516,72 +5512,72 @@
                 </profile>
               </profiles>
               <selectionEntryGroups>
-                <selectionEntryGroup id="c606-c71a-288c-5faf" name="Arm 3" hidden="false" collective="false" defaultSelectionEntryId="dc9b-9962-0713-0b94">
+                <selectionEntryGroup id="c606-c71a-288c-5faf" name="Arm 3" hidden="false" collective="false" import="true" defaultSelectionEntryId="dc9b-9962-0713-0b94">
                   <constraints>
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1533-5f7c-6f1d-9047" type="min"/>
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9046-9782-61c3-6781" type="max"/>
                   </constraints>
                   <entryLinks>
-                    <entryLink id="dc9b-9962-0713-0b94" name="New EntryLink" hidden="false" collective="false" targetId="6008-4737-d8e6-e63b" type="selectionEntry"/>
-                    <entryLink id="3e6f-e484-770d-61d8" name="Rokkit Launcha" hidden="false" collective="false" targetId="a8c1-7fb9-7f7b-84c5" type="selectionEntry"/>
-                    <entryLink id="a0af-aa57-f164-109c" name="Skorcha" hidden="false" collective="false" targetId="e05b-21b5-8727-ea9d" type="selectionEntry"/>
-                    <entryLink id="0d40-1b7b-f8d7-5586" name="Kustom Mega-blasta" hidden="false" collective="false" targetId="6d70-25a8-b496-2457" type="selectionEntry"/>
-                    <entryLink id="baf9-78fd-5d6a-8e65" name="Dread Saw" hidden="false" collective="false" targetId="6310-b918-b696-23dc" type="selectionEntry"/>
-                    <entryLink id="954b-1b65-9d55-626f" name="Dread Klaw (Index)" hidden="false" collective="false" targetId="6e69-5a9b-cfdf-05d5" type="selectionEntry"/>
+                    <entryLink id="dc9b-9962-0713-0b94" name="New EntryLink" hidden="false" collective="false" import="true" targetId="6008-4737-d8e6-e63b" type="selectionEntry"/>
+                    <entryLink id="3e6f-e484-770d-61d8" name="Rokkit Launcha" hidden="false" collective="false" import="true" targetId="a8c1-7fb9-7f7b-84c5" type="selectionEntry"/>
+                    <entryLink id="a0af-aa57-f164-109c" name="Skorcha" hidden="false" collective="false" import="true" targetId="e05b-21b5-8727-ea9d" type="selectionEntry"/>
+                    <entryLink id="0d40-1b7b-f8d7-5586" name="Kustom Mega-blasta" hidden="false" collective="false" import="true" targetId="6d70-25a8-b496-2457" type="selectionEntry"/>
+                    <entryLink id="baf9-78fd-5d6a-8e65" name="Dread Saw" hidden="false" collective="false" import="true" targetId="6310-b918-b696-23dc" type="selectionEntry"/>
+                    <entryLink id="954b-1b65-9d55-626f" name="Dread Klaw (Index)" hidden="false" collective="false" import="true" targetId="6e69-5a9b-cfdf-05d5" type="selectionEntry"/>
                   </entryLinks>
                 </selectionEntryGroup>
-                <selectionEntryGroup id="d48b-7488-e33a-227d" name="Arm 4" hidden="false" collective="false" defaultSelectionEntryId="69c4-2b61-674b-9d24">
+                <selectionEntryGroup id="d48b-7488-e33a-227d" name="Arm 4" hidden="false" collective="false" import="true" defaultSelectionEntryId="69c4-2b61-674b-9d24">
                   <constraints>
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ba9a-c806-7ce1-6bdc" type="min"/>
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3a02-e9ca-4163-05a3" type="max"/>
                   </constraints>
                   <entryLinks>
-                    <entryLink id="69c4-2b61-674b-9d24" name="New EntryLink" hidden="false" collective="false" targetId="6008-4737-d8e6-e63b" type="selectionEntry"/>
-                    <entryLink id="cdfb-565f-ec7c-d521" name="New EntryLink" hidden="false" collective="false" targetId="a8c1-7fb9-7f7b-84c5" type="selectionEntry"/>
-                    <entryLink id="79a2-5702-6fcb-0935" name="Skorcha" hidden="false" collective="false" targetId="e05b-21b5-8727-ea9d" type="selectionEntry"/>
-                    <entryLink id="b27a-5de4-8b54-a482" name="Kustom Mega-blasta" hidden="false" collective="false" targetId="6d70-25a8-b496-2457" type="selectionEntry"/>
-                    <entryLink id="3b9f-71b3-c373-5c72" name="Dread Saw" hidden="false" collective="false" targetId="6310-b918-b696-23dc" type="selectionEntry"/>
-                    <entryLink id="b9cd-e390-8c5b-d5a8" name="Dread Klaw (Index)" hidden="false" collective="false" targetId="6e69-5a9b-cfdf-05d5" type="selectionEntry"/>
+                    <entryLink id="69c4-2b61-674b-9d24" name="New EntryLink" hidden="false" collective="false" import="true" targetId="6008-4737-d8e6-e63b" type="selectionEntry"/>
+                    <entryLink id="cdfb-565f-ec7c-d521" name="New EntryLink" hidden="false" collective="false" import="true" targetId="a8c1-7fb9-7f7b-84c5" type="selectionEntry"/>
+                    <entryLink id="79a2-5702-6fcb-0935" name="Skorcha" hidden="false" collective="false" import="true" targetId="e05b-21b5-8727-ea9d" type="selectionEntry"/>
+                    <entryLink id="b27a-5de4-8b54-a482" name="Kustom Mega-blasta" hidden="false" collective="false" import="true" targetId="6d70-25a8-b496-2457" type="selectionEntry"/>
+                    <entryLink id="3b9f-71b3-c373-5c72" name="Dread Saw" hidden="false" collective="false" import="true" targetId="6310-b918-b696-23dc" type="selectionEntry"/>
+                    <entryLink id="b9cd-e390-8c5b-d5a8" name="Dread Klaw (Index)" hidden="false" collective="false" import="true" targetId="6e69-5a9b-cfdf-05d5" type="selectionEntry"/>
                   </entryLinks>
                 </selectionEntryGroup>
-                <selectionEntryGroup id="2daf-45f4-748b-c29c" name="Arm 2" hidden="false" collective="false" defaultSelectionEntryId="098c-ad77-97e8-27f9">
+                <selectionEntryGroup id="2daf-45f4-748b-c29c" name="Arm 2" hidden="false" collective="false" import="true" defaultSelectionEntryId="098c-ad77-97e8-27f9">
                   <constraints>
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0a72-fae9-f738-c864" type="max"/>
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fd92-d2c3-8a9e-7aee" type="min"/>
                   </constraints>
                   <entryLinks>
-                    <entryLink id="098c-ad77-97e8-27f9" name="Dread Klaw" hidden="false" collective="false" targetId="4a86-c7ac-85e6-1182" type="selectionEntry">
+                    <entryLink id="098c-ad77-97e8-27f9" name="Dread Klaw" hidden="false" collective="false" import="true" targetId="4a86-c7ac-85e6-1182" type="selectionEntry">
                       <categoryLinks>
                         <categoryLink id="3fdd-d8a8-3ddc-8e36" name="New CategoryLink" hidden="false" targetId="99f3-bf12-63e0-0b7c" primary="false"/>
                       </categoryLinks>
                     </entryLink>
-                    <entryLink id="3d07-0da0-f691-b3ab" name="Dread Saw" hidden="false" collective="false" targetId="6310-b918-b696-23dc" type="selectionEntry"/>
-                    <entryLink id="98d8-fdba-ffb2-3714" name="Kustom Mega-blasta" hidden="false" collective="false" targetId="6d70-25a8-b496-2457" type="selectionEntry"/>
-                    <entryLink id="7fe2-e950-b920-3e91" name="Rokkit Launcha" hidden="false" collective="false" targetId="a8c1-7fb9-7f7b-84c5" type="selectionEntry"/>
-                    <entryLink id="efe9-d1f0-08e3-1d58" name="Skorcha" hidden="false" collective="false" targetId="e05b-21b5-8727-ea9d" type="selectionEntry"/>
+                    <entryLink id="3d07-0da0-f691-b3ab" name="Dread Saw" hidden="false" collective="false" import="true" targetId="6310-b918-b696-23dc" type="selectionEntry"/>
+                    <entryLink id="98d8-fdba-ffb2-3714" name="Kustom Mega-blasta" hidden="false" collective="false" import="true" targetId="6d70-25a8-b496-2457" type="selectionEntry"/>
+                    <entryLink id="7fe2-e950-b920-3e91" name="Rokkit Launcha" hidden="false" collective="false" import="true" targetId="a8c1-7fb9-7f7b-84c5" type="selectionEntry"/>
+                    <entryLink id="efe9-d1f0-08e3-1d58" name="Skorcha" hidden="false" collective="false" import="true" targetId="e05b-21b5-8727-ea9d" type="selectionEntry"/>
                   </entryLinks>
                 </selectionEntryGroup>
-                <selectionEntryGroup id="d9e6-cacb-1545-6f0c" name="Arm 1" hidden="false" collective="false" defaultSelectionEntryId="2a97-09bc-7382-d00d">
+                <selectionEntryGroup id="d9e6-cacb-1545-6f0c" name="Arm 1" hidden="false" collective="false" import="true" defaultSelectionEntryId="2a97-09bc-7382-d00d">
                   <constraints>
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0e40-7501-5e04-d9ac" type="max"/>
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d424-b46a-df44-e074" type="min"/>
                   </constraints>
                   <entryLinks>
-                    <entryLink id="2a97-09bc-7382-d00d" name="Dread Klaw" hidden="false" collective="false" targetId="4a86-c7ac-85e6-1182" type="selectionEntry">
+                    <entryLink id="2a97-09bc-7382-d00d" name="Dread Klaw" hidden="false" collective="false" import="true" targetId="4a86-c7ac-85e6-1182" type="selectionEntry">
                       <categoryLinks>
                         <categoryLink id="2d52-cb6a-6336-f1a6" name="New CategoryLink" hidden="false" targetId="99f3-bf12-63e0-0b7c" primary="false"/>
                       </categoryLinks>
                     </entryLink>
-                    <entryLink id="2ff5-a5aa-49fc-877e" name="Dread Saw" hidden="false" collective="false" targetId="6310-b918-b696-23dc" type="selectionEntry"/>
-                    <entryLink id="6b9b-a916-b8b9-3847" name="Kustom Mega-blasta" hidden="false" collective="false" targetId="6d70-25a8-b496-2457" type="selectionEntry"/>
-                    <entryLink id="86be-01f7-3746-0ae8" name="Rokkit Launcha" hidden="false" collective="false" targetId="a8c1-7fb9-7f7b-84c5" type="selectionEntry"/>
-                    <entryLink id="c45f-8502-4b27-faa6" name="Skorcha" hidden="false" collective="false" targetId="e05b-21b5-8727-ea9d" type="selectionEntry"/>
+                    <entryLink id="2ff5-a5aa-49fc-877e" name="Dread Saw" hidden="false" collective="false" import="true" targetId="6310-b918-b696-23dc" type="selectionEntry"/>
+                    <entryLink id="6b9b-a916-b8b9-3847" name="Kustom Mega-blasta" hidden="false" collective="false" import="true" targetId="6d70-25a8-b496-2457" type="selectionEntry"/>
+                    <entryLink id="86be-01f7-3746-0ae8" name="Rokkit Launcha" hidden="false" collective="false" import="true" targetId="a8c1-7fb9-7f7b-84c5" type="selectionEntry"/>
+                    <entryLink id="c45f-8502-4b27-faa6" name="Skorcha" hidden="false" collective="false" import="true" targetId="e05b-21b5-8727-ea9d" type="selectionEntry"/>
                   </entryLinks>
                 </selectionEntryGroup>
               </selectionEntryGroups>
               <entryLinks>
-                <entryLink id="2fb1-8351-9391-9c98" name="Has Battle Honours" hidden="false" collective="false" targetId="4763-757f-499f-d998" type="selectionEntry"/>
-                <entryLink id="c807-93b0-43ec-ef62" name="Battle Honours" hidden="false" collective="false" targetId="5518-d0f5-a880-d71c" type="selectionEntryGroup"/>
+                <entryLink id="2fb1-8351-9391-9c98" name="Has Battle Honours" hidden="false" collective="false" import="true" targetId="4763-757f-499f-d998" type="selectionEntry"/>
+                <entryLink id="c807-93b0-43ec-ef62" name="Battle Honours" hidden="false" collective="false" import="true" targetId="5518-d0f5-a880-d71c" type="selectionEntryGroup"/>
               </entryLinks>
               <costs>
                 <cost name="pts" typeId="points" value="55.0"/>
@@ -5598,7 +5594,7 @@
         <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="4a86-c7ac-85e6-1182" name="Dread Klaw" hidden="false" collective="false" type="upgrade">
+    <selectionEntry id="4a86-c7ac-85e6-1182" name="Dread Klaw" hidden="false" collective="false" import="true" type="upgrade">
       <profiles>
         <profile id="2b72-3c61-c140-03cf" name="Dread Klaw" hidden="false" typeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" typeName="Weapon">
           <characteristics>
@@ -5617,7 +5613,7 @@
         <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="e05b-21b5-8727-ea9d" name="Skorcha" hidden="false" collective="false" type="upgrade">
+    <selectionEntry id="e05b-21b5-8727-ea9d" name="Skorcha" hidden="false" collective="false" import="true" type="upgrade">
       <infoLinks>
         <infoLink id="5a11-e526-150c-d213" name="Skorcha" hidden="false" targetId="1123-0b30-9f1f-ca82" type="profile"/>
       </infoLinks>
@@ -5627,7 +5623,7 @@
         <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="963f-1e91-85d2-f6d6" name="Killa Kans" hidden="false" collective="false" type="unit">
+    <selectionEntry id="963f-1e91-85d2-f6d6" name="Killa Kans" hidden="false" collective="false" import="true" type="unit">
       <modifiers>
         <modifier type="increment" field="e356-c769-5920-6e14" value="5">
           <conditions>
@@ -5661,13 +5657,13 @@
         <categoryLink id="ae5c-82de-52c5-75f1" name="Gretchin" hidden="false" targetId="0b2c-1505-90c2-24ed" primary="false"/>
       </categoryLinks>
       <selectionEntryGroups>
-        <selectionEntryGroup id="ac10-937b-fa44-5b59" name="Mob" hidden="false" collective="false" defaultSelectionEntryId="1c7c-6ff8-9ba9-9461">
+        <selectionEntryGroup id="ac10-937b-fa44-5b59" name="Mob" hidden="false" collective="false" import="true" defaultSelectionEntryId="1c7c-6ff8-9ba9-9461">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d75d-34f9-8371-5968" type="min"/>
             <constraint field="selections" scope="parent" value="6.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="58dd-518c-3e61-245b" type="max"/>
           </constraints>
           <selectionEntries>
-            <selectionEntry id="1c7c-6ff8-9ba9-9461" name="Killa Kan" hidden="false" collective="false" type="model">
+            <selectionEntry id="1c7c-6ff8-9ba9-9461" name="Killa Kan" hidden="false" collective="false" import="true" type="model">
               <profiles>
                 <profile id="9b6c-25ae-cad1-adbf" name="Killa Kan" hidden="false" typeId="800f-21d0-4387-c943" typeName="Unit">
                   <characteristics>
@@ -5684,26 +5680,26 @@
                 </profile>
               </profiles>
               <selectionEntryGroups>
-                <selectionEntryGroup id="2f7b-ef27-7f64-97d2" name="Gun Arm" hidden="false" collective="false" defaultSelectionEntryId="6fa1-aec4-2a7c-bf60">
+                <selectionEntryGroup id="2f7b-ef27-7f64-97d2" name="Gun Arm" hidden="false" collective="false" import="true" defaultSelectionEntryId="6fa1-aec4-2a7c-bf60">
                   <constraints>
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ae94-7666-0203-421e" type="min"/>
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1f28-e496-31fd-4f3f" type="max"/>
                   </constraints>
                   <entryLinks>
-                    <entryLink id="6fa1-aec4-2a7c-bf60" name="Big Shoota" hidden="false" collective="false" targetId="6008-4737-d8e6-e63b" type="selectionEntry"/>
-                    <entryLink id="9481-97eb-8489-dd5c" name="Rokkit Launcha" hidden="false" collective="false" targetId="a8c1-7fb9-7f7b-84c5" type="selectionEntry"/>
-                    <entryLink id="2086-9709-4648-0ab1" name="Skorcha" hidden="false" collective="false" targetId="e05b-21b5-8727-ea9d" type="selectionEntry"/>
-                    <entryLink id="0c50-cf92-649c-3a0e" name="Kustom Mega-blasta (Index)" hidden="false" collective="false" targetId="4cb0-1ccc-7926-6c37" type="selectionEntry"/>
-                    <entryLink id="d9b8-1933-31a9-1f12" name="Grotzooka" hidden="false" collective="false" targetId="e91e-e2c3-15e1-e677" type="selectionEntry"/>
+                    <entryLink id="6fa1-aec4-2a7c-bf60" name="Big Shoota" hidden="false" collective="false" import="true" targetId="6008-4737-d8e6-e63b" type="selectionEntry"/>
+                    <entryLink id="9481-97eb-8489-dd5c" name="Rokkit Launcha" hidden="false" collective="false" import="true" targetId="a8c1-7fb9-7f7b-84c5" type="selectionEntry"/>
+                    <entryLink id="2086-9709-4648-0ab1" name="Skorcha" hidden="false" collective="false" import="true" targetId="e05b-21b5-8727-ea9d" type="selectionEntry"/>
+                    <entryLink id="0c50-cf92-649c-3a0e" name="Kustom Mega-blasta (Index)" hidden="false" collective="false" import="true" targetId="4cb0-1ccc-7926-6c37" type="selectionEntry"/>
+                    <entryLink id="d9b8-1933-31a9-1f12" name="Grotzooka" hidden="false" collective="false" import="true" targetId="e91e-e2c3-15e1-e677" type="selectionEntry"/>
                   </entryLinks>
                 </selectionEntryGroup>
-                <selectionEntryGroup id="1ca7-3e8d-128e-60c2" name="Melee Arm" hidden="false" collective="false" defaultSelectionEntryId="163a-fb82-5df3-f4f1">
+                <selectionEntryGroup id="1ca7-3e8d-128e-60c2" name="Melee Arm" hidden="false" collective="false" import="true" defaultSelectionEntryId="163a-fb82-5df3-f4f1">
                   <constraints>
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d326-9aa5-ae12-e91f" type="max"/>
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2887-22ba-e14c-6349" type="min"/>
                   </constraints>
                   <selectionEntries>
-                    <selectionEntry id="163a-fb82-5df3-f4f1" name="Kan Klaw" hidden="false" collective="false" type="upgrade">
+                    <selectionEntry id="163a-fb82-5df3-f4f1" name="Kan Klaw" hidden="false" collective="false" import="true" type="upgrade">
                       <profiles>
                         <profile id="66fb-d448-fb4a-52a2" name="Kan Klaw" hidden="false" typeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" typeName="Weapon">
                           <characteristics>
@@ -5722,7 +5718,7 @@
                         <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
                       </costs>
                     </selectionEntry>
-                    <selectionEntry id="8169-585d-9333-a397" name="Drilla" hidden="false" collective="false" type="upgrade">
+                    <selectionEntry id="8169-585d-9333-a397" name="Drilla" hidden="false" collective="false" import="true" type="upgrade">
                       <profiles>
                         <profile id="57bf-4ca0-70e6-61e1" name="Drilla" hidden="false" typeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" typeName="Weapon">
                           <characteristics>
@@ -5741,7 +5737,7 @@
                         <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
                       </costs>
                     </selectionEntry>
-                    <selectionEntry id="1e0d-63ff-a045-5025" name="Buzzsaw" hidden="false" collective="false" type="upgrade">
+                    <selectionEntry id="1e0d-63ff-a045-5025" name="Buzzsaw" hidden="false" collective="false" import="true" type="upgrade">
                       <profiles>
                         <profile id="38fc-6738-49ac-f666" name="Buzzsaw" hidden="false" typeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" typeName="Weapon">
                           <characteristics>
@@ -5764,8 +5760,8 @@
                 </selectionEntryGroup>
               </selectionEntryGroups>
               <entryLinks>
-                <entryLink id="cab1-e284-7205-8eb7" name="Has Battle Honours" hidden="false" collective="false" targetId="4763-757f-499f-d998" type="selectionEntry"/>
-                <entryLink id="f557-d92e-008f-db0f" name="Battle Honours" hidden="false" collective="false" targetId="5518-d0f5-a880-d71c" type="selectionEntryGroup"/>
+                <entryLink id="cab1-e284-7205-8eb7" name="Has Battle Honours" hidden="false" collective="false" import="true" targetId="4763-757f-499f-d998" type="selectionEntry"/>
+                <entryLink id="f557-d92e-008f-db0f" name="Battle Honours" hidden="false" collective="false" import="true" targetId="5518-d0f5-a880-d71c" type="selectionEntryGroup"/>
               </entryLinks>
               <costs>
                 <cost name="pts" typeId="points" value="40.0"/>
@@ -5782,7 +5778,7 @@
         <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="6cbb-033d-b491-4076" name="Morkanaut" hidden="false" collective="false" type="unit">
+    <selectionEntry id="6cbb-033d-b491-4076" name="Morkanaut" hidden="false" collective="false" import="true" type="unit">
       <profiles>
         <profile id="dec6-2ad0-3577-3a5c" name="Big &apos;n&apos; Stompy" hidden="false" typeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" typeName="Abilities">
           <characteristics>
@@ -5846,43 +5842,43 @@
         <categoryLink id="7b91-2fed-38dd-073e" name="New CategoryLink" hidden="false" targetId="6cc4-1b62-8e8a-05cd" primary="false"/>
       </categoryLinks>
       <entryLinks>
-        <entryLink id="b830-d175-ba0a-14c7" name="Kustom Force Field" hidden="false" collective="false" targetId="886c-c494-3fbb-e1ec" type="selectionEntry">
+        <entryLink id="b830-d175-ba0a-14c7" name="Kustom Force Field" hidden="false" collective="false" import="true" targetId="886c-c494-3fbb-e1ec" type="selectionEntry">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="cb21-7a60-1ab1-b63a" type="max"/>
           </constraints>
         </entryLink>
-        <entryLink id="d604-0a67-1dd4-541c" name="Kustom Mega-zappa" hidden="false" collective="false" targetId="6322-7945-e129-cc1d" type="selectionEntry">
+        <entryLink id="d604-0a67-1dd4-541c" name="Kustom Mega-zappa" hidden="false" collective="false" import="true" targetId="6322-7945-e129-cc1d" type="selectionEntry">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9802-48c5-e466-c4ef" type="max"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a2b4-cd6e-bf0f-c347" type="min"/>
           </constraints>
         </entryLink>
-        <entryLink id="6c2f-c469-439c-ddeb" name="Kustom Mega-blasta" hidden="false" collective="false" targetId="6d70-25a8-b496-2457" type="selectionEntry">
+        <entryLink id="6c2f-c469-439c-ddeb" name="Kustom Mega-blasta" hidden="false" collective="false" import="true" targetId="6d70-25a8-b496-2457" type="selectionEntry">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="681e-521d-8f55-b4ba" type="max"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7025-e0bb-fcfe-dd1e" type="min"/>
           </constraints>
         </entryLink>
-        <entryLink id="f941-41ff-bb31-21e6" name="New EntryLink" hidden="false" collective="false" targetId="a4f1-6ccb-1c50-405b" type="selectionEntry">
+        <entryLink id="f941-41ff-bb31-21e6" name="New EntryLink" hidden="false" collective="false" import="true" targetId="a4f1-6ccb-1c50-405b" type="selectionEntry">
           <constraints>
             <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fa52-6cbf-218d-008e" type="max"/>
             <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="71b2-694b-cbac-f90f" type="min"/>
           </constraints>
         </entryLink>
-        <entryLink id="31ed-e8e0-d143-98be" name="New EntryLink" hidden="false" collective="false" targetId="a8c1-7fb9-7f7b-84c5" type="selectionEntry">
+        <entryLink id="31ed-e8e0-d143-98be" name="New EntryLink" hidden="false" collective="false" import="true" targetId="a8c1-7fb9-7f7b-84c5" type="selectionEntry">
           <constraints>
             <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9d15-f16a-1144-cad1" type="max"/>
             <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="cc11-6e81-2de5-695a" type="min"/>
           </constraints>
         </entryLink>
-        <entryLink id="f23e-d7f2-eb6e-e301" name="Klaw of Gork (Or possibly Mork)" hidden="false" collective="false" targetId="61fe-8a20-a40d-fcb2" type="selectionEntry">
+        <entryLink id="f23e-d7f2-eb6e-e301" name="Klaw of Gork (Or possibly Mork)" hidden="false" collective="false" import="true" targetId="61fe-8a20-a40d-fcb2" type="selectionEntry">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7bdb-f0cb-d6b8-020e" type="max"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7687-65ed-c36d-f94e" type="min"/>
           </constraints>
         </entryLink>
-        <entryLink id="1ec5-6558-4787-7b0a" name="Has Battle Honours" hidden="false" collective="false" targetId="4763-757f-499f-d998" type="selectionEntry"/>
-        <entryLink id="fa9c-32e1-ce56-7e8c" name="Battle Honours" hidden="false" collective="false" targetId="5518-d0f5-a880-d71c" type="selectionEntryGroup"/>
+        <entryLink id="1ec5-6558-4787-7b0a" name="Has Battle Honours" hidden="false" collective="false" import="true" targetId="4763-757f-499f-d998" type="selectionEntry"/>
+        <entryLink id="fa9c-32e1-ce56-7e8c" name="Battle Honours" hidden="false" collective="false" import="true" targetId="5518-d0f5-a880-d71c" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
         <cost name=" PL" typeId="e356-c769-5920-6e14" value="15.0"/>
@@ -5890,7 +5886,7 @@
         <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="b37c-86e3-6303-3825" name="Kustom Mega Kannon" hidden="false" collective="false" type="upgrade">
+    <selectionEntry id="b37c-86e3-6303-3825" name="Kustom Mega Kannon" hidden="false" collective="false" import="true" type="upgrade">
       <profiles>
         <profile id="4a2e-8859-2252-c6d0" name="Kustom Mega Kannon" hidden="false" typeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" typeName="Weapon">
           <characteristics>
@@ -5909,7 +5905,7 @@
         <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="61fe-8a20-a40d-fcb2" name="Klaw of Gork (Or possibly Mork)" hidden="false" collective="false" type="upgrade">
+    <selectionEntry id="61fe-8a20-a40d-fcb2" name="Klaw of Gork (Or possibly Mork)" hidden="false" collective="false" import="true" type="upgrade">
       <profiles>
         <profile id="b7ea-d711-bcd3-b06f" name="Klaw of Gork (Crush)" hidden="false" typeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" typeName="Weapon">
           <characteristics>
@@ -5938,7 +5934,7 @@
         <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="efe5-5715-d739-d18e" name="Gorkanaut" hidden="false" collective="false" type="unit">
+    <selectionEntry id="efe5-5715-d739-d18e" name="Gorkanaut" hidden="false" collective="false" import="true" type="unit">
       <profiles>
         <profile id="fe54-927e-8e39-b7ae" name="Big &apos;n&apos; Stompy" hidden="false" typeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" typeName="Abilities">
           <characteristics>
@@ -6002,7 +5998,7 @@
         <categoryLink id="87e6-ec09-0145-893b" name="New CategoryLink" hidden="false" targetId="6562-99dc-d2f5-0863" primary="false"/>
       </categoryLinks>
       <selectionEntries>
-        <selectionEntry id="374d-3abf-bf7c-1f9f" name="Deffstorm Mega-Shoota" hidden="false" collective="false" type="upgrade">
+        <selectionEntry id="374d-3abf-bf7c-1f9f" name="Deffstorm Mega-Shoota" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="63a2-215b-1b25-e8ae" type="min"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a872-bc0d-6380-eb39" type="max"/>
@@ -6027,32 +6023,32 @@
         </selectionEntry>
       </selectionEntries>
       <entryLinks>
-        <entryLink id="e96d-8bfd-b11a-6c7d" name="New EntryLink" hidden="false" collective="false" targetId="a4f1-6ccb-1c50-405b" type="selectionEntry">
+        <entryLink id="e96d-8bfd-b11a-6c7d" name="New EntryLink" hidden="false" collective="false" import="true" targetId="a4f1-6ccb-1c50-405b" type="selectionEntry">
           <constraints>
             <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5bd8-3642-7419-33c4" type="max"/>
             <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="98ea-3da6-4710-8e97" type="min"/>
           </constraints>
         </entryLink>
-        <entryLink id="a4da-c3c4-f35e-815a" name="Rokkit Launcha" hidden="false" collective="false" targetId="a8c1-7fb9-7f7b-84c5" type="selectionEntry">
+        <entryLink id="a4da-c3c4-f35e-815a" name="Rokkit Launcha" hidden="false" collective="false" import="true" targetId="a8c1-7fb9-7f7b-84c5" type="selectionEntry">
           <constraints>
             <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9a79-8e76-b79f-4335" type="max"/>
             <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="05cf-3b07-a800-0fcd" type="min"/>
           </constraints>
         </entryLink>
-        <entryLink id="82fa-caaf-db15-144e" name="Klaw of Gork (Or possibly Mork)" hidden="false" collective="false" targetId="61fe-8a20-a40d-fcb2" type="selectionEntry">
+        <entryLink id="82fa-caaf-db15-144e" name="Klaw of Gork (Or possibly Mork)" hidden="false" collective="false" import="true" targetId="61fe-8a20-a40d-fcb2" type="selectionEntry">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9e79-2e91-2fb5-2cac" type="max"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="cd58-661a-654a-6134" type="min"/>
           </constraints>
         </entryLink>
-        <entryLink id="4894-32c0-91c0-b660" name="Skorcha" hidden="false" collective="false" targetId="e05b-21b5-8727-ea9d" type="selectionEntry">
+        <entryLink id="4894-32c0-91c0-b660" name="Skorcha" hidden="false" collective="false" import="true" targetId="e05b-21b5-8727-ea9d" type="selectionEntry">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2ed5-6e6f-afee-88f4" type="max"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="45b6-f01d-5c8e-c369" type="min"/>
           </constraints>
         </entryLink>
-        <entryLink id="74e6-647e-7b7f-05e7" name="Has Battle Honours" hidden="false" collective="false" targetId="4763-757f-499f-d998" type="selectionEntry"/>
-        <entryLink id="5d9a-b1c5-b67f-3a29" name="Battle Honours" hidden="false" collective="false" targetId="5518-d0f5-a880-d71c" type="selectionEntryGroup"/>
+        <entryLink id="74e6-647e-7b7f-05e7" name="Has Battle Honours" hidden="false" collective="false" import="true" targetId="4763-757f-499f-d998" type="selectionEntry"/>
+        <entryLink id="5d9a-b1c5-b67f-3a29" name="Battle Honours" hidden="false" collective="false" import="true" targetId="5518-d0f5-a880-d71c" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
         <cost name=" PL" typeId="e356-c769-5920-6e14" value="15.0"/>
@@ -6060,7 +6056,7 @@
         <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="bdf8-0eca-cfc0-07fd" name="Lootas" hidden="false" collective="false" type="upgrade">
+    <selectionEntry id="bdf8-0eca-cfc0-07fd" name="Lootas" hidden="false" collective="false" import="true" type="upgrade">
       <modifiers>
         <modifier type="increment" field="e356-c769-5920-6e14" value="4">
           <conditions>
@@ -6086,13 +6082,13 @@
         <categoryLink id="2a77-f957-00de-82ee" name="New CategoryLink" hidden="false" targetId="9052-f7b4-95fa-16f6" primary="false"/>
       </categoryLinks>
       <selectionEntryGroups>
-        <selectionEntryGroup id="f765-025b-6209-fa42" name="Mob" hidden="false" collective="false" defaultSelectionEntryId="0adf-a214-7051-6022">
+        <selectionEntryGroup id="f765-025b-6209-fa42" name="Mob" hidden="false" collective="false" import="true" defaultSelectionEntryId="0adf-a214-7051-6022">
           <constraints>
             <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5308-a67c-5567-aad0" type="min"/>
             <constraint field="selections" scope="parent" value="15.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0c86-26eb-ef38-e5e2" type="max"/>
           </constraints>
           <selectionEntries>
-            <selectionEntry id="0adf-a214-7051-6022" name="Loota" hidden="false" collective="false" type="model">
+            <selectionEntry id="0adf-a214-7051-6022" name="Loota" hidden="false" collective="false" import="true" type="model">
               <constraints>
                 <constraint field="selections" scope="parent" value="15.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7355-1504-caa0-c689" type="max"/>
               </constraints>
@@ -6112,7 +6108,7 @@
                 </profile>
               </profiles>
               <selectionEntries>
-                <selectionEntry id="6da7-6230-9e90-c8ab" name="Deffgun" hidden="false" collective="true" type="upgrade">
+                <selectionEntry id="6da7-6230-9e90-c8ab" name="Deffgun" hidden="false" collective="true" import="true" type="upgrade">
                   <constraints>
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4de2-73b5-57b6-45e3" type="min"/>
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f421-47ea-c647-0154" type="max"/>
@@ -6128,7 +6124,7 @@
                 </selectionEntry>
               </selectionEntries>
               <entryLinks>
-                <entryLink id="7364-5c12-329a-96e3" name="New EntryLink" hidden="false" collective="false" targetId="6df7-0ee7-7e6d-b182" type="selectionEntry"/>
+                <entryLink id="7364-5c12-329a-96e3" name="New EntryLink" hidden="false" collective="false" import="true" targetId="6df7-0ee7-7e6d-b182" type="selectionEntry"/>
               </entryLinks>
               <costs>
                 <cost name="pts" typeId="points" value="17.0"/>
@@ -6136,7 +6132,7 @@
                 <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
               </costs>
             </selectionEntry>
-            <selectionEntry id="8c7e-8d44-855e-bebd" name="Spanner" hidden="false" collective="false" type="model">
+            <selectionEntry id="8c7e-8d44-855e-bebd" name="Spanner" hidden="false" collective="false" import="true" type="model">
               <modifiers>
                 <modifier type="increment" field="ffa2-94bf-30d3-4d10" value="1">
                   <repeats>
@@ -6166,34 +6162,34 @@
                 <infoLink id="5ded-3e65-b8f2-ac6d" name="Mekaniak" hidden="false" targetId="e5ad-516c-ad0a-54a1" type="profile"/>
               </infoLinks>
               <selectionEntryGroups>
-                <selectionEntryGroup id="f978-5f7f-e783-45b2" name="Arm 1 (Index)" hidden="false" collective="false">
+                <selectionEntryGroup id="f978-5f7f-e783-45b2" name="Arm 1 (Index)" hidden="false" collective="false" import="true">
                   <constraints>
                     <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2d56-b635-a058-73c1" type="min"/>
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="036d-1ea8-0a30-b50f" type="max"/>
                   </constraints>
                   <entryLinks>
-                    <entryLink id="3797-8b34-9c10-7248" name="New EntryLink" hidden="false" collective="false" targetId="c4df-c43d-08a6-18ab" type="selectionEntry"/>
-                    <entryLink id="7a24-d802-694a-89ba" name="Killsaw" hidden="false" collective="false" targetId="f15a-fc8e-65b1-e4b8" type="selectionEntry"/>
+                    <entryLink id="3797-8b34-9c10-7248" name="New EntryLink" hidden="false" collective="false" import="true" targetId="c4df-c43d-08a6-18ab" type="selectionEntry"/>
+                    <entryLink id="7a24-d802-694a-89ba" name="Killsaw" hidden="false" collective="false" import="true" targetId="f15a-fc8e-65b1-e4b8" type="selectionEntry"/>
                   </entryLinks>
                 </selectionEntryGroup>
-                <selectionEntryGroup id="5d12-6b91-ce5b-fcda" name="Arm 2" hidden="false" collective="false" defaultSelectionEntryId="7209-c91a-b33e-1a8c">
+                <selectionEntryGroup id="5d12-6b91-ce5b-fcda" name="Arm 2" hidden="false" collective="false" import="true" defaultSelectionEntryId="7209-c91a-b33e-1a8c">
                   <constraints>
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fb8e-68da-7123-f9be" type="min"/>
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="070c-959d-9563-e890" type="max"/>
                   </constraints>
                   <entryLinks>
-                    <entryLink id="2208-fca9-1d10-e711" name="Slugga (Index)" hidden="false" collective="false" targetId="b618-ec7e-d5cd-56ad" type="selectionEntry"/>
-                    <entryLink id="4556-8902-236e-f0b6" name="Kombi-Rokkit (Index)" hidden="false" collective="false" targetId="b427-a07f-0027-e062" type="selectionEntry"/>
-                    <entryLink id="a04d-31b5-b383-38ea" name="Kombi-Skorcha (Index)" hidden="false" collective="false" targetId="bb1b-00f0-1da0-824c" type="selectionEntry"/>
-                    <entryLink id="7209-c91a-b33e-1a8c" name="Kustom Mega-blasta" hidden="false" collective="false" targetId="6d70-25a8-b496-2457" type="selectionEntry"/>
-                    <entryLink id="b13b-7bda-5e33-9ca7" name="Kustom Mega-Slugga (Index)" hidden="false" collective="false" targetId="f0cf-1bde-c442-378a" type="selectionEntry"/>
-                    <entryLink id="9bcc-85f2-09f9-543d" name="Rokkit Launcha" hidden="false" collective="false" targetId="a8c1-7fb9-7f7b-84c5" type="selectionEntry"/>
-                    <entryLink id="bc6d-519b-6001-b24c" name="Big Shoota" hidden="false" collective="false" targetId="6008-4737-d8e6-e63b" type="selectionEntry"/>
+                    <entryLink id="2208-fca9-1d10-e711" name="Slugga (Index)" hidden="false" collective="false" import="true" targetId="b618-ec7e-d5cd-56ad" type="selectionEntry"/>
+                    <entryLink id="4556-8902-236e-f0b6" name="Kombi-Rokkit (Index)" hidden="false" collective="false" import="true" targetId="b427-a07f-0027-e062" type="selectionEntry"/>
+                    <entryLink id="a04d-31b5-b383-38ea" name="Kombi-Skorcha (Index)" hidden="false" collective="false" import="true" targetId="bb1b-00f0-1da0-824c" type="selectionEntry"/>
+                    <entryLink id="7209-c91a-b33e-1a8c" name="Kustom Mega-blasta" hidden="false" collective="false" import="true" targetId="6d70-25a8-b496-2457" type="selectionEntry"/>
+                    <entryLink id="b13b-7bda-5e33-9ca7" name="Kustom Mega-Slugga (Index)" hidden="false" collective="false" import="true" targetId="f0cf-1bde-c442-378a" type="selectionEntry"/>
+                    <entryLink id="9bcc-85f2-09f9-543d" name="Rokkit Launcha" hidden="false" collective="false" import="true" targetId="a8c1-7fb9-7f7b-84c5" type="selectionEntry"/>
+                    <entryLink id="bc6d-519b-6001-b24c" name="Big Shoota" hidden="false" collective="false" import="true" targetId="6008-4737-d8e6-e63b" type="selectionEntry"/>
                   </entryLinks>
                 </selectionEntryGroup>
               </selectionEntryGroups>
               <entryLinks>
-                <entryLink id="e874-3422-f59e-ff3b" name="Stikkbombs" hidden="false" collective="false" targetId="6df7-0ee7-7e6d-b182" type="selectionEntry">
+                <entryLink id="e874-3422-f59e-ff3b" name="Stikkbombs" hidden="false" collective="false" import="true" targetId="6df7-0ee7-7e6d-b182" type="selectionEntry">
                   <constraints>
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9c6d-214c-f98e-a035" type="max"/>
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fdc3-11cd-d1da-9ad5" type="min"/>
@@ -6210,8 +6206,8 @@
         </selectionEntryGroup>
       </selectionEntryGroups>
       <entryLinks>
-        <entryLink id="bfeb-ca5a-f976-c7ca" name="Has Battle Honours" hidden="false" collective="false" targetId="4763-757f-499f-d998" type="selectionEntry"/>
-        <entryLink id="4eb3-24c8-f437-ed2c" name="Battle Honours" hidden="false" collective="false" targetId="5518-d0f5-a880-d71c" type="selectionEntryGroup"/>
+        <entryLink id="bfeb-ca5a-f976-c7ca" name="Has Battle Honours" hidden="false" collective="false" import="true" targetId="4763-757f-499f-d998" type="selectionEntry"/>
+        <entryLink id="4eb3-24c8-f437-ed2c" name="Battle Honours" hidden="false" collective="false" import="true" targetId="5518-d0f5-a880-d71c" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
         <cost name=" PL" typeId="e356-c769-5920-6e14" value="4.0"/>
@@ -6219,7 +6215,7 @@
         <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="8d81-3378-2c49-7b5c" name="Flash Gitz" hidden="false" collective="false" type="upgrade">
+    <selectionEntry id="8d81-3378-2c49-7b5c" name="Flash Gitz" hidden="false" collective="false" import="true" type="upgrade">
       <modifiers>
         <modifier type="increment" field="e356-c769-5920-6e14" value="6">
           <conditions>
@@ -6248,7 +6244,7 @@
         <categoryLink id="e5b7-6bbc-073e-bc32" name="Faction: Freebootas" hidden="false" targetId="9202-2837-f931-9163" primary="false"/>
       </categoryLinks>
       <selectionEntries>
-        <selectionEntry id="b3ce-3b37-1e52-1d84" name="Kaptin" hidden="false" collective="false" type="model">
+        <selectionEntry id="b3ce-3b37-1e52-1d84" name="Kaptin" hidden="false" collective="false" import="true" type="model">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="15bc-8cec-ada5-0bfd" type="min"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="df1c-403d-8000-846e" type="max"/>
@@ -6269,7 +6265,7 @@
             </profile>
           </profiles>
           <selectionEntries>
-            <selectionEntry id="c4b6-93bd-eeb0-a841" name="Gitfinda Squig" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="c4b6-93bd-eeb0-a841" name="Gitfinda Squig" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0ede-a651-7bbc-b29e" type="max"/>
               </constraints>
@@ -6288,24 +6284,24 @@
             </selectionEntry>
           </selectionEntries>
           <selectionEntryGroups>
-            <selectionEntryGroup id="67a1-6b4a-d2c8-deae" name="Extra Weapon" hidden="false" collective="false">
+            <selectionEntryGroup id="67a1-6b4a-d2c8-deae" name="Extra Weapon" hidden="false" collective="false" import="true">
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9345-a09d-67a0-f814" type="max"/>
               </constraints>
               <entryLinks>
-                <entryLink id="1c22-3b70-d40a-a0ed" name="New EntryLink" hidden="false" collective="false" targetId="c4df-c43d-08a6-18ab" type="selectionEntry"/>
-                <entryLink id="f08d-aeca-5088-46a2" name="New EntryLink" hidden="false" collective="false" targetId="d13b-ad69-e6a2-d485" type="selectionEntry"/>
+                <entryLink id="1c22-3b70-d40a-a0ed" name="New EntryLink" hidden="false" collective="false" import="true" targetId="c4df-c43d-08a6-18ab" type="selectionEntry"/>
+                <entryLink id="f08d-aeca-5088-46a2" name="New EntryLink" hidden="false" collective="false" import="true" targetId="d13b-ad69-e6a2-d485" type="selectionEntry"/>
               </entryLinks>
             </selectionEntryGroup>
           </selectionEntryGroups>
           <entryLinks>
-            <entryLink id="639e-dd6c-1d64-99b4" name="New EntryLink" hidden="false" collective="false" targetId="0dc8-66e8-eb75-aa8a" type="selectionEntry">
+            <entryLink id="639e-dd6c-1d64-99b4" name="New EntryLink" hidden="false" collective="false" import="true" targetId="0dc8-66e8-eb75-aa8a" type="selectionEntry">
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="79c7-2371-3762-580f" type="min"/>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1744-b5c2-315a-cb9f" type="max"/>
               </constraints>
             </entryLink>
-            <entryLink id="6c2a-d580-d0e5-a861" name="Stikkbombs" hidden="false" collective="false" targetId="6df7-0ee7-7e6d-b182" type="selectionEntry">
+            <entryLink id="6c2a-d580-d0e5-a861" name="Stikkbombs" hidden="false" collective="false" import="true" targetId="6df7-0ee7-7e6d-b182" type="selectionEntry">
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bb05-1a35-a07c-9def" type="max"/>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f4ba-9081-89bb-2699" type="min"/>
@@ -6320,13 +6316,13 @@
         </selectionEntry>
       </selectionEntries>
       <selectionEntryGroups>
-        <selectionEntryGroup id="9992-3ceb-662c-ba48" name="Mob" hidden="false" collective="false" defaultSelectionEntryId="27f1-6830-b61a-0f18">
+        <selectionEntryGroup id="9992-3ceb-662c-ba48" name="Mob" hidden="false" collective="false" import="true" defaultSelectionEntryId="27f1-6830-b61a-0f18">
           <constraints>
             <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c6d0-e7e2-8777-85d4" type="min"/>
             <constraint field="selections" scope="parent" value="9.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fa66-5fae-58c9-26e3" type="max"/>
           </constraints>
           <selectionEntries>
-            <selectionEntry id="27f1-6830-b61a-0f18" name="Flash Git" hidden="false" collective="false" type="model">
+            <selectionEntry id="27f1-6830-b61a-0f18" name="Flash Git" hidden="false" collective="false" import="true" type="model">
               <constraints>
                 <constraint field="selections" scope="parent" value="9.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5db6-f8fb-e1c0-4845" type="max"/>
               </constraints>
@@ -6346,13 +6342,13 @@
                 </profile>
               </profiles>
               <entryLinks>
-                <entryLink id="af7c-83dd-fc52-b9ef" name="New EntryLink" hidden="false" collective="false" targetId="0dc8-66e8-eb75-aa8a" type="selectionEntry">
+                <entryLink id="af7c-83dd-fc52-b9ef" name="New EntryLink" hidden="false" collective="false" import="true" targetId="0dc8-66e8-eb75-aa8a" type="selectionEntry">
                   <constraints>
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="29c1-afc2-aabc-3cd9" type="min"/>
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4b88-71e4-d0a4-3a5b" type="max"/>
                   </constraints>
                 </entryLink>
-                <entryLink id="9910-209d-6e43-181a" name="Stikkbombs" hidden="false" collective="false" targetId="6df7-0ee7-7e6d-b182" type="selectionEntry">
+                <entryLink id="9910-209d-6e43-181a" name="Stikkbombs" hidden="false" collective="false" import="true" targetId="6df7-0ee7-7e6d-b182" type="selectionEntry">
                   <constraints>
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ec5f-8ae8-4bca-e669" type="max"/>
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9a7a-2377-62da-b270" type="min"/>
@@ -6369,7 +6365,7 @@
         </selectionEntryGroup>
       </selectionEntryGroups>
       <entryLinks>
-        <entryLink id="3eb5-96ea-7d63-ac3b" name="Ammo Runt" hidden="false" collective="false" targetId="c8f6-b38b-637f-3c7c" type="selectionEntry">
+        <entryLink id="3eb5-96ea-7d63-ac3b" name="Ammo Runt" hidden="false" collective="false" import="true" targetId="c8f6-b38b-637f-3c7c" type="selectionEntry">
           <modifiers>
             <modifier type="increment" field="0886-89f1-0e02-af78" value="1">
               <repeats>
@@ -6381,8 +6377,8 @@
             <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0886-89f1-0e02-af78" type="max"/>
           </constraints>
         </entryLink>
-        <entryLink id="3386-f77f-cf01-5d7b" name="Has Battle Honours" hidden="false" collective="false" targetId="4763-757f-499f-d998" type="selectionEntry"/>
-        <entryLink id="5931-dd36-99de-cca9" name="Battle Honours" hidden="false" collective="false" targetId="5518-d0f5-a880-d71c" type="selectionEntryGroup"/>
+        <entryLink id="3386-f77f-cf01-5d7b" name="Has Battle Honours" hidden="false" collective="false" import="true" targetId="4763-757f-499f-d998" type="selectionEntry"/>
+        <entryLink id="5931-dd36-99de-cca9" name="Battle Honours" hidden="false" collective="false" import="true" targetId="5518-d0f5-a880-d71c" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
         <cost name=" PL" typeId="e356-c769-5920-6e14" value="7.0"/>
@@ -6390,7 +6386,7 @@
         <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="0dc8-66e8-eb75-aa8a" name="Snazzgun" hidden="false" collective="true" type="upgrade">
+    <selectionEntry id="0dc8-66e8-eb75-aa8a" name="Snazzgun" hidden="false" collective="true" import="true" type="upgrade">
       <profiles>
         <profile id="9897-ba8e-1f9b-18a2" name="Snazzgun" hidden="false" typeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" typeName="Weapon">
           <characteristics>
@@ -6409,7 +6405,7 @@
         <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="8ef1-3dff-656f-1a8c" name="Stompa" hidden="false" collective="false" type="unit">
+    <selectionEntry id="8ef1-3dff-656f-1a8c" name="Stompa" hidden="false" collective="false" import="true" type="unit">
       <profiles>
         <profile id="7770-d670-a206-9cd0" name="Bigger &apos;n&apos; Stompier" hidden="false" typeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" typeName="Abilities">
           <characteristics>
@@ -6500,7 +6496,7 @@
         <categoryLink id="4693-fb7e-79e8-f8d9" name="New CategoryLink" hidden="false" targetId="fb3e-2eaa-d312-76b0" primary="false"/>
       </categoryLinks>
       <selectionEntries>
-        <selectionEntry id="e841-5528-69a2-3d29" name="Deffkannon" hidden="false" collective="false" type="upgrade">
+        <selectionEntry id="e841-5528-69a2-3d29" name="Deffkannon" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="16ef-2f44-4df3-7a73" type="min"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="51a3-5335-135e-5ee9" type="max"/>
@@ -6523,7 +6519,7 @@
             <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
           </costs>
         </selectionEntry>
-        <selectionEntry id="db3c-574e-59ca-bbdc" name="Supa-Gatler" hidden="false" collective="false" type="upgrade">
+        <selectionEntry id="db3c-574e-59ca-bbdc" name="Supa-Gatler" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3780-a818-4200-d302" type="min"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b03c-51a3-ae2e-740d" type="max"/>
@@ -6551,7 +6547,7 @@
             <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
           </costs>
         </selectionEntry>
-        <selectionEntry id="902b-0eb0-d338-cff3" name="Supa-Rokkit" hidden="false" collective="false" type="upgrade">
+        <selectionEntry id="902b-0eb0-d338-cff3" name="Supa-Rokkit" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
             <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="021e-64f7-a79c-5965" type="min"/>
             <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ba22-ded7-9c31-2b01" type="max"/>
@@ -6574,7 +6570,7 @@
             <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
           </costs>
         </selectionEntry>
-        <selectionEntry id="6d0a-1b16-7f4f-5bef" name="Mega-Choppa" hidden="false" collective="false" type="upgrade">
+        <selectionEntry id="6d0a-1b16-7f4f-5bef" name="Mega-Choppa" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="775c-a95c-3475-89f3" type="min"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1732-985e-65da-8122" type="max"/>
@@ -6609,25 +6605,25 @@
         </selectionEntry>
       </selectionEntries>
       <entryLinks>
-        <entryLink id="c58e-c755-0506-e4e5" name="Twin Big Shoota" hidden="false" collective="false" targetId="a4f1-6ccb-1c50-405b" type="selectionEntry">
+        <entryLink id="c58e-c755-0506-e4e5" name="Twin Big Shoota" hidden="false" collective="false" import="true" targetId="a4f1-6ccb-1c50-405b" type="selectionEntry">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e52a-fc83-0fc0-2aff" type="max"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="769b-eb4c-5bfc-2956" type="min"/>
           </constraints>
         </entryLink>
-        <entryLink id="bcfd-9ece-13e3-50a3" name="Big Shoota" hidden="false" collective="false" targetId="6008-4737-d8e6-e63b" type="selectionEntry">
+        <entryLink id="bcfd-9ece-13e3-50a3" name="Big Shoota" hidden="false" collective="false" import="true" targetId="6008-4737-d8e6-e63b" type="selectionEntry">
           <constraints>
             <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="84f0-1b11-2ab3-bf85" type="max"/>
             <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="eddb-abb6-04f1-93d2" type="min"/>
           </constraints>
         </entryLink>
-        <entryLink id="286b-bec5-2438-f771" name="New EntryLink" hidden="false" collective="false" targetId="e05b-21b5-8727-ea9d" type="selectionEntry">
+        <entryLink id="286b-bec5-2438-f771" name="New EntryLink" hidden="false" collective="false" import="true" targetId="e05b-21b5-8727-ea9d" type="selectionEntry">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="27b3-a14b-1ca9-a5b0" type="max"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="61f8-ac89-3723-d693" type="min"/>
           </constraints>
         </entryLink>
-        <entryLink id="6be8-1042-a3ca-164c" name="Warlord" hidden="false" collective="false" targetId="33f6-60da-7b70-5fee" type="selectionEntry">
+        <entryLink id="6be8-1042-a3ca-164c" name="Warlord" hidden="false" collective="false" import="true" targetId="33f6-60da-7b70-5fee" type="selectionEntry">
           <modifiers>
             <modifier type="set" field="hidden" value="true">
               <conditions>
@@ -6636,7 +6632,7 @@
             </modifier>
           </modifiers>
         </entryLink>
-        <entryLink id="e37f-38e1-c1dc-730f" name="Tezdrek&apos;s Stompa Power Field" hidden="false" collective="false" targetId="e1a7-cfd9-6a33-c529" type="selectionEntry">
+        <entryLink id="e37f-38e1-c1dc-730f" name="Tezdrek&apos;s Stompa Power Field" hidden="false" collective="false" import="true" targetId="e1a7-cfd9-6a33-c529" type="selectionEntry">
           <modifiers>
             <modifier type="set" field="hidden" value="true">
               <conditions>
@@ -6648,8 +6644,8 @@
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bf03-7af4-618e-7d27" type="max"/>
           </constraints>
         </entryLink>
-        <entryLink id="21d4-35c8-f36d-43a2" name="Warlord Traits" hidden="false" collective="false" targetId="c2ce-6759-e009-8c11" type="selectionEntryGroup"/>
-        <entryLink id="13f7-f006-00fa-e304" name="Stratagem: Field Commander" hidden="false" collective="false" targetId="d043-3847-e963-fb5d" type="selectionEntry">
+        <entryLink id="21d4-35c8-f36d-43a2" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="c2ce-6759-e009-8c11" type="selectionEntryGroup"/>
+        <entryLink id="13f7-f006-00fa-e304" name="Stratagem: Field Commander" hidden="false" collective="false" import="true" targetId="d043-3847-e963-fb5d" type="selectionEntry">
           <modifiers>
             <modifier type="set" field="hidden" value="true">
               <conditions>
@@ -6658,7 +6654,7 @@
             </modifier>
           </modifiers>
         </entryLink>
-        <entryLink id="d18f-5c73-4a81-0a61" name="Stompa Mob Character" hidden="false" collective="false" targetId="a2e0-0ff7-462d-bb22" type="selectionEntry"/>
+        <entryLink id="d18f-5c73-4a81-0a61" name="Stompa Mob Character" hidden="false" collective="false" import="true" targetId="a2e0-0ff7-462d-bb22" type="selectionEntry"/>
       </entryLinks>
       <costs>
         <cost name=" PL" typeId="e356-c769-5920-6e14" value="46.0"/>
@@ -6666,7 +6662,7 @@
         <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="5bcd-2f69-1bb9-070d" name="Tankbustas" hidden="false" collective="false" type="upgrade">
+    <selectionEntry id="5bcd-2f69-1bb9-070d" name="Tankbustas" hidden="false" collective="false" import="true" type="upgrade">
       <modifiers>
         <modifier type="increment" field="e356-c769-5920-6e14" value="4">
           <conditions>
@@ -6699,7 +6695,7 @@
         <categoryLink id="9f3a-ecd4-cefb-6061" name="New CategoryLink" hidden="false" targetId="abc4-649b-dfbe-9092" primary="false"/>
       </categoryLinks>
       <selectionEntries>
-        <selectionEntry id="bc90-919d-4451-bab4" name="Bomb Squig" hidden="false" collective="false" type="upgrade">
+        <selectionEntry id="bc90-919d-4451-bab4" name="Bomb Squig" hidden="false" collective="false" import="true" type="upgrade">
           <modifiers>
             <modifier type="increment" field="93e9-9b12-42bf-0d75" value="2">
               <repeats>
@@ -6736,7 +6732,7 @@
             <categoryLink id="e88f-d3a6-b0b0-957d" name="New CategoryLink" hidden="false" targetId="3d52-fccf-10c0-3fae" primary="false"/>
           </categoryLinks>
           <selectionEntries>
-            <selectionEntry id="8e7f-5b71-bae3-c82c" name="Squig Bomb" hidden="false" collective="true" type="upgrade">
+            <selectionEntry id="8e7f-5b71-bae3-c82c" name="Squig Bomb" hidden="false" collective="true" import="true" type="upgrade">
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c8fa-d8a2-cc17-0e7e" type="min"/>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bbc1-c314-eb40-f527" type="max"/>
@@ -6768,13 +6764,13 @@
         </selectionEntry>
       </selectionEntries>
       <selectionEntryGroups>
-        <selectionEntryGroup id="6447-d9ac-1e8a-4fdf" name="Mob" hidden="false" collective="false" defaultSelectionEntryId="6729-15fc-b7b1-dfc6">
+        <selectionEntryGroup id="6447-d9ac-1e8a-4fdf" name="Mob" hidden="false" collective="false" import="true" defaultSelectionEntryId="6729-15fc-b7b1-dfc6">
           <constraints>
             <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2b81-d0e4-76f3-c8cc" type="min"/>
             <constraint field="selections" scope="parent" value="15.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8ace-a071-762a-d764" type="max"/>
           </constraints>
           <selectionEntries>
-            <selectionEntry id="6729-15fc-b7b1-dfc6" name="Tankbusta" hidden="false" collective="false" type="model">
+            <selectionEntry id="6729-15fc-b7b1-dfc6" name="Tankbusta" hidden="false" collective="false" import="true" type="model">
               <profiles>
                 <profile id="1cbe-7652-2d37-7745" name="Tankbusta" hidden="false" typeId="800f-21d0-4387-c943" typeName="Unit">
                   <characteristics>
@@ -6791,7 +6787,7 @@
                 </profile>
               </profiles>
               <selectionEntries>
-                <selectionEntry id="d17c-5bd1-4d26-3ac5" name="Rokkit Launcha" hidden="false" collective="true" type="upgrade">
+                <selectionEntry id="d17c-5bd1-4d26-3ac5" name="Rokkit Launcha" hidden="false" collective="true" import="true" type="upgrade">
                   <constraints>
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d89e-d6f5-f3c3-329b" type="min"/>
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8646-5374-ad15-5d7c" type="max"/>
@@ -6807,8 +6803,8 @@
                 </selectionEntry>
               </selectionEntries>
               <entryLinks>
-                <entryLink id="4507-93ba-45dc-7370" name="New EntryLink" hidden="false" collective="false" targetId="6df7-0ee7-7e6d-b182" type="selectionEntry"/>
-                <entryLink id="baf2-bff4-67fc-1ec2" name="Tankbusta Bombs" hidden="false" collective="false" targetId="a592-1727-ef00-dae1" type="selectionEntry">
+                <entryLink id="4507-93ba-45dc-7370" name="New EntryLink" hidden="false" collective="false" import="true" targetId="6df7-0ee7-7e6d-b182" type="selectionEntry"/>
+                <entryLink id="baf2-bff4-67fc-1ec2" name="Tankbusta Bombs" hidden="false" collective="false" import="true" targetId="a592-1727-ef00-dae1" type="selectionEntry">
                   <constraints>
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="71e4-ecc3-2ed5-9df1" type="max"/>
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="82d2-d7de-1708-302c" type="min"/>
@@ -6821,7 +6817,7 @@
                 <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
               </costs>
             </selectionEntry>
-            <selectionEntry id="85b6-cb9a-0d78-52cd" name="Boss Nob" hidden="false" collective="false" type="model">
+            <selectionEntry id="85b6-cb9a-0d78-52cd" name="Boss Nob" hidden="false" collective="false" import="true" type="model">
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e20f-e060-20e6-0b03" type="max"/>
               </constraints>
@@ -6841,21 +6837,21 @@
                 </profile>
               </profiles>
               <selectionEntryGroups>
-                <selectionEntryGroup id="4c44-325f-093c-1d1c" name="Gear (Index)" hidden="false" collective="false" defaultSelectionEntryId="dedc-7cf5-2598-d553">
+                <selectionEntryGroup id="4c44-325f-093c-1d1c" name="Gear (Index)" hidden="false" collective="false" import="true" defaultSelectionEntryId="dedc-7cf5-2598-d553">
                   <constraints>
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a833-e35c-47fe-e9cf" type="max"/>
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="076f-f274-5be4-62cd" type="min"/>
                   </constraints>
                   <entryLinks>
-                    <entryLink id="dedc-7cf5-2598-d553" name="New EntryLink" hidden="false" collective="false" targetId="a8c1-7fb9-7f7b-84c5" type="selectionEntry"/>
-                    <entryLink id="f17e-9350-27de-019d" name="New EntryLink" hidden="false" collective="false" targetId="0470-1b47-489b-14c9" type="selectionEntry"/>
-                    <entryLink id="2aa7-3989-fdb4-5288" name="New EntryLink" hidden="false" collective="false" targetId="fe00-451f-6735-6fd9" type="selectionEntry"/>
+                    <entryLink id="dedc-7cf5-2598-d553" name="New EntryLink" hidden="false" collective="false" import="true" targetId="a8c1-7fb9-7f7b-84c5" type="selectionEntry"/>
+                    <entryLink id="f17e-9350-27de-019d" name="New EntryLink" hidden="false" collective="false" import="true" targetId="0470-1b47-489b-14c9" type="selectionEntry"/>
+                    <entryLink id="2aa7-3989-fdb4-5288" name="New EntryLink" hidden="false" collective="false" import="true" targetId="fe00-451f-6735-6fd9" type="selectionEntry"/>
                   </entryLinks>
                 </selectionEntryGroup>
               </selectionEntryGroups>
               <entryLinks>
-                <entryLink id="9ddc-c86e-d2c3-77e1" name="Stikkbombs" hidden="false" collective="false" targetId="6df7-0ee7-7e6d-b182" type="selectionEntry"/>
-                <entryLink id="d432-abad-649b-e7f9" name="Tankbusta Bombs" hidden="false" collective="false" targetId="a592-1727-ef00-dae1" type="selectionEntry">
+                <entryLink id="9ddc-c86e-d2c3-77e1" name="Stikkbombs" hidden="false" collective="false" import="true" targetId="6df7-0ee7-7e6d-b182" type="selectionEntry"/>
+                <entryLink id="d432-abad-649b-e7f9" name="Tankbusta Bombs" hidden="false" collective="false" import="true" targetId="a592-1727-ef00-dae1" type="selectionEntry">
                   <constraints>
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0bf7-b1ed-ee56-b530" type="max"/>
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b596-16d2-be6b-8bd7" type="min"/>
@@ -6868,7 +6864,7 @@
                 <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
               </costs>
             </selectionEntry>
-            <selectionEntry id="a36a-b5b5-f6e6-50ac" name="Tankbusta w/ Hammer" hidden="false" collective="false" type="model">
+            <selectionEntry id="a36a-b5b5-f6e6-50ac" name="Tankbusta w/ Hammer" hidden="false" collective="false" import="true" type="model">
               <modifiers>
                 <modifier type="increment" field="635c-4989-dc30-a6f6" value="1">
                   <repeats>
@@ -6895,7 +6891,7 @@
                 </profile>
               </profiles>
               <selectionEntries>
-                <selectionEntry id="2e8b-1167-70bc-14a3" name="Tankhammer" hidden="false" collective="true" type="upgrade">
+                <selectionEntry id="2e8b-1167-70bc-14a3" name="Tankhammer" hidden="false" collective="true" import="true" type="upgrade">
                   <constraints>
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f86e-7eba-bbf7-0c61" type="min"/>
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c9d8-5195-d742-c7ae" type="max"/>
@@ -6920,8 +6916,8 @@
                 </selectionEntry>
               </selectionEntries>
               <entryLinks>
-                <entryLink id="cc10-0776-79ff-bce5" name="New EntryLink" hidden="false" collective="false" targetId="6df7-0ee7-7e6d-b182" type="selectionEntry"/>
-                <entryLink id="e0c1-697c-2d3d-805c" name="Tankbusta Bombs" hidden="false" collective="false" targetId="a592-1727-ef00-dae1" type="selectionEntry">
+                <entryLink id="cc10-0776-79ff-bce5" name="New EntryLink" hidden="false" collective="false" import="true" targetId="6df7-0ee7-7e6d-b182" type="selectionEntry"/>
+                <entryLink id="e0c1-697c-2d3d-805c" name="Tankbusta Bombs" hidden="false" collective="false" import="true" targetId="a592-1727-ef00-dae1" type="selectionEntry">
                   <constraints>
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1c5c-c7d2-b64d-071f" type="max"/>
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d8df-7d0d-5f27-0e8e" type="min"/>
@@ -6934,7 +6930,7 @@
                 <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
               </costs>
             </selectionEntry>
-            <selectionEntry id="33ed-37ad-ce4c-782b" name="Tankbusta w/ Pistols" hidden="false" collective="false" type="model">
+            <selectionEntry id="33ed-37ad-ce4c-782b" name="Tankbusta w/ Pistols" hidden="false" collective="false" import="true" type="model">
               <modifiers>
                 <modifier type="increment" field="cbf2-58a6-d06c-74b6" value="1">
                   <repeats>
@@ -6961,7 +6957,7 @@
                 </profile>
               </profiles>
               <selectionEntries>
-                <selectionEntry id="92c3-23f1-5b01-5826" name="Pair of Rokkit Pistols" hidden="false" collective="true" type="upgrade">
+                <selectionEntry id="92c3-23f1-5b01-5826" name="Pair of Rokkit Pistols" hidden="false" collective="true" import="true" type="upgrade">
                   <constraints>
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="95e8-b446-1650-241e" type="min"/>
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="33eb-18af-c3aa-e0ba" type="max"/>
@@ -6986,8 +6982,8 @@
                 </selectionEntry>
               </selectionEntries>
               <entryLinks>
-                <entryLink id="7111-9056-2236-b95a" name="New EntryLink" hidden="false" collective="false" targetId="6df7-0ee7-7e6d-b182" type="selectionEntry"/>
-                <entryLink id="5bba-f9fb-4ab8-59d0" name="Tankbusta Bombs" hidden="false" collective="false" targetId="a592-1727-ef00-dae1" type="selectionEntry">
+                <entryLink id="7111-9056-2236-b95a" name="New EntryLink" hidden="false" collective="false" import="true" targetId="6df7-0ee7-7e6d-b182" type="selectionEntry"/>
+                <entryLink id="5bba-f9fb-4ab8-59d0" name="Tankbusta Bombs" hidden="false" collective="false" import="true" targetId="a592-1727-ef00-dae1" type="selectionEntry">
                   <constraints>
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="623a-d5fd-82a7-1c21" type="max"/>
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7a78-66d3-85fe-9094" type="min"/>
@@ -7004,8 +7000,8 @@
         </selectionEntryGroup>
       </selectionEntryGroups>
       <entryLinks>
-        <entryLink id="8e63-44f3-92f5-7b39" name="Has Battle Honours" hidden="false" collective="false" targetId="4763-757f-499f-d998" type="selectionEntry"/>
-        <entryLink id="3ea4-7326-bb37-5312" name="Battle Honours" hidden="false" collective="false" targetId="5518-d0f5-a880-d71c" type="selectionEntryGroup"/>
+        <entryLink id="8e63-44f3-92f5-7b39" name="Has Battle Honours" hidden="false" collective="false" import="true" targetId="4763-757f-499f-d998" type="selectionEntry"/>
+        <entryLink id="3ea4-7326-bb37-5312" name="Battle Honours" hidden="false" collective="false" import="true" targetId="5518-d0f5-a880-d71c" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
         <cost name=" PL" typeId="e356-c769-5920-6e14" value="4.0"/>
@@ -7013,7 +7009,7 @@
         <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="a592-1727-ef00-dae1" name="Tankbusta Bombs" hidden="false" collective="true" type="upgrade">
+    <selectionEntry id="a592-1727-ef00-dae1" name="Tankbusta Bombs" hidden="false" collective="true" import="true" type="upgrade">
       <profiles>
         <profile id="ae51-7252-e5c3-f9b8" name="Tankbusta Bombs" hidden="false" typeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" typeName="Weapon">
           <characteristics>
@@ -7032,7 +7028,7 @@
         <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="5a1a-e62f-5896-dca6" name="Power Stabba" hidden="false" collective="false" type="upgrade">
+    <selectionEntry id="5a1a-e62f-5896-dca6" name="Power Stabba" hidden="false" collective="false" import="true" type="upgrade">
       <profiles>
         <profile id="26e0-b01f-b3cc-173b" name="Power Stabba" hidden="false" typeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" typeName="Weapon">
           <characteristics>
@@ -7051,7 +7047,7 @@
         <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="2472-0afa-3962-274a" name="Zhadsnark Da Ripper" hidden="false" collective="false" type="unit">
+    <selectionEntry id="2472-0afa-3962-274a" name="Zhadsnark Da Ripper" hidden="false" collective="false" import="true" type="unit">
       <modifiers>
         <modifier type="set" field="hidden" value="true">
           <conditionGroups>
@@ -7109,7 +7105,7 @@
         <categoryLink id="3742-28ac-7f0d-7a6c" name="Speed Freeks" hidden="false" targetId="258d-e4cb-6f35-fe20" primary="false"/>
       </categoryLinks>
       <selectionEntries>
-        <selectionEntry id="d9aa-9a77-54cc-6ef1" name="Da Pain Klaw" hidden="false" collective="false" type="upgrade">
+        <selectionEntry id="d9aa-9a77-54cc-6ef1" name="Da Pain Klaw" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2374-e916-c0b5-370c" type="min"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="48b3-b727-6e01-bba3" type="max"/>
@@ -7132,7 +7128,7 @@
             <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
           </costs>
         </selectionEntry>
-        <selectionEntry id="cbb9-9ca4-cd38-bcf7" name="Da Beast" hidden="false" collective="false" type="upgrade">
+        <selectionEntry id="cbb9-9ca4-cd38-bcf7" name="Da Beast" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="926b-00a8-03f6-06db" type="min"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="820a-437b-8216-4e17" type="max"/>
@@ -7145,7 +7141,7 @@
             </profile>
           </profiles>
           <entryLinks>
-            <entryLink id="c542-ed2f-b5fa-e470" name="Big Shoota" hidden="false" collective="false" targetId="6008-4737-d8e6-e63b" type="selectionEntry">
+            <entryLink id="c542-ed2f-b5fa-e470" name="Big Shoota" hidden="false" collective="false" import="true" targetId="6008-4737-d8e6-e63b" type="selectionEntry">
               <constraints>
                 <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2b0d-5fa1-ce2a-59f0" type="min"/>
                 <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1e42-5c85-239d-475f" type="max"/>
@@ -7160,14 +7156,14 @@
         </selectionEntry>
       </selectionEntries>
       <entryLinks>
-        <entryLink id="52a9-f568-094c-72ed" name="Slugga" hidden="false" collective="false" targetId="d13b-ad69-e6a2-d485" type="selectionEntry">
+        <entryLink id="52a9-f568-094c-72ed" name="Slugga" hidden="false" collective="false" import="true" targetId="d13b-ad69-e6a2-d485" type="selectionEntry">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8da1-dc80-ec93-3739" type="min"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1651-3fc6-3f99-24fb" type="max"/>
           </constraints>
         </entryLink>
-        <entryLink id="e039-c7b1-bb6f-2d68" name="Stikkbombs" hidden="false" collective="false" targetId="6df7-0ee7-7e6d-b182" type="selectionEntry"/>
-        <entryLink id="bb4f-6a3c-3da9-acda" name="Warlord" hidden="false" collective="false" targetId="33f6-60da-7b70-5fee" type="selectionEntry"/>
+        <entryLink id="e039-c7b1-bb6f-2d68" name="Stikkbombs" hidden="false" collective="false" import="true" targetId="6df7-0ee7-7e6d-b182" type="selectionEntry"/>
+        <entryLink id="bb4f-6a3c-3da9-acda" name="Warlord" hidden="false" collective="false" import="true" targetId="33f6-60da-7b70-5fee" type="selectionEntry"/>
       </entryLinks>
       <costs>
         <cost name=" PL" typeId="e356-c769-5920-6e14" value="7.0"/>
@@ -7175,7 +7171,7 @@
         <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="36e2-087e-77dd-441b" name="Ork Mek Boss Buzzgob" hidden="false" collective="false" type="unit">
+    <selectionEntry id="36e2-087e-77dd-441b" name="Ork Mek Boss Buzzgob" hidden="false" collective="false" import="true" type="unit">
       <modifiers>
         <modifier type="set" field="hidden" value="true">
           <conditionGroups>
@@ -7228,7 +7224,7 @@
         <categoryLink id="9257-ebc7-2c6f-c8f6" name="New CategoryLink" hidden="false" targetId="5b59-d8c9-677c-a096" primary="false"/>
       </categoryLinks>
       <selectionEntries>
-        <selectionEntry id="173b-0416-7567-f91c" name="Nitnuckle and Lunk" hidden="false" collective="false" type="upgrade">
+        <selectionEntry id="173b-0416-7567-f91c" name="Nitnuckle and Lunk" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="13dd-6c29-05f2-a80f" type="max"/>
           </constraints>
@@ -7267,7 +7263,7 @@
             <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
           </costs>
         </selectionEntry>
-        <selectionEntry id="36b0-adf5-384a-efbb" name="Mek arms" hidden="false" collective="false" type="upgrade">
+        <selectionEntry id="36b0-adf5-384a-efbb" name="Mek arms" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6edd-fd72-3123-8d2f" type="min"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a65e-2853-321b-cb6d" type="max"/>
@@ -7290,7 +7286,7 @@
             <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
           </costs>
         </selectionEntry>
-        <selectionEntry id="bff3-52f8-476d-99b5" name="Kustom Force Field" hidden="false" collective="false" type="upgrade">
+        <selectionEntry id="bff3-52f8-476d-99b5" name="Kustom Force Field" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ed06-917c-a072-3cf5" type="max"/>
           </constraints>
@@ -7309,8 +7305,8 @@
         </selectionEntry>
       </selectionEntries>
       <entryLinks>
-        <entryLink id="b7a9-ac15-e3b8-128b" name="Stikkbombs" hidden="false" collective="false" targetId="6df7-0ee7-7e6d-b182" type="selectionEntry"/>
-        <entryLink id="843f-a31f-d150-dfe3" name="Big Choppa" hidden="false" collective="false" targetId="0470-1b47-489b-14c9" type="selectionEntry">
+        <entryLink id="b7a9-ac15-e3b8-128b" name="Stikkbombs" hidden="false" collective="false" import="true" targetId="6df7-0ee7-7e6d-b182" type="selectionEntry"/>
+        <entryLink id="843f-a31f-d150-dfe3" name="Big Choppa" hidden="false" collective="false" import="true" targetId="0470-1b47-489b-14c9" type="selectionEntry">
           <modifiers>
             <modifier type="set" field="points" value="0.0"/>
           </modifiers>
@@ -7319,13 +7315,13 @@
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f584-a71e-5367-2aba" type="max"/>
           </constraints>
         </entryLink>
-        <entryLink id="2dbe-7610-a837-e377" name="Slugga" hidden="false" collective="false" targetId="d13b-ad69-e6a2-d485" type="selectionEntry">
+        <entryLink id="2dbe-7610-a837-e377" name="Slugga" hidden="false" collective="false" import="true" targetId="d13b-ad69-e6a2-d485" type="selectionEntry">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4328-9c2a-2974-188d" type="min"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="20a8-31b7-f011-f33a" type="max"/>
           </constraints>
         </entryLink>
-        <entryLink id="da1f-7a2e-85aa-a64a" name="Warlord" hidden="false" collective="false" targetId="33f6-60da-7b70-5fee" type="selectionEntry"/>
+        <entryLink id="da1f-7a2e-85aa-a64a" name="Warlord" hidden="false" collective="false" import="true" targetId="33f6-60da-7b70-5fee" type="selectionEntry"/>
       </entryLinks>
       <costs>
         <cost name=" PL" typeId="e356-c769-5920-6e14" value="6.0"/>
@@ -7333,7 +7329,7 @@
         <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="c7e2-297c-a0f9-a9fe" name="Grot Tanks" hidden="false" collective="false" type="unit">
+    <selectionEntry id="c7e2-297c-a0f9-a9fe" name="Grot Tanks" hidden="false" collective="false" import="true" type="unit">
       <modifiers>
         <modifier type="increment" field="e356-c769-5920-6e14" value="6">
           <conditions>
@@ -7362,7 +7358,7 @@
         <categoryLink id="ff5c-1cbd-fd3e-e4ab" name="New CategoryLink" hidden="false" targetId="0b2c-1505-90c2-24ed" primary="false"/>
       </categoryLinks>
       <selectionEntries>
-        <selectionEntry id="046c-df28-59d9-d547" name="Big Mek Required" hidden="false" collective="false" type="upgrade">
+        <selectionEntry id="046c-df28-59d9-d547" name="Big Mek Required" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7642-e858-79e6-bbbb" type="min"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bdc8-85db-0a3d-e1c3" type="max"/>
@@ -7375,13 +7371,13 @@
         </selectionEntry>
       </selectionEntries>
       <selectionEntryGroups>
-        <selectionEntryGroup id="1069-a41d-6ed3-b330" name="Mob" hidden="false" collective="false" defaultSelectionEntryId="1952-cfd1-6c20-5406">
+        <selectionEntryGroup id="1069-a41d-6ed3-b330" name="Mob" hidden="false" collective="false" import="true" defaultSelectionEntryId="1952-cfd1-6c20-5406">
           <constraints>
             <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7ebc-9bd3-d35e-c4bc" type="min"/>
             <constraint field="selections" scope="parent" value="8.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c8a0-22b0-bb6f-f469" type="max"/>
           </constraints>
           <selectionEntries>
-            <selectionEntry id="1952-cfd1-6c20-5406" name="Grot Tank" hidden="false" collective="false" type="model">
+            <selectionEntry id="1952-cfd1-6c20-5406" name="Grot Tank" hidden="false" collective="false" import="true" type="model">
               <profiles>
                 <profile id="512f-c621-16c8-6f49" name="Grot Tank" hidden="false" typeId="800f-21d0-4387-c943" typeName="Unit">
                   <characteristics>
@@ -7398,28 +7394,28 @@
                 </profile>
               </profiles>
               <selectionEntryGroups>
-                <selectionEntryGroup id="b2ff-1b13-d7cf-86d2" name="Main Gun" hidden="false" collective="false" defaultSelectionEntryId="acb5-e37e-d775-da4a">
+                <selectionEntryGroup id="b2ff-1b13-d7cf-86d2" name="Main Gun" hidden="false" collective="false" import="true" defaultSelectionEntryId="acb5-e37e-d775-da4a">
                   <constraints>
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7cd9-88f0-210f-d322" type="min"/>
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bd83-d7ac-a8a5-09eb" type="max"/>
                   </constraints>
                   <entryLinks>
-                    <entryLink id="acb5-e37e-d775-da4a" name="Big Shoota" hidden="false" collective="false" targetId="6008-4737-d8e6-e63b" type="selectionEntry"/>
-                    <entryLink id="2bdc-0c2c-5d2b-a375" name="Rokkit Launcha" hidden="false" collective="false" targetId="a8c1-7fb9-7f7b-84c5" type="selectionEntry"/>
-                    <entryLink id="0295-6183-386c-5bfe" name="Skorcha" hidden="false" collective="false" targetId="e05b-21b5-8727-ea9d" type="selectionEntry"/>
-                    <entryLink id="f6a7-f0de-8964-db55" name="Kustom Mega-blasta" hidden="false" collective="false" targetId="6d70-25a8-b496-2457" type="selectionEntry"/>
-                    <entryLink id="0681-523a-4fb6-681d" name="Grotzooka" hidden="false" collective="false" targetId="e91e-e2c3-15e1-e677" type="selectionEntry"/>
+                    <entryLink id="acb5-e37e-d775-da4a" name="Big Shoota" hidden="false" collective="false" import="true" targetId="6008-4737-d8e6-e63b" type="selectionEntry"/>
+                    <entryLink id="2bdc-0c2c-5d2b-a375" name="Rokkit Launcha" hidden="false" collective="false" import="true" targetId="a8c1-7fb9-7f7b-84c5" type="selectionEntry"/>
+                    <entryLink id="0295-6183-386c-5bfe" name="Skorcha" hidden="false" collective="false" import="true" targetId="e05b-21b5-8727-ea9d" type="selectionEntry"/>
+                    <entryLink id="f6a7-f0de-8964-db55" name="Kustom Mega-blasta" hidden="false" collective="false" import="true" targetId="6d70-25a8-b496-2457" type="selectionEntry"/>
+                    <entryLink id="0681-523a-4fb6-681d" name="Grotzooka" hidden="false" collective="false" import="true" targetId="e91e-e2c3-15e1-e677" type="selectionEntry"/>
                   </entryLinks>
                 </selectionEntryGroup>
               </selectionEntryGroups>
               <entryLinks>
-                <entryLink id="5e6e-646a-0d14-1ba4" name="Shoota" hidden="false" collective="false" targetId="f314-b941-342f-289c" type="selectionEntry">
+                <entryLink id="5e6e-646a-0d14-1ba4" name="Shoota" hidden="false" collective="false" import="true" targetId="f314-b941-342f-289c" type="selectionEntry">
                   <constraints>
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a249-b695-9fa6-101d" type="max"/>
                   </constraints>
                 </entryLink>
-                <entryLink id="42d8-0d8e-4a1e-4e05" name="Has Battle Honours" hidden="false" collective="false" targetId="4763-757f-499f-d998" type="selectionEntry"/>
-                <entryLink id="99f4-f203-203e-3690" name="Battle Honours" hidden="false" collective="false" targetId="5518-d0f5-a880-d71c" type="selectionEntryGroup"/>
+                <entryLink id="42d8-0d8e-4a1e-4e05" name="Has Battle Honours" hidden="false" collective="false" import="true" targetId="4763-757f-499f-d998" type="selectionEntry"/>
+                <entryLink id="99f4-f203-203e-3690" name="Battle Honours" hidden="false" collective="false" import="true" targetId="5518-d0f5-a880-d71c" type="selectionEntryGroup"/>
               </entryLinks>
               <costs>
                 <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0"/>
@@ -7427,7 +7423,7 @@
                 <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
               </costs>
             </selectionEntry>
-            <selectionEntry id="b541-4d1f-4c69-3e05" name="Kommanda" hidden="false" collective="false" type="model">
+            <selectionEntry id="b541-4d1f-4c69-3e05" name="Kommanda" hidden="false" collective="false" import="true" type="model">
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3ec0-c866-aef7-4e7a" type="max"/>
               </constraints>
@@ -7447,33 +7443,33 @@
                 </profile>
               </profiles>
               <selectionEntryGroups>
-                <selectionEntryGroup id="a084-ccb1-4d77-6b79" name="Main Gun (1-2)" hidden="false" collective="false" defaultSelectionEntryId="4b21-b9bb-39bc-bffd">
+                <selectionEntryGroup id="a084-ccb1-4d77-6b79" name="Main Gun (1-2)" hidden="false" collective="false" import="true" defaultSelectionEntryId="4b21-b9bb-39bc-bffd">
                   <constraints>
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d2b6-50f7-12eb-4a3f" type="min"/>
                     <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fa2d-9a15-b4f9-5fab" type="max"/>
                   </constraints>
                   <entryLinks>
-                    <entryLink id="4b21-b9bb-39bc-bffd" name="Big Shoota" hidden="false" collective="false" targetId="6008-4737-d8e6-e63b" type="selectionEntry">
+                    <entryLink id="4b21-b9bb-39bc-bffd" name="Big Shoota" hidden="false" collective="false" import="true" targetId="6008-4737-d8e6-e63b" type="selectionEntry">
                       <constraints>
                         <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="37a7-1aef-d01f-7f90" type="max"/>
                       </constraints>
                     </entryLink>
-                    <entryLink id="46e5-32a0-d105-5617" name="Rokkit Launcha" hidden="false" collective="false" targetId="a8c1-7fb9-7f7b-84c5" type="selectionEntry">
+                    <entryLink id="46e5-32a0-d105-5617" name="Rokkit Launcha" hidden="false" collective="false" import="true" targetId="a8c1-7fb9-7f7b-84c5" type="selectionEntry">
                       <constraints>
                         <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c3d8-7180-1928-29b3" type="max"/>
                       </constraints>
                     </entryLink>
-                    <entryLink id="5039-b202-df40-02bb" name="Skorcha" hidden="false" collective="false" targetId="e05b-21b5-8727-ea9d" type="selectionEntry">
+                    <entryLink id="5039-b202-df40-02bb" name="Skorcha" hidden="false" collective="false" import="true" targetId="e05b-21b5-8727-ea9d" type="selectionEntry">
                       <constraints>
                         <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1964-46c5-2536-804a" type="max"/>
                       </constraints>
                     </entryLink>
-                    <entryLink id="0779-0e83-c4d7-5d16" name="Kustom Mega-blasta" hidden="false" collective="false" targetId="6d70-25a8-b496-2457" type="selectionEntry">
+                    <entryLink id="0779-0e83-c4d7-5d16" name="Kustom Mega-blasta" hidden="false" collective="false" import="true" targetId="6d70-25a8-b496-2457" type="selectionEntry">
                       <constraints>
                         <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7f3e-612b-2a9f-58f3" type="max"/>
                       </constraints>
                     </entryLink>
-                    <entryLink id="4abc-34e3-73d3-221a" name="Grotzooka" hidden="false" collective="false" targetId="e91e-e2c3-15e1-e677" type="selectionEntry">
+                    <entryLink id="4abc-34e3-73d3-221a" name="Grotzooka" hidden="false" collective="false" import="true" targetId="e91e-e2c3-15e1-e677" type="selectionEntry">
                       <constraints>
                         <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8dfa-5511-255d-3e81" type="max"/>
                       </constraints>
@@ -7482,13 +7478,13 @@
                 </selectionEntryGroup>
               </selectionEntryGroups>
               <entryLinks>
-                <entryLink id="16c8-4969-ce02-182b" name="Shoota" hidden="false" collective="false" targetId="f314-b941-342f-289c" type="selectionEntry">
+                <entryLink id="16c8-4969-ce02-182b" name="Shoota" hidden="false" collective="false" import="true" targetId="f314-b941-342f-289c" type="selectionEntry">
                   <constraints>
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b0b1-80ef-f2ba-41fa" type="max"/>
                   </constraints>
                 </entryLink>
-                <entryLink id="7926-e751-1664-fb80" name="Has Battle Honours" hidden="false" collective="false" targetId="4763-757f-499f-d998" type="selectionEntry"/>
-                <entryLink id="929a-2020-0a03-06bc" name="Battle Honours" hidden="false" collective="false" targetId="5518-d0f5-a880-d71c" type="selectionEntryGroup"/>
+                <entryLink id="7926-e751-1664-fb80" name="Has Battle Honours" hidden="false" collective="false" import="true" targetId="4763-757f-499f-d998" type="selectionEntry"/>
+                <entryLink id="929a-2020-0a03-06bc" name="Battle Honours" hidden="false" collective="false" import="true" targetId="5518-d0f5-a880-d71c" type="selectionEntryGroup"/>
               </entryLinks>
               <costs>
                 <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0"/>
@@ -7505,7 +7501,7 @@
         <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="e91e-e2c3-15e1-e677" name="Grotzooka" hidden="false" collective="false" type="upgrade">
+    <selectionEntry id="e91e-e2c3-15e1-e677" name="Grotzooka" hidden="false" collective="false" import="true" type="upgrade">
       <infoLinks>
         <infoLink id="2e55-708a-032b-e535" name="Grotzooka" hidden="false" targetId="f05d-1990-b3e0-4a44" type="profile"/>
       </infoLinks>
@@ -7515,7 +7511,7 @@
         <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="688b-7929-cf2f-6c5d" name="Grot Mega-Tank" hidden="false" collective="false" type="unit">
+    <selectionEntry id="688b-7929-cf2f-6c5d" name="Grot Mega-Tank" hidden="false" collective="false" import="true" type="unit">
       <profiles>
         <profile id="5675-a957-aff1-7a22" name="Rolling Scrap Pile" hidden="false" typeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" typeName="Abilities">
           <characteristics>
@@ -7558,7 +7554,7 @@
         <categoryLink id="ba3d-a4cd-ffcb-7d3b" name="New CategoryLink" hidden="false" targetId="e1ff-90b3-1689-5fec" primary="false"/>
       </categoryLinks>
       <selectionEntries>
-        <selectionEntry id="0575-a059-96ea-3001" name="Boom Kanisters" hidden="false" collective="false" type="upgrade">
+        <selectionEntry id="0575-a059-96ea-3001" name="Boom Kanisters" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
             <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1ae2-a687-f4ab-59d4" type="max"/>
           </constraints>
@@ -7582,13 +7578,13 @@
         </selectionEntry>
       </selectionEntries>
       <selectionEntryGroups>
-        <selectionEntryGroup id="ca29-5da0-3a90-ab53" name="Heavy Turrets (2)" hidden="false" collective="false" defaultSelectionEntryId="55d3-e2ee-5156-db16">
+        <selectionEntryGroup id="ca29-5da0-3a90-ab53" name="Heavy Turrets (2)" hidden="false" collective="false" import="true" defaultSelectionEntryId="55d3-e2ee-5156-db16">
           <constraints>
             <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b28f-e35b-733d-a635" type="min"/>
             <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e611-cf68-334a-58cd" type="max"/>
           </constraints>
           <selectionEntries>
-            <selectionEntry id="871d-e2c9-cb43-17e6" name="2x Skorcha" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="871d-e2c9-cb43-17e6" name="2x Skorcha" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
                 <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="03ed-b37a-a48b-7c99" type="max"/>
               </constraints>
@@ -7601,7 +7597,7 @@
                 <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
               </costs>
             </selectionEntry>
-            <selectionEntry id="6a9d-da7f-edfa-23d7" name="2x Grotzookas" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="6a9d-da7f-edfa-23d7" name="2x Grotzookas" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
                 <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1c41-77af-5969-5983" type="max"/>
               </constraints>
@@ -7614,7 +7610,7 @@
                 <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
               </costs>
             </selectionEntry>
-            <selectionEntry id="954b-8ae0-c239-4095" name="2x Kustom Mega Blasta" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="954b-8ae0-c239-4095" name="2x Kustom Mega Blasta" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
                 <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="baf9-5331-80f0-369d" type="max"/>
               </constraints>
@@ -7629,45 +7625,45 @@
             </selectionEntry>
           </selectionEntries>
           <entryLinks>
-            <entryLink id="55d3-e2ee-5156-db16" name="Twin Big Shoota" hidden="false" collective="false" targetId="a4f1-6ccb-1c50-405b" type="selectionEntry">
+            <entryLink id="55d3-e2ee-5156-db16" name="Twin Big Shoota" hidden="false" collective="false" import="true" targetId="a4f1-6ccb-1c50-405b" type="selectionEntry">
               <constraints>
                 <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="268c-c511-c5bb-b2c9" type="max"/>
               </constraints>
             </entryLink>
-            <entryLink id="4557-0ee7-1974-8902" name="Rack of Rokkits" hidden="false" collective="false" targetId="17f9-fccd-55db-b80a" type="selectionEntry">
+            <entryLink id="4557-0ee7-1974-8902" name="Rack of Rokkits" hidden="false" collective="false" import="true" targetId="17f9-fccd-55db-b80a" type="selectionEntry">
               <constraints>
                 <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e3bd-5bb9-b907-e417" type="max"/>
               </constraints>
             </entryLink>
           </entryLinks>
         </selectionEntryGroup>
-        <selectionEntryGroup id="323c-f293-3635-d581" name="Light Turret (3)" hidden="false" collective="false" defaultSelectionEntryId="0c48-76c0-b858-1af0">
+        <selectionEntryGroup id="323c-f293-3635-d581" name="Light Turret (3)" hidden="false" collective="false" import="true" defaultSelectionEntryId="0c48-76c0-b858-1af0">
           <constraints>
             <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="36fd-4d3e-3f67-cbd9" type="min"/>
             <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="727f-f0f9-03c7-d6eb" type="max"/>
           </constraints>
           <entryLinks>
-            <entryLink id="0c48-76c0-b858-1af0" name="Big Shoota" hidden="false" collective="false" targetId="6008-4737-d8e6-e63b" type="selectionEntry">
+            <entryLink id="0c48-76c0-b858-1af0" name="Big Shoota" hidden="false" collective="false" import="true" targetId="6008-4737-d8e6-e63b" type="selectionEntry">
               <constraints>
                 <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="cb8c-b112-951e-8de5" type="max"/>
               </constraints>
             </entryLink>
-            <entryLink id="7290-80dd-45d0-d159" name="Rokkit Launcha" hidden="false" collective="false" targetId="a8c1-7fb9-7f7b-84c5" type="selectionEntry">
+            <entryLink id="7290-80dd-45d0-d159" name="Rokkit Launcha" hidden="false" collective="false" import="true" targetId="a8c1-7fb9-7f7b-84c5" type="selectionEntry">
               <constraints>
                 <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6354-39a9-2845-6c07" type="max"/>
               </constraints>
             </entryLink>
-            <entryLink id="115d-f36c-528f-4daf" name="Skorcha" hidden="false" collective="false" targetId="e05b-21b5-8727-ea9d" type="selectionEntry">
+            <entryLink id="115d-f36c-528f-4daf" name="Skorcha" hidden="false" collective="false" import="true" targetId="e05b-21b5-8727-ea9d" type="selectionEntry">
               <constraints>
                 <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c216-7bd1-c61c-5bd5" type="max"/>
               </constraints>
             </entryLink>
-            <entryLink id="d651-2031-0286-261c" name="Kustom Mega-blasta" hidden="false" collective="false" targetId="6d70-25a8-b496-2457" type="selectionEntry">
+            <entryLink id="d651-2031-0286-261c" name="Kustom Mega-blasta" hidden="false" collective="false" import="true" targetId="6d70-25a8-b496-2457" type="selectionEntry">
               <constraints>
                 <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b3a1-e6d4-44ba-df41" type="max"/>
               </constraints>
             </entryLink>
-            <entryLink id="3930-78f5-cc67-99a1" name="Grotzooka" hidden="false" collective="false" targetId="e91e-e2c3-15e1-e677" type="selectionEntry">
+            <entryLink id="3930-78f5-cc67-99a1" name="Grotzooka" hidden="false" collective="false" import="true" targetId="e91e-e2c3-15e1-e677" type="selectionEntry">
               <constraints>
                 <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f54e-d33e-ad84-6ae2" type="max"/>
               </constraints>
@@ -7676,18 +7672,18 @@
         </selectionEntryGroup>
       </selectionEntryGroups>
       <entryLinks>
-        <entryLink id="020b-1a26-7073-a6b7" name="Shoota" hidden="false" collective="false" targetId="f314-b941-342f-289c" type="selectionEntry">
+        <entryLink id="020b-1a26-7073-a6b7" name="Shoota" hidden="false" collective="false" import="true" targetId="f314-b941-342f-289c" type="selectionEntry">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5cf9-4d14-bc96-c21c" type="max"/>
           </constraints>
         </entryLink>
-        <entryLink id="5b4c-e927-b823-b9a5" name="Wreckin&apos; Ball" hidden="false" collective="false" targetId="afdc-8903-044a-a42e" type="selectionEntry">
+        <entryLink id="5b4c-e927-b823-b9a5" name="Wreckin&apos; Ball" hidden="false" collective="false" import="true" targetId="afdc-8903-044a-a42e" type="selectionEntry">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="77da-1ea1-8e87-b724" type="max"/>
           </constraints>
         </entryLink>
-        <entryLink id="c4e6-11b8-0333-63e4" name="Has Battle Honours" hidden="false" collective="false" targetId="4763-757f-499f-d998" type="selectionEntry"/>
-        <entryLink id="2a51-e710-4b7b-2519" name="Battle Honours" hidden="false" collective="false" targetId="5518-d0f5-a880-d71c" type="selectionEntryGroup"/>
+        <entryLink id="c4e6-11b8-0333-63e4" name="Has Battle Honours" hidden="false" collective="false" import="true" targetId="4763-757f-499f-d998" type="selectionEntry"/>
+        <entryLink id="2a51-e710-4b7b-2519" name="Battle Honours" hidden="false" collective="false" import="true" targetId="5518-d0f5-a880-d71c" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
         <cost name=" PL" typeId="e356-c769-5920-6e14" value="7.0"/>
@@ -7695,7 +7691,7 @@
         <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="e6c8-1855-9421-3cc4" name="Squiggoth" hidden="false" collective="false" type="unit">
+    <selectionEntry id="e6c8-1855-9421-3cc4" name="Squiggoth" hidden="false" collective="false" import="true" type="unit">
       <profiles>
         <profile id="f3a8-cca7-3a6a-0da9" name="Squiggoth" hidden="false" typeId="800f-21d0-4387-c943" typeName="Unit">
           <characteristics>
@@ -7762,26 +7758,26 @@
         <categoryLink id="aba2-d774-3e88-aca3" name="New CategoryLink" hidden="false" targetId="3b77-decb-d468-6bcc" primary="false"/>
       </categoryLinks>
       <selectionEntryGroups>
-        <selectionEntryGroup id="22ab-4d80-f712-42e0" name="Gun" hidden="false" collective="false" defaultSelectionEntryId="0b93-0bb6-4714-a36a">
+        <selectionEntryGroup id="22ab-4d80-f712-42e0" name="Gun" hidden="false" collective="false" import="true" defaultSelectionEntryId="0b93-0bb6-4714-a36a">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="98c9-eecf-1dfb-b297" type="max"/>
           </constraints>
           <entryLinks>
-            <entryLink id="0b93-0bb6-4714-a36a" name="Kannon" hidden="false" collective="false" targetId="b3d8-73ff-d4fc-c2ac" type="selectionEntry"/>
-            <entryLink id="60ba-251c-5ff3-7dd4" name="Zzap gun" hidden="false" collective="false" targetId="b390-deb9-6d7e-d632" type="selectionEntry"/>
-            <entryLink id="f275-4c61-c236-3b31" name="Lobba" hidden="false" collective="false" targetId="b25a-5184-36ce-d147" type="selectionEntry"/>
+            <entryLink id="0b93-0bb6-4714-a36a" name="Kannon" hidden="false" collective="false" import="true" targetId="b3d8-73ff-d4fc-c2ac" type="selectionEntry"/>
+            <entryLink id="60ba-251c-5ff3-7dd4" name="Zzap gun" hidden="false" collective="false" import="true" targetId="b390-deb9-6d7e-d632" type="selectionEntry"/>
+            <entryLink id="f275-4c61-c236-3b31" name="Lobba" hidden="false" collective="false" import="true" targetId="b25a-5184-36ce-d147" type="selectionEntry"/>
           </entryLinks>
         </selectionEntryGroup>
       </selectionEntryGroups>
       <entryLinks>
-        <entryLink id="6879-7ecb-c51c-1bfc" name="Gorin&apos; Horns" hidden="false" collective="false" targetId="945e-f882-56b2-3f7e" type="selectionEntry">
+        <entryLink id="6879-7ecb-c51c-1bfc" name="Gorin&apos; Horns" hidden="false" collective="false" import="true" targetId="945e-f882-56b2-3f7e" type="selectionEntry">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2bbe-6b36-cd5e-d716" type="min"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bc14-433b-7f81-5e1f" type="max"/>
           </constraints>
         </entryLink>
-        <entryLink id="7204-b6e6-cd48-1ac9" name="Has Battle Honours" hidden="false" collective="false" targetId="4763-757f-499f-d998" type="selectionEntry"/>
-        <entryLink id="4450-2f9d-aea9-d9ae" name="Battle Honours" hidden="false" collective="false" targetId="5518-d0f5-a880-d71c" type="selectionEntryGroup"/>
+        <entryLink id="7204-b6e6-cd48-1ac9" name="Has Battle Honours" hidden="false" collective="false" import="true" targetId="4763-757f-499f-d998" type="selectionEntry"/>
+        <entryLink id="4450-2f9d-aea9-d9ae" name="Battle Honours" hidden="false" collective="false" import="true" targetId="5518-d0f5-a880-d71c" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
         <cost name=" PL" typeId="e356-c769-5920-6e14" value="12.0"/>
@@ -7789,7 +7785,7 @@
         <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="1254-ab58-4b43-66ab" name="Meka-Dread" hidden="false" collective="false" type="unit">
+    <selectionEntry id="1254-ab58-4b43-66ab" name="Meka-Dread" hidden="false" collective="false" import="true" type="unit">
       <profiles>
         <profile id="1e12-428a-17d9-56b5" name="Meka-Dread" hidden="false" typeId="800f-21d0-4387-c943" typeName="Unit">
           <characteristics>
@@ -7851,13 +7847,13 @@
         <categoryLink id="f58d-094c-0115-1135" name="New CategoryLink" hidden="false" targetId="c8fd-783f-3230-493e" primary="false"/>
       </categoryLinks>
       <selectionEntryGroups>
-        <selectionEntryGroup id="3ae2-dfbe-8361-978f" name="Special Ability" hidden="false" collective="false" defaultSelectionEntryId="45e5-356c-4e01-2587">
+        <selectionEntryGroup id="3ae2-dfbe-8361-978f" name="Special Ability" hidden="false" collective="false" import="true" defaultSelectionEntryId="45e5-356c-4e01-2587">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="aaea-be9a-0c73-948a" type="min"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4e66-b979-c6cc-343d" type="max"/>
           </constraints>
           <selectionEntries>
-            <selectionEntry id="45e5-356c-4e01-2587" name="Mega Charga" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="45e5-356c-4e01-2587" name="Mega Charga" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="18bd-5162-8216-5d2f" type="max"/>
               </constraints>
@@ -7874,7 +7870,7 @@
                 <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
               </costs>
             </selectionEntry>
-            <selectionEntry id="e583-7cba-d29c-6543" name="Rokkit-Bomms" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="e583-7cba-d29c-6543" name="Rokkit-Bomms" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a01b-0e6a-bba8-5096" type="max"/>
               </constraints>
@@ -7896,9 +7892,9 @@
                 <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
               </costs>
             </selectionEntry>
-            <selectionEntry id="cc49-4342-2118-1409" name="2 Big Shootas" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="cc49-4342-2118-1409" name="2 Big Shootas" hidden="false" collective="false" import="true" type="upgrade">
               <entryLinks>
-                <entryLink id="5246-a862-f7a0-05b3" name="Big Shoota" hidden="false" collective="false" targetId="6008-4737-d8e6-e63b" type="selectionEntry">
+                <entryLink id="5246-a862-f7a0-05b3" name="Big Shoota" hidden="false" collective="false" import="true" targetId="6008-4737-d8e6-e63b" type="selectionEntry">
                   <constraints>
                     <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a027-e326-2a52-e386" type="min"/>
                     <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a656-574d-4b37-46be" type="max"/>
@@ -7913,24 +7909,24 @@
             </selectionEntry>
           </selectionEntries>
           <entryLinks>
-            <entryLink id="608a-34d9-ddc8-5be2" name="Kustom Force Field" hidden="false" collective="false" targetId="886c-c494-3fbb-e1ec" type="selectionEntry"/>
+            <entryLink id="608a-34d9-ddc8-5be2" name="Kustom Force Field" hidden="false" collective="false" import="true" targetId="886c-c494-3fbb-e1ec" type="selectionEntry"/>
           </entryLinks>
         </selectionEntryGroup>
-        <selectionEntryGroup id="54ea-7b9f-1de5-0eaa" name="Arms" hidden="false" collective="false" defaultSelectionEntryId="55ab-88b5-4b3a-e557">
+        <selectionEntryGroup id="54ea-7b9f-1de5-0eaa" name="Arms" hidden="false" collective="false" import="true" defaultSelectionEntryId="55ab-88b5-4b3a-e557">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="30cd-f40f-4a54-30c4" type="min"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="eaeb-0a59-38da-b4b5" type="max"/>
           </constraints>
           <selectionEntries>
-            <selectionEntry id="55ab-88b5-4b3a-e557" name="2 Rippa Klaws" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="55ab-88b5-4b3a-e557" name="2 Rippa Klaws" hidden="false" collective="false" import="true" type="upgrade">
               <selectionEntries>
-                <selectionEntry id="821d-5991-0f95-939a" name="Rippa Klaw 1" hidden="false" collective="false" type="upgrade">
+                <selectionEntry id="821d-5991-0f95-939a" name="Rippa Klaw 1" hidden="false" collective="false" import="true" type="upgrade">
                   <constraints>
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a27f-2071-7325-c4de" type="max"/>
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3746-90fa-396b-8356" type="min"/>
                   </constraints>
                   <entryLinks>
-                    <entryLink id="2649-a2b8-d641-f97f" name="Rippa Klaw" hidden="false" collective="false" targetId="3b66-1d97-8b6d-3175" type="selectionEntry">
+                    <entryLink id="2649-a2b8-d641-f97f" name="Rippa Klaw" hidden="false" collective="false" import="true" targetId="3b66-1d97-8b6d-3175" type="selectionEntry">
                       <constraints>
                         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9be1-ffce-06ac-c1b4" type="min"/>
                         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ead4-5a41-0c40-030f" type="max"/>
@@ -7943,13 +7939,13 @@
                     <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
                   </costs>
                 </selectionEntry>
-                <selectionEntry id="568b-028f-8522-b82f" name="Rippa Klaw 2" hidden="false" collective="false" type="upgrade">
+                <selectionEntry id="568b-028f-8522-b82f" name="Rippa Klaw 2" hidden="false" collective="false" import="true" type="upgrade">
                   <constraints>
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9668-ff41-1eb6-dc49" type="min"/>
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c1c3-cbc4-f9be-9bdd" type="max"/>
                   </constraints>
                   <entryLinks>
-                    <entryLink id="b758-c9da-9cb6-6b17" name="Rippa Klaw" hidden="false" collective="false" targetId="3b66-1d97-8b6d-3175" type="selectionEntry">
+                    <entryLink id="b758-c9da-9cb6-6b17" name="Rippa Klaw" hidden="false" collective="false" import="true" targetId="3b66-1d97-8b6d-3175" type="selectionEntry">
                       <modifiers>
                         <modifier type="set" field="points" value="18"/>
                       </modifiers>
@@ -7972,15 +7968,15 @@
                 <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
               </costs>
             </selectionEntry>
-            <selectionEntry id="608e-2b70-5705-251d" name="Big Zzappa + Rippa Klaw" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="608e-2b70-5705-251d" name="Big Zzappa + Rippa Klaw" hidden="false" collective="false" import="true" type="upgrade">
               <entryLinks>
-                <entryLink id="0e49-0e51-19d0-538c" name="Big Zzappa" hidden="false" collective="false" targetId="0ee1-1fff-eb8b-ae31" type="selectionEntry">
+                <entryLink id="0e49-0e51-19d0-538c" name="Big Zzappa" hidden="false" collective="false" import="true" targetId="0ee1-1fff-eb8b-ae31" type="selectionEntry">
                   <constraints>
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f3ea-8b6d-91c7-9a95" type="min"/>
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b3db-d680-d5bb-91c7" type="max"/>
                   </constraints>
                 </entryLink>
-                <entryLink id="d588-c366-d06f-13fc" name="Rippa Klaw" hidden="false" collective="false" targetId="3b66-1d97-8b6d-3175" type="selectionEntry">
+                <entryLink id="d588-c366-d06f-13fc" name="Rippa Klaw" hidden="false" collective="false" import="true" targetId="3b66-1d97-8b6d-3175" type="selectionEntry">
                   <constraints>
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="82cd-a19f-899d-9c62" type="min"/>
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2327-0585-6d3d-f7c5" type="max"/>
@@ -7993,15 +7989,15 @@
                 <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
               </costs>
             </selectionEntry>
-            <selectionEntry id="458c-22b8-880a-6460" name="Killkannon + Rippa Klaw" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="458c-22b8-880a-6460" name="Killkannon + Rippa Klaw" hidden="false" collective="false" import="true" type="upgrade">
               <entryLinks>
-                <entryLink id="d1f9-27ae-5f6e-4748" name="Rippa Klaw" hidden="false" collective="false" targetId="3b66-1d97-8b6d-3175" type="selectionEntry">
+                <entryLink id="d1f9-27ae-5f6e-4748" name="Rippa Klaw" hidden="false" collective="false" import="true" targetId="3b66-1d97-8b6d-3175" type="selectionEntry">
                   <constraints>
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1fe3-2f50-958c-2b55" type="min"/>
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c519-97b6-f937-44a3" type="max"/>
                   </constraints>
                 </entryLink>
-                <entryLink id="a83e-7dce-48ea-070b" name="Killkannon" hidden="false" collective="false" targetId="44ac-f70b-3b79-6eb8" type="selectionEntry">
+                <entryLink id="a83e-7dce-48ea-070b" name="Killkannon" hidden="false" collective="false" import="true" targetId="44ac-f70b-3b79-6eb8" type="selectionEntry">
                   <constraints>
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b54c-676b-9e3f-30bd" type="min"/>
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b9ba-9319-1472-b750" type="max"/>
@@ -8014,15 +8010,15 @@
                 <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
               </costs>
             </selectionEntry>
-            <selectionEntry id="b8d7-42b0-c1f6-47b6" name="Rattler Kannon + Rippa Klaw" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="b8d7-42b0-c1f6-47b6" name="Rattler Kannon + Rippa Klaw" hidden="false" collective="false" import="true" type="upgrade">
               <entryLinks>
-                <entryLink id="2200-4fa6-2f01-6c91" name="Rippa Klaw" hidden="false" collective="false" targetId="3b66-1d97-8b6d-3175" type="selectionEntry">
+                <entryLink id="2200-4fa6-2f01-6c91" name="Rippa Klaw" hidden="false" collective="false" import="true" targetId="3b66-1d97-8b6d-3175" type="selectionEntry">
                   <constraints>
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b2d3-8dc0-7414-6252" type="min"/>
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5415-a5c5-5b12-9432" type="max"/>
                   </constraints>
                 </entryLink>
-                <entryLink id="5a57-df61-2ec1-c221" name="Rattler Kannon" hidden="false" collective="false" targetId="c868-7433-9274-8546" type="selectionEntry">
+                <entryLink id="5a57-df61-2ec1-c221" name="Rattler Kannon" hidden="false" collective="false" import="true" targetId="c868-7433-9274-8546" type="selectionEntry">
                   <constraints>
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="886c-c2ca-3ebc-dcda" type="min"/>
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5af3-10d4-9c55-d468" type="max"/>
@@ -8035,15 +8031,15 @@
                 <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
               </costs>
             </selectionEntry>
-            <selectionEntry id="2eb7-8ef5-c6b9-64ff" name="Shunta + Rippa Klaw" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="2eb7-8ef5-c6b9-64ff" name="Shunta + Rippa Klaw" hidden="false" collective="false" import="true" type="upgrade">
               <entryLinks>
-                <entryLink id="00aa-d49e-254f-8046" name="Shunta" hidden="false" collective="false" targetId="c5a3-956e-e030-d56d" type="selectionEntry">
+                <entryLink id="00aa-d49e-254f-8046" name="Shunta" hidden="false" collective="false" import="true" targetId="c5a3-956e-e030-d56d" type="selectionEntry">
                   <constraints>
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="eb3b-344b-85b1-4c28" type="min"/>
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4ab3-1576-c27e-fea8" type="max"/>
                   </constraints>
                 </entryLink>
-                <entryLink id="168b-70d9-205e-ada9" name="Rippa Klaw" hidden="false" collective="false" targetId="3b66-1d97-8b6d-3175" type="selectionEntry">
+                <entryLink id="168b-70d9-205e-ada9" name="Rippa Klaw" hidden="false" collective="false" import="true" targetId="3b66-1d97-8b6d-3175" type="selectionEntry">
                   <constraints>
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="91a8-76e7-6271-acf4" type="min"/>
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="dbfd-d50d-9e4f-61e7" type="max"/>
@@ -8060,8 +8056,8 @@
         </selectionEntryGroup>
       </selectionEntryGroups>
       <entryLinks>
-        <entryLink id="8c58-bf8e-607a-11a0" name="Has Battle Honours" hidden="false" collective="false" targetId="4763-757f-499f-d998" type="selectionEntry"/>
-        <entryLink id="94fb-5cd5-1569-a3ef" name="Battle Honours" hidden="false" collective="false" targetId="5518-d0f5-a880-d71c" type="selectionEntryGroup"/>
+        <entryLink id="8c58-bf8e-607a-11a0" name="Has Battle Honours" hidden="false" collective="false" import="true" targetId="4763-757f-499f-d998" type="selectionEntry"/>
+        <entryLink id="94fb-5cd5-1569-a3ef" name="Battle Honours" hidden="false" collective="false" import="true" targetId="5518-d0f5-a880-d71c" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
         <cost name=" PL" typeId="e356-c769-5920-6e14" value="12.0"/>
@@ -8069,7 +8065,7 @@
         <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="3b66-1d97-8b6d-3175" name="Rippa Klaw" hidden="false" collective="false" type="upgrade">
+    <selectionEntry id="3b66-1d97-8b6d-3175" name="Rippa Klaw" hidden="false" collective="false" import="true" type="upgrade">
       <profiles>
         <profile id="af03-1076-40fc-ab02" name="Rippa Klaw" hidden="false" typeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" typeName="Weapon">
           <characteristics>
@@ -8088,7 +8084,7 @@
         <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="6879-dd66-6ee7-56a8" name="Lifta Wagon" hidden="false" collective="false" type="unit">
+    <selectionEntry id="6879-dd66-6ee7-56a8" name="Lifta Wagon" hidden="false" collective="false" import="true" type="unit">
       <profiles>
         <profile id="c185-2ffe-2974-7403" name="Lifta Wagon" hidden="false" typeId="800f-21d0-4387-c943" typeName="Unit">
           <characteristics>
@@ -8146,7 +8142,7 @@
         <categoryLink id="941d-64d0-860d-1a60" name="New CategoryLink" hidden="false" targetId="af84-f23e-0197-d873" primary="false"/>
       </categoryLinks>
       <selectionEntries>
-        <selectionEntry id="3104-7f7a-133f-c713" name="Deff Rolla" hidden="false" collective="false" type="upgrade">
+        <selectionEntry id="3104-7f7a-133f-c713" name="Deff Rolla" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f99b-1c02-02e8-c6ea" type="max"/>
           </constraints>
@@ -8168,7 +8164,7 @@
             <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
           </costs>
         </selectionEntry>
-        <selectionEntry id="51a3-8b68-1497-b118" name="Grabbin&apos; Klaw" hidden="false" collective="false" type="upgrade">
+        <selectionEntry id="51a3-8b68-1497-b118" name="Grabbin&apos; Klaw" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="33c5-a8a6-2145-dfa8" type="max"/>
           </constraints>
@@ -8192,27 +8188,27 @@
         </selectionEntry>
       </selectionEntries>
       <selectionEntryGroups>
-        <selectionEntryGroup id="d65b-867c-de99-3c62" name="Other Guns (0-2)" hidden="false" collective="false">
+        <selectionEntryGroup id="d65b-867c-de99-3c62" name="Other Guns (0-2)" hidden="false" collective="false" import="true">
           <constraints>
             <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7721-c430-14b5-ff14" type="min"/>
             <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ed38-4e18-e8b3-bb4a" type="max"/>
           </constraints>
           <entryLinks>
-            <entryLink id="100b-4bc1-fe8c-67e3" name="New EntryLink" hidden="false" collective="false" targetId="6008-4737-d8e6-e63b" type="selectionEntry"/>
-            <entryLink id="c208-dd2d-0bce-fa48" name="New EntryLink" hidden="false" collective="false" targetId="a8c1-7fb9-7f7b-84c5" type="selectionEntry"/>
+            <entryLink id="100b-4bc1-fe8c-67e3" name="New EntryLink" hidden="false" collective="false" import="true" targetId="6008-4737-d8e6-e63b" type="selectionEntry"/>
+            <entryLink id="c208-dd2d-0bce-fa48" name="New EntryLink" hidden="false" collective="false" import="true" targetId="a8c1-7fb9-7f7b-84c5" type="selectionEntry"/>
           </entryLinks>
         </selectionEntryGroup>
       </selectionEntryGroups>
       <entryLinks>
-        <entryLink id="2fa3-e091-8fc3-3f81" name="New EntryLink" hidden="false" collective="false" targetId="afdc-8903-044a-a42e" type="selectionEntry"/>
-        <entryLink id="390c-9c5f-82cf-3d13" name="Lifta-Droppa" hidden="false" collective="false" targetId="ea50-a127-aba6-dfc4" type="selectionEntry">
+        <entryLink id="2fa3-e091-8fc3-3f81" name="New EntryLink" hidden="false" collective="false" import="true" targetId="afdc-8903-044a-a42e" type="selectionEntry"/>
+        <entryLink id="390c-9c5f-82cf-3d13" name="Lifta-Droppa" hidden="false" collective="false" import="true" targetId="ea50-a127-aba6-dfc4" type="selectionEntry">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c4c7-4415-9194-4d13" type="max"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ea04-8ef4-5bd0-ac65" type="min"/>
           </constraints>
         </entryLink>
-        <entryLink id="19bf-2f96-bb9c-754b" name="Has Battle Honours" hidden="false" collective="false" targetId="4763-757f-499f-d998" type="selectionEntry"/>
-        <entryLink id="79fa-6a78-eef3-7f12" name="Battle Honours" hidden="false" collective="false" targetId="5518-d0f5-a880-d71c" type="selectionEntryGroup"/>
+        <entryLink id="19bf-2f96-bb9c-754b" name="Has Battle Honours" hidden="false" collective="false" import="true" targetId="4763-757f-499f-d998" type="selectionEntry"/>
+        <entryLink id="79fa-6a78-eef3-7f12" name="Battle Honours" hidden="false" collective="false" import="true" targetId="5518-d0f5-a880-d71c" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
         <cost name=" PL" typeId="e356-c769-5920-6e14" value="10.0"/>
@@ -8220,7 +8216,7 @@
         <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="9576-6195-fe16-dab7" name="Big Trakk" hidden="false" collective="false" type="unit">
+    <selectionEntry id="9576-6195-fe16-dab7" name="Big Trakk" hidden="false" collective="false" import="true" type="unit">
       <profiles>
         <profile id="e3ba-fd3c-1712-68c4" name="Big Trakk" hidden="false" typeId="800f-21d0-4387-c943" typeName="Unit">
           <characteristics>
@@ -8303,36 +8299,36 @@
         <categoryLink id="1dbb-86ed-f590-9fd2" name="New CategoryLink" hidden="false" targetId="abf5fd55-9ac7-4263-8bc1-a9fb0a8fa6a6" primary="true"/>
       </categoryLinks>
       <selectionEntryGroups>
-        <selectionEntryGroup id="cf6e-816e-427a-2bd8" name="Other Guns (0-2)" hidden="false" collective="false">
+        <selectionEntryGroup id="cf6e-816e-427a-2bd8" name="Other Guns (0-2)" hidden="false" collective="false" import="true">
           <constraints>
             <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="13cd-639f-ac8c-df29" type="min"/>
             <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e9bc-5dbb-55bf-0e65" type="max"/>
           </constraints>
           <entryLinks>
-            <entryLink id="bca8-3765-1ee6-2a7d" name="Big Shoota" hidden="false" collective="false" targetId="6008-4737-d8e6-e63b" type="selectionEntry">
+            <entryLink id="bca8-3765-1ee6-2a7d" name="Big Shoota" hidden="false" collective="false" import="true" targetId="6008-4737-d8e6-e63b" type="selectionEntry">
               <constraints>
                 <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7885-9044-86e8-314e" type="max"/>
               </constraints>
             </entryLink>
-            <entryLink id="1ecf-7017-eace-fbb1" name="Rokkit Launcha" hidden="false" collective="false" targetId="a8c1-7fb9-7f7b-84c5" type="selectionEntry">
+            <entryLink id="1ecf-7017-eace-fbb1" name="Rokkit Launcha" hidden="false" collective="false" import="true" targetId="a8c1-7fb9-7f7b-84c5" type="selectionEntry">
               <constraints>
                 <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0144-c6cd-e1e1-17ba" type="max"/>
               </constraints>
             </entryLink>
-            <entryLink id="80de-792c-4ded-7984" name="Skorcha" hidden="false" collective="false" targetId="e05b-21b5-8727-ea9d" type="selectionEntry">
+            <entryLink id="80de-792c-4ded-7984" name="Skorcha" hidden="false" collective="false" import="true" targetId="e05b-21b5-8727-ea9d" type="selectionEntry">
               <constraints>
                 <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a77e-5d6a-d3b6-13bd" type="max"/>
               </constraints>
             </entryLink>
           </entryLinks>
         </selectionEntryGroup>
-        <selectionEntryGroup id="987c-8a7d-e0a9-703d" name="Guns" hidden="false" collective="false" defaultSelectionEntryId="f99d-d80f-6f1d-197a">
+        <selectionEntryGroup id="987c-8a7d-e0a9-703d" name="Guns" hidden="false" collective="false" import="true" defaultSelectionEntryId="f99d-d80f-6f1d-197a">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f747-ed4d-563c-1a2b" type="max"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3c98-44f6-fcd8-d945" type="min"/>
           </constraints>
           <selectionEntries>
-            <selectionEntry id="f99d-d80f-6f1d-197a" name="2x Big Shoota" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="f99d-d80f-6f1d-197a" name="2x Big Shoota" hidden="false" collective="false" import="true" type="upgrade">
               <infoLinks>
                 <infoLink id="9da8-a014-c700-a23d" name="Big Shoota" hidden="false" targetId="674c-6501-898c-16d6" type="profile"/>
               </infoLinks>
@@ -8342,7 +8338,7 @@
                 <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
               </costs>
             </selectionEntry>
-            <selectionEntry id="524d-00f0-efd7-1636" name="2x Rokkit Launcha" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="524d-00f0-efd7-1636" name="2x Rokkit Launcha" hidden="false" collective="false" import="true" type="upgrade">
               <infoLinks>
                 <infoLink id="6a22-fe7a-ea6b-f205" name="Rokkit Launcha" hidden="false" targetId="fa68-4aa1-f708-5aed" type="profile"/>
               </infoLinks>
@@ -8352,7 +8348,7 @@
                 <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
               </costs>
             </selectionEntry>
-            <selectionEntry id="14a7-7e5b-1da1-d8f6" name="2x Skorcha" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="14a7-7e5b-1da1-d8f6" name="2x Skorcha" hidden="false" collective="false" import="true" type="upgrade">
               <infoLinks>
                 <infoLink id="b746-d5dc-0677-acca" name="Skorcha" hidden="false" targetId="1123-0b30-9f1f-ca82" type="profile"/>
               </infoLinks>
@@ -8362,7 +8358,7 @@
                 <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
               </costs>
             </selectionEntry>
-            <selectionEntry id="b3d7-c4bc-8aa9-8a29" name="Big Shoota + Rokkit Launcha" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="b3d7-c4bc-8aa9-8a29" name="Big Shoota + Rokkit Launcha" hidden="false" collective="false" import="true" type="upgrade">
               <infoLinks>
                 <infoLink id="2d3f-4c18-4d24-c9fd" name="Big Shoota" hidden="false" targetId="674c-6501-898c-16d6" type="profile"/>
                 <infoLink id="734b-3ffc-5cc8-0520" name="Rokkit Launcha" hidden="false" targetId="fa68-4aa1-f708-5aed" type="profile"/>
@@ -8373,7 +8369,7 @@
                 <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
               </costs>
             </selectionEntry>
-            <selectionEntry id="6791-d3d9-c878-7f57" name="Big Shoota + Skorcha" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="6791-d3d9-c878-7f57" name="Big Shoota + Skorcha" hidden="false" collective="false" import="true" type="upgrade">
               <infoLinks>
                 <infoLink id="68b0-dba7-3166-b039" name="Big Shoota" hidden="false" targetId="674c-6501-898c-16d6" type="profile"/>
                 <infoLink id="6297-052e-3b77-12b3" name="Skorcha" hidden="false" targetId="1123-0b30-9f1f-ca82" type="profile"/>
@@ -8384,7 +8380,7 @@
                 <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
               </costs>
             </selectionEntry>
-            <selectionEntry id="839e-bebe-5b76-8afb" name="Rokkit Launcha + Skorcha" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="839e-bebe-5b76-8afb" name="Rokkit Launcha + Skorcha" hidden="false" collective="false" import="true" type="upgrade">
               <infoLinks>
                 <infoLink id="22bb-74fe-7858-c2df" name="Skorcha" hidden="false" targetId="1123-0b30-9f1f-ca82" type="profile"/>
                 <infoLink id="0c1b-add6-df45-b281" name="Rokkit Launcha" hidden="false" targetId="fa68-4aa1-f708-5aed" type="profile"/>
@@ -8397,32 +8393,32 @@
             </selectionEntry>
           </selectionEntries>
           <entryLinks>
-            <entryLink id="96f1-b87e-cd88-fc54" name="Kannon" hidden="false" collective="false" targetId="b3d8-73ff-d4fc-c2ac" type="selectionEntry"/>
-            <entryLink id="b511-c196-5539-4383" name="Lobba" hidden="false" collective="false" targetId="b25a-5184-36ce-d147" type="selectionEntry"/>
-            <entryLink id="04b9-2bee-8969-672f" name="Zzap gun" hidden="false" collective="false" targetId="b390-deb9-6d7e-d632" type="selectionEntry"/>
-            <entryLink id="3cb3-8194-21fa-d228" name="Killkannon" hidden="false" collective="false" targetId="44ac-f70b-3b79-6eb8" type="selectionEntry"/>
-            <entryLink id="f9ff-9d4f-c918-9cd3" name="Supa-Skorcha" hidden="false" collective="false" targetId="2359-3c2a-aee6-958a" type="selectionEntry"/>
-            <entryLink id="9b8a-d541-80e8-ec7f" name="Big Lobba" hidden="false" collective="false" targetId="89f0-03b2-7895-69ff" type="selectionEntry"/>
-            <entryLink id="1e9c-aa72-bb69-ad6d" name="Big Zzappa" hidden="false" collective="false" targetId="0ee1-1fff-eb8b-ae31" type="selectionEntry"/>
-            <entryLink id="255b-53f7-9652-c19c" name="Flakka Gunz" hidden="false" collective="false" targetId="cf83-47e8-29be-d795" type="selectionEntry"/>
-            <entryLink id="1f7f-9cf3-1ccb-2aca" name="Supa-Kannon" hidden="false" collective="false" targetId="1488-b982-0723-3c3d" type="selectionEntry"/>
+            <entryLink id="96f1-b87e-cd88-fc54" name="Kannon" hidden="false" collective="false" import="true" targetId="b3d8-73ff-d4fc-c2ac" type="selectionEntry"/>
+            <entryLink id="b511-c196-5539-4383" name="Lobba" hidden="false" collective="false" import="true" targetId="b25a-5184-36ce-d147" type="selectionEntry"/>
+            <entryLink id="04b9-2bee-8969-672f" name="Zzap gun" hidden="false" collective="false" import="true" targetId="b390-deb9-6d7e-d632" type="selectionEntry"/>
+            <entryLink id="3cb3-8194-21fa-d228" name="Killkannon" hidden="false" collective="false" import="true" targetId="44ac-f70b-3b79-6eb8" type="selectionEntry"/>
+            <entryLink id="f9ff-9d4f-c918-9cd3" name="Supa-Skorcha" hidden="false" collective="false" import="true" targetId="2359-3c2a-aee6-958a" type="selectionEntry"/>
+            <entryLink id="9b8a-d541-80e8-ec7f" name="Big Lobba" hidden="false" collective="false" import="true" targetId="89f0-03b2-7895-69ff" type="selectionEntry"/>
+            <entryLink id="1e9c-aa72-bb69-ad6d" name="Big Zzappa" hidden="false" collective="false" import="true" targetId="0ee1-1fff-eb8b-ae31" type="selectionEntry"/>
+            <entryLink id="255b-53f7-9652-c19c" name="Flakka Gunz" hidden="false" collective="false" import="true" targetId="cf83-47e8-29be-d795" type="selectionEntry"/>
+            <entryLink id="1f7f-9cf3-1ccb-2aca" name="Supa-Kannon" hidden="false" collective="false" import="true" targetId="1488-b982-0723-3c3d" type="selectionEntry"/>
           </entryLinks>
         </selectionEntryGroup>
       </selectionEntryGroups>
       <entryLinks>
-        <entryLink id="9bd4-9333-e464-8180" name="Grot Riggers" hidden="false" collective="false" targetId="c5aa-3d54-aeaa-36ca" type="selectionEntry">
+        <entryLink id="9bd4-9333-e464-8180" name="Grot Riggers" hidden="false" collective="false" import="true" targetId="c5aa-3d54-aeaa-36ca" type="selectionEntry">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fb35-307b-7705-77ca" type="max"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8bba-7dae-3d8e-802d" type="min"/>
           </constraints>
         </entryLink>
-        <entryLink id="e631-518e-3c47-e942" name="Grot Sponson" hidden="false" collective="false" targetId="2efd-be89-30eb-f182" type="selectionEntry">
+        <entryLink id="e631-518e-3c47-e942" name="Grot Sponson" hidden="false" collective="false" import="true" targetId="2efd-be89-30eb-f182" type="selectionEntry">
           <constraints>
             <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c4d9-adc8-a379-d173" type="max"/>
           </constraints>
         </entryLink>
-        <entryLink id="6174-9eaa-b48d-4be9" name="Has Battle Honours" hidden="false" collective="false" targetId="4763-757f-499f-d998" type="selectionEntry"/>
-        <entryLink id="39ce-b685-cad2-3de9" name="Battle Honours" hidden="false" collective="false" targetId="5518-d0f5-a880-d71c" type="selectionEntryGroup"/>
+        <entryLink id="6174-9eaa-b48d-4be9" name="Has Battle Honours" hidden="false" collective="false" import="true" targetId="4763-757f-499f-d998" type="selectionEntry"/>
+        <entryLink id="39ce-b685-cad2-3de9" name="Battle Honours" hidden="false" collective="false" import="true" targetId="5518-d0f5-a880-d71c" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
         <cost name=" PL" typeId="e356-c769-5920-6e14" value="9.0"/>
@@ -8430,7 +8426,7 @@
         <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="44ac-f70b-3b79-6eb8" name="Killkannon" hidden="false" collective="false" type="upgrade">
+    <selectionEntry id="44ac-f70b-3b79-6eb8" name="Killkannon" hidden="false" collective="false" import="true" type="upgrade">
       <profiles>
         <profile id="9d36-d646-387a-436f" name="Killkannon" hidden="false" typeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" typeName="Weapon">
           <characteristics>
@@ -8449,7 +8445,7 @@
         <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="2359-3c2a-aee6-958a" name="Supa-Skorcha" hidden="false" collective="false" type="upgrade">
+    <selectionEntry id="2359-3c2a-aee6-958a" name="Supa-Skorcha" hidden="false" collective="false" import="true" type="upgrade">
       <profiles>
         <profile id="1807-13b2-3287-25dd" name="Supa-Skorcha" hidden="false" typeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" typeName="Weapon">
           <characteristics>
@@ -8468,7 +8464,7 @@
         <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="0ee1-1fff-eb8b-ae31" name="Big Zzappa" hidden="false" collective="false" type="upgrade">
+    <selectionEntry id="0ee1-1fff-eb8b-ae31" name="Big Zzappa" hidden="false" collective="false" import="true" type="upgrade">
       <profiles>
         <profile id="b072-3fdd-dcce-4e5d" name="Big Zzappa" hidden="false" typeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" typeName="Weapon">
           <characteristics>
@@ -8487,7 +8483,7 @@
         <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="89f0-03b2-7895-69ff" name="Big Lobba" hidden="false" collective="false" type="upgrade">
+    <selectionEntry id="89f0-03b2-7895-69ff" name="Big Lobba" hidden="false" collective="false" import="true" type="upgrade">
       <profiles>
         <profile id="b629-2e64-a68a-4cb4" name="Big Lobba" hidden="false" typeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" typeName="Weapon">
           <characteristics>
@@ -8506,7 +8502,7 @@
         <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="cf83-47e8-29be-d795" name="Flakka Gunz" hidden="false" collective="false" type="upgrade">
+    <selectionEntry id="cf83-47e8-29be-d795" name="Flakka Gunz" hidden="false" collective="false" import="true" type="upgrade">
       <profiles>
         <profile id="08b6-cfc6-8353-4f00" name="Flakka Gunz" hidden="false" typeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" typeName="Weapon">
           <characteristics>
@@ -8525,7 +8521,7 @@
         <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="c868-7433-9274-8546" name="Rattler Kannon" hidden="false" collective="false" type="upgrade">
+    <selectionEntry id="c868-7433-9274-8546" name="Rattler Kannon" hidden="false" collective="false" import="true" type="upgrade">
       <infoLinks>
         <infoLink id="e015-d22d-332a-be19" name="Rattler Kannon" hidden="false" targetId="4613-48d6-d948-0a0a" type="profile"/>
       </infoLinks>
@@ -8535,7 +8531,7 @@
         <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="c5a3-956e-e030-d56d" name="Shunta" hidden="false" collective="false" type="upgrade">
+    <selectionEntry id="c5a3-956e-e030-d56d" name="Shunta" hidden="false" collective="false" import="true" type="upgrade">
       <profiles>
         <profile id="b13d-be99-2e07-313d" name="Shunta" hidden="false" typeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" typeName="Weapon">
           <characteristics>
@@ -8554,7 +8550,7 @@
         <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="1488-b982-0723-3c3d" name="Supa-Kannon" hidden="false" collective="false" type="upgrade">
+    <selectionEntry id="1488-b982-0723-3c3d" name="Supa-Kannon" hidden="false" collective="false" import="true" type="upgrade">
       <constraints>
         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0af1-140f-09ed-591d" type="max"/>
       </constraints>
@@ -8576,7 +8572,7 @@
         <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="83bd-01d2-82f5-1e73" name="Battlewagon with Supa-Kannon" hidden="false" collective="false" type="unit">
+    <selectionEntry id="83bd-01d2-82f5-1e73" name="Battlewagon with Supa-Kannon" hidden="false" collective="false" import="true" type="unit">
       <profiles>
         <profile id="a49a-7616-d4b1-5597" name="Battlewagon" hidden="false" typeId="800f-21d0-4387-c943" typeName="Unit">
           <modifiers>
@@ -8642,7 +8638,7 @@
         <categoryLink id="f23a-a927-ce5b-c51d" name="New CategoryLink" hidden="false" targetId="609c-77e8-7913-3713" primary="false"/>
       </categoryLinks>
       <selectionEntries>
-        <selectionEntry id="35e8-8f83-bd65-1d63" name="Deff Rolla" hidden="false" collective="false" type="upgrade">
+        <selectionEntry id="35e8-8f83-bd65-1d63" name="Deff Rolla" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0bdd-ea7a-da96-1502" type="max"/>
           </constraints>
@@ -8664,7 +8660,7 @@
             <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
           </costs>
         </selectionEntry>
-        <selectionEntry id="6e73-98fe-e4ef-af40" name="Grabbin&apos; Klaw" hidden="false" collective="false" type="upgrade">
+        <selectionEntry id="6e73-98fe-e4ef-af40" name="Grabbin&apos; Klaw" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="178a-c921-780a-abd1" type="max"/>
           </constraints>
@@ -8686,7 +8682,7 @@
             <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
           </costs>
         </selectionEntry>
-        <selectionEntry id="bc62-ece9-c497-47f1" name="&apos;ard Case" hidden="false" collective="false" type="upgrade">
+        <selectionEntry id="bc62-ece9-c497-47f1" name="&apos;ard Case" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3b90-b998-4f46-80ca" type="max"/>
           </constraints>
@@ -8705,27 +8701,27 @@
         </selectionEntry>
       </selectionEntries>
       <selectionEntryGroups>
-        <selectionEntryGroup id="a440-f077-06a2-d26a" name="Other Guns (0-4)" hidden="false" collective="false">
+        <selectionEntryGroup id="a440-f077-06a2-d26a" name="Other Guns (0-4)" hidden="false" collective="false" import="true">
           <constraints>
             <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6ea0-148c-21d2-8304" type="min"/>
             <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="cdae-db83-0d31-03cd" type="max"/>
           </constraints>
           <entryLinks>
-            <entryLink id="8e98-7163-bc9e-df98" name="New EntryLink" hidden="false" collective="false" targetId="6008-4737-d8e6-e63b" type="selectionEntry"/>
-            <entryLink id="d51f-bc2a-0308-da6f" name="New EntryLink" hidden="false" collective="false" targetId="a8c1-7fb9-7f7b-84c5" type="selectionEntry"/>
+            <entryLink id="8e98-7163-bc9e-df98" name="New EntryLink" hidden="false" collective="false" import="true" targetId="6008-4737-d8e6-e63b" type="selectionEntry"/>
+            <entryLink id="d51f-bc2a-0308-da6f" name="New EntryLink" hidden="false" collective="false" import="true" targetId="a8c1-7fb9-7f7b-84c5" type="selectionEntry"/>
           </entryLinks>
         </selectionEntryGroup>
       </selectionEntryGroups>
       <entryLinks>
-        <entryLink id="5afd-5f23-797e-15b8" name="Wreckin&apos; Ball" hidden="false" collective="false" targetId="afdc-8903-044a-a42e" type="selectionEntry"/>
-        <entryLink id="a4ab-49e5-9fbd-3870" name="Supa-Kannon" hidden="false" collective="false" targetId="1488-b982-0723-3c3d" type="selectionEntry">
+        <entryLink id="5afd-5f23-797e-15b8" name="Wreckin&apos; Ball" hidden="false" collective="false" import="true" targetId="afdc-8903-044a-a42e" type="selectionEntry"/>
+        <entryLink id="a4ab-49e5-9fbd-3870" name="Supa-Kannon" hidden="false" collective="false" import="true" targetId="1488-b982-0723-3c3d" type="selectionEntry">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="df02-7363-641a-5e21" type="min"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a493-c0a4-10fb-8800" type="max"/>
           </constraints>
         </entryLink>
-        <entryLink id="146e-8a7b-9522-30a1" name="Has Battle Honours" hidden="false" collective="false" targetId="4763-757f-499f-d998" type="selectionEntry"/>
-        <entryLink id="0293-b3a8-d203-9abe" name="Battle Honours" hidden="false" collective="false" targetId="5518-d0f5-a880-d71c" type="selectionEntryGroup"/>
+        <entryLink id="146e-8a7b-9522-30a1" name="Has Battle Honours" hidden="false" collective="false" import="true" targetId="4763-757f-499f-d998" type="selectionEntry"/>
+        <entryLink id="0293-b3a8-d203-9abe" name="Battle Honours" hidden="false" collective="false" import="true" targetId="5518-d0f5-a880-d71c" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
         <cost name=" PL" typeId="e356-c769-5920-6e14" value="13.0"/>
@@ -8733,7 +8729,7 @@
         <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="5521-9ab8-c925-50c2" name="Kill Tank" hidden="false" collective="false" type="unit">
+    <selectionEntry id="5521-9ab8-c925-50c2" name="Kill Tank" hidden="false" collective="false" import="true" type="unit">
       <profiles>
         <profile id="8430-7dde-e155-1e6e" name="Kill Tank" hidden="false" typeId="800f-21d0-4387-c943" typeName="Unit">
           <characteristics>
@@ -8797,45 +8793,45 @@
         <categoryLink id="885d-a340-14ce-7e5a" name="New CategoryLink" hidden="false" targetId="c888f08a-6cea-4a01-8126-d374a9231554" primary="true"/>
       </categoryLinks>
       <selectionEntryGroups>
-        <selectionEntryGroup id="cf16-0d1e-c4b8-42cc" name="Other Guns (0-2)" hidden="false" collective="false">
+        <selectionEntryGroup id="cf16-0d1e-c4b8-42cc" name="Other Guns (0-2)" hidden="false" collective="false" import="true">
           <constraints>
             <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="71a4-3651-eef2-bcf7" type="max"/>
           </constraints>
           <entryLinks>
-            <entryLink id="ced4-e97f-afee-3f0b" name="Big Shoota" hidden="false" collective="false" targetId="6008-4737-d8e6-e63b" type="selectionEntry">
+            <entryLink id="ced4-e97f-afee-3f0b" name="Big Shoota" hidden="false" collective="false" import="true" targetId="6008-4737-d8e6-e63b" type="selectionEntry">
               <constraints>
                 <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="89c1-033a-0ffd-93a4" type="max"/>
               </constraints>
             </entryLink>
-            <entryLink id="06ef-94d1-d6ee-4d87" name="Rokkit Launcha" hidden="false" collective="false" targetId="a8c1-7fb9-7f7b-84c5" type="selectionEntry">
+            <entryLink id="06ef-94d1-d6ee-4d87" name="Rokkit Launcha" hidden="false" collective="false" import="true" targetId="a8c1-7fb9-7f7b-84c5" type="selectionEntry">
               <constraints>
                 <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0478-a69c-697d-d15f" type="max"/>
               </constraints>
             </entryLink>
-            <entryLink id="c0db-ce88-37fb-9002" name="Skorcha" hidden="false" collective="false" targetId="e05b-21b5-8727-ea9d" type="selectionEntry">
+            <entryLink id="c0db-ce88-37fb-9002" name="Skorcha" hidden="false" collective="false" import="true" targetId="e05b-21b5-8727-ea9d" type="selectionEntry">
               <constraints>
                 <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d835-37dd-fb98-95ca" type="max"/>
               </constraints>
             </entryLink>
-            <entryLink id="85ec-dd72-8c8d-d068" name="Twin Big Shoota" hidden="false" collective="false" targetId="a4f1-6ccb-1c50-405b" type="selectionEntry">
+            <entryLink id="85ec-dd72-8c8d-d068" name="Twin Big Shoota" hidden="false" collective="false" import="true" targetId="a4f1-6ccb-1c50-405b" type="selectionEntry">
               <constraints>
                 <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="5ea8-56f6-6b2c-d474" type="max"/>
               </constraints>
             </entryLink>
-            <entryLink id="f782-f001-b960-564d" name="Rack of Rokkits" hidden="false" collective="false" targetId="17f9-fccd-55db-b80a" type="selectionEntry">
+            <entryLink id="f782-f001-b960-564d" name="Rack of Rokkits" hidden="false" collective="false" import="true" targetId="17f9-fccd-55db-b80a" type="selectionEntry">
               <constraints>
                 <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6db9-7025-e866-6830" type="max"/>
               </constraints>
             </entryLink>
           </entryLinks>
         </selectionEntryGroup>
-        <selectionEntryGroup id="d490-fb4a-7855-6031" name="Big Gun" hidden="false" collective="false" defaultSelectionEntryId="0246-459b-1a0b-dd3b">
+        <selectionEntryGroup id="d490-fb4a-7855-6031" name="Big Gun" hidden="false" collective="false" import="true" defaultSelectionEntryId="0246-459b-1a0b-dd3b">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c7fd-076e-11c0-e152" type="max"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1b0a-b379-56c5-3695" type="min"/>
           </constraints>
           <selectionEntries>
-            <selectionEntry id="cdc7-c53f-9d96-e3be" name="Giga Shoota" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="cdc7-c53f-9d96-e3be" name="Giga Shoota" hidden="false" collective="false" import="true" type="upgrade">
               <profiles>
                 <profile id="a99f-0dcc-4fd2-051e" name="Giga Shoota" hidden="false" typeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" typeName="Weapon">
                   <characteristics>
@@ -8854,7 +8850,7 @@
                 <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
               </costs>
             </selectionEntry>
-            <selectionEntry id="0246-459b-1a0b-dd3b" name="Bursta Kannon" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="0246-459b-1a0b-dd3b" name="Bursta Kannon" hidden="false" collective="false" import="true" type="upgrade">
               <profiles>
                 <profile id="b740-13de-ac18-82c6" name="Bursta Kannon" hidden="false" typeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" typeName="Weapon">
                   <characteristics>
@@ -8877,19 +8873,19 @@
         </selectionEntryGroup>
       </selectionEntryGroups>
       <entryLinks>
-        <entryLink id="fa83-8645-4830-e2cc" name="Twin Big Shoota" hidden="false" collective="false" targetId="a4f1-6ccb-1c50-405b" type="selectionEntry">
+        <entryLink id="fa83-8645-4830-e2cc" name="Twin Big Shoota" hidden="false" collective="false" import="true" targetId="a4f1-6ccb-1c50-405b" type="selectionEntry">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="e974-4b62-f74d-68e5" type="min"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="2ede-27b5-9d80-a66b" type="max"/>
           </constraints>
         </entryLink>
-        <entryLink id="438d-16a9-ab06-c612" name="Reinforced Ram" hidden="false" collective="false" targetId="95b5-fb4b-a7d2-ec1a" type="selectionEntry">
+        <entryLink id="438d-16a9-ab06-c612" name="Reinforced Ram" hidden="false" collective="false" import="true" targetId="95b5-fb4b-a7d2-ec1a" type="selectionEntry">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="19db-bf4a-66a4-b645" type="min"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c3cc-778b-bf27-0d0e" type="max"/>
           </constraints>
         </entryLink>
-        <entryLink id="3519-1f4c-09cc-53ab" name="Grot Riggers" hidden="false" collective="false" targetId="c5aa-3d54-aeaa-36ca" type="selectionEntry">
+        <entryLink id="3519-1f4c-09cc-53ab" name="Grot Riggers" hidden="false" collective="false" import="true" targetId="c5aa-3d54-aeaa-36ca" type="selectionEntry">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8067-7d4d-efb8-1128" type="max"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="dcc2-cb87-3eaf-b0ab" type="min"/>
@@ -8902,7 +8898,7 @@
         <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="d382-287a-3c10-6596" name="&apos;Chinork&apos; Warkopta" hidden="false" collective="false" type="unit">
+    <selectionEntry id="d382-287a-3c10-6596" name="&apos;Chinork&apos; Warkopta" hidden="false" collective="false" import="true" type="unit">
       <profiles>
         <profile id="d8cf-c761-2e3a-2b5a" name="Turbo-boost" hidden="false" typeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" typeName="Abilities">
           <characteristics>
@@ -8953,13 +8949,13 @@
         <categoryLink id="11e6-0db6-b824-9015" name="New CategoryLink" hidden="false" targetId="1b66-3f5f-6705-079a" primary="true"/>
       </categoryLinks>
       <selectionEntryGroups>
-        <selectionEntryGroup id="e236-6abd-d27c-97c9" name="Main Guns" hidden="false" collective="false" defaultSelectionEntryId="d70b-036e-97ad-37a6">
+        <selectionEntryGroup id="e236-6abd-d27c-97c9" name="Main Guns" hidden="false" collective="false" import="true" defaultSelectionEntryId="d70b-036e-97ad-37a6">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f807-041b-2152-9de5" type="min"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="182a-2c4c-e02f-cd80" type="max"/>
           </constraints>
           <selectionEntries>
-            <selectionEntry id="d70b-036e-97ad-37a6" name="2x Deffguns" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="d70b-036e-97ad-37a6" name="2x Deffguns" hidden="false" collective="false" import="true" type="upgrade">
               <infoLinks>
                 <infoLink id="1ae2-8c1c-5971-8e7d" name="Deffgun" hidden="false" targetId="7036-51d4-7745-a494" type="profile"/>
               </infoLinks>
@@ -8969,7 +8965,7 @@
                 <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
               </costs>
             </selectionEntry>
-            <selectionEntry id="3198-0ad6-56b6-084f" name="2x Rattler Kannon" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="3198-0ad6-56b6-084f" name="2x Rattler Kannon" hidden="false" collective="false" import="true" type="upgrade">
               <infoLinks>
                 <infoLink id="597e-cd79-cb70-103e" name="Rattler Kannon" hidden="false" targetId="4613-48d6-d948-0a0a" type="profile"/>
               </infoLinks>
@@ -8981,27 +8977,27 @@
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
-        <selectionEntryGroup id="48c8-cafd-85ae-28e9" name="Other Gun" hidden="false" collective="false" defaultSelectionEntryId="06a3-2631-2cc1-d5ab">
+        <selectionEntryGroup id="48c8-cafd-85ae-28e9" name="Other Gun" hidden="false" collective="false" import="true" defaultSelectionEntryId="06a3-2631-2cc1-d5ab">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6a55-222d-2254-f0b7" type="min"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3a78-349f-3cb8-4a66" type="max"/>
           </constraints>
           <entryLinks>
-            <entryLink id="2ede-ea57-8d45-ee58" name="Kustom Mega-blasta" hidden="false" collective="false" targetId="6d70-25a8-b496-2457" type="selectionEntry"/>
-            <entryLink id="06a3-2631-2cc1-d5ab" name="Big Shoota" hidden="false" collective="false" targetId="6008-4737-d8e6-e63b" type="selectionEntry"/>
-            <entryLink id="551f-a116-f339-926d" name="Skorcha" hidden="false" collective="false" targetId="e05b-21b5-8727-ea9d" type="selectionEntry"/>
-            <entryLink id="cded-18c5-97f4-5093" name="Rokkit Launcha" hidden="false" collective="false" targetId="a8c1-7fb9-7f7b-84c5" type="selectionEntry"/>
+            <entryLink id="2ede-ea57-8d45-ee58" name="Kustom Mega-blasta" hidden="false" collective="false" import="true" targetId="6d70-25a8-b496-2457" type="selectionEntry"/>
+            <entryLink id="06a3-2631-2cc1-d5ab" name="Big Shoota" hidden="false" collective="false" import="true" targetId="6008-4737-d8e6-e63b" type="selectionEntry"/>
+            <entryLink id="551f-a116-f339-926d" name="Skorcha" hidden="false" collective="false" import="true" targetId="e05b-21b5-8727-ea9d" type="selectionEntry"/>
+            <entryLink id="cded-18c5-97f4-5093" name="Rokkit Launcha" hidden="false" collective="false" import="true" targetId="a8c1-7fb9-7f7b-84c5" type="selectionEntry"/>
           </entryLinks>
         </selectionEntryGroup>
       </selectionEntryGroups>
       <entryLinks>
-        <entryLink id="8416-9de2-022a-1cee" name="Bigbomm" hidden="false" collective="false" targetId="c8a1-49f7-f886-4447" type="selectionEntry">
+        <entryLink id="8416-9de2-022a-1cee" name="Bigbomm" hidden="false" collective="false" import="true" targetId="c8a1-49f7-f886-4447" type="selectionEntry">
           <constraints>
             <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="46de-8a5a-5b8e-2301" type="max"/>
           </constraints>
         </entryLink>
-        <entryLink id="d5a4-a4d1-2a8a-3aaf" name="Has Battle Honours" hidden="false" collective="false" targetId="4763-757f-499f-d998" type="selectionEntry"/>
-        <entryLink id="1f4c-5e9b-f604-edf6" name="Battle Honours" hidden="false" collective="false" targetId="5518-d0f5-a880-d71c" type="selectionEntryGroup"/>
+        <entryLink id="d5a4-a4d1-2a8a-3aaf" name="Has Battle Honours" hidden="false" collective="false" import="true" targetId="4763-757f-499f-d998" type="selectionEntry"/>
+        <entryLink id="1f4c-5e9b-f604-edf6" name="Battle Honours" hidden="false" collective="false" import="true" targetId="5518-d0f5-a880-d71c" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
         <cost name=" PL" typeId="e356-c769-5920-6e14" value="8.0"/>
@@ -9009,7 +9005,7 @@
         <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="e75a-217f-2d54-09e1" name="Kustom Stompa" hidden="false" collective="false" type="unit">
+    <selectionEntry id="e75a-217f-2d54-09e1" name="Kustom Stompa" hidden="false" collective="false" import="true" type="unit">
       <profiles>
         <profile id="66ef-a4f4-6bb3-126b" name="Bigger &apos;n&apos; Stompier" hidden="false" typeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" typeName="Abilities">
           <characteristics>
@@ -9100,7 +9096,7 @@
         <categoryLink id="a2ee-5760-9eec-d9a8" name="New CategoryLink" hidden="false" targetId="9451-626d-1cb3-4907" primary="false"/>
       </categoryLinks>
       <selectionEntries>
-        <selectionEntry id="fc5b-5eb7-779b-ee10" name="The Gaze of Mork" hidden="false" collective="false" type="upgrade">
+        <selectionEntry id="fc5b-5eb7-779b-ee10" name="The Gaze of Mork" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="dbbe-5d4b-11c7-b2e8" type="min"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bf9a-d3e4-ffab-240f" type="max"/>
@@ -9123,7 +9119,7 @@
             <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
           </costs>
         </selectionEntry>
-        <selectionEntry id="995e-ecbd-b9aa-cb51" name="Supa-Rokkit" hidden="false" collective="false" type="upgrade">
+        <selectionEntry id="995e-ecbd-b9aa-cb51" name="Supa-Rokkit" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
             <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3365-3b43-d564-b47c" type="min"/>
             <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="cb18-463a-e2ce-e95a" type="max"/>
@@ -9146,7 +9142,7 @@
             <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
           </costs>
         </selectionEntry>
-        <selectionEntry id="ce42-3d35-b452-241a" name="Belly Gun" hidden="false" collective="false" type="upgrade">
+        <selectionEntry id="ce42-3d35-b452-241a" name="Belly Gun" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="12e3-9b06-9ec2-8079" type="max"/>
           </constraints>
@@ -9170,13 +9166,13 @@
         </selectionEntry>
       </selectionEntries>
       <selectionEntryGroups>
-        <selectionEntryGroup id="6c9e-c85e-299a-c79d" name="Arm 1" hidden="false" collective="false" defaultSelectionEntryId="6f98-39c8-2b53-163a">
+        <selectionEntryGroup id="6c9e-c85e-299a-c79d" name="Arm 1" hidden="false" collective="false" import="true" defaultSelectionEntryId="6f98-39c8-2b53-163a">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ec51-b871-ac3d-1778" type="min"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2a3f-e66f-005a-791a" type="max"/>
           </constraints>
           <selectionEntries>
-            <selectionEntry id="6f98-39c8-2b53-163a" name="Deffkannon and Supa-Gatler" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="6f98-39c8-2b53-163a" name="Deffkannon and Supa-Gatler" hidden="false" collective="false" import="true" type="upgrade">
               <profiles>
                 <profile id="6e68-beca-5b78-f0ec" name="Psycho-Dakka-Blast!" hidden="false" typeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" typeName="Abilities">
                   <characteristics>
@@ -9212,17 +9208,17 @@
             </selectionEntry>
           </selectionEntries>
           <entryLinks>
-            <entryLink id="35c4-7c28-aca8-f618" name="Lifta-Droppa" hidden="false" collective="false" targetId="ea50-a127-aba6-dfc4" type="selectionEntry"/>
-            <entryLink id="7af2-3bed-0055-4e41" name="Mega Klaw" hidden="false" collective="false" targetId="46b2-df57-7c2f-80d7" type="selectionEntry"/>
+            <entryLink id="35c4-7c28-aca8-f618" name="Lifta-Droppa" hidden="false" collective="false" import="true" targetId="ea50-a127-aba6-dfc4" type="selectionEntry"/>
+            <entryLink id="7af2-3bed-0055-4e41" name="Mega Klaw" hidden="false" collective="false" import="true" targetId="46b2-df57-7c2f-80d7" type="selectionEntry"/>
           </entryLinks>
         </selectionEntryGroup>
-        <selectionEntryGroup id="7259-ddab-547b-e4e0" name="Arm 2" hidden="false" collective="false" defaultSelectionEntryId="b217-a7be-d61c-32a3">
+        <selectionEntryGroup id="7259-ddab-547b-e4e0" name="Arm 2" hidden="false" collective="false" import="true" defaultSelectionEntryId="b217-a7be-d61c-32a3">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="cf5a-3ae9-4d34-e1d3" type="min"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bdc0-5001-3295-3656" type="max"/>
           </constraints>
           <entryLinks>
-            <entryLink id="b217-a7be-d61c-32a3" name="Mega Klaw" hidden="false" collective="false" targetId="46b2-df57-7c2f-80d7" type="selectionEntry">
+            <entryLink id="b217-a7be-d61c-32a3" name="Mega Klaw" hidden="false" collective="false" import="true" targetId="46b2-df57-7c2f-80d7" type="selectionEntry">
               <modifiers>
                 <modifier type="set" field="points" value="31">
                   <conditions>
@@ -9231,35 +9227,35 @@
                 </modifier>
               </modifiers>
             </entryLink>
-            <entryLink id="cca3-0763-f2ae-c882" name="Lifta-Droppa" hidden="false" collective="false" targetId="ea50-a127-aba6-dfc4" type="selectionEntry"/>
+            <entryLink id="cca3-0763-f2ae-c882" name="Lifta-Droppa" hidden="false" collective="false" import="true" targetId="ea50-a127-aba6-dfc4" type="selectionEntry"/>
           </entryLinks>
         </selectionEntryGroup>
       </selectionEntryGroups>
       <entryLinks>
-        <entryLink id="0bf2-77b9-a335-8e45" name="Twin Big Shoota" hidden="false" collective="false" targetId="a4f1-6ccb-1c50-405b" type="selectionEntry">
+        <entryLink id="0bf2-77b9-a335-8e45" name="Twin Big Shoota" hidden="false" collective="false" import="true" targetId="a4f1-6ccb-1c50-405b" type="selectionEntry">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6e27-9bb6-9c21-3e88" type="max"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fa87-fc28-6637-5237" type="min"/>
           </constraints>
         </entryLink>
-        <entryLink id="4e62-a9c2-d576-5b32" name="New EntryLink" hidden="false" collective="false" targetId="6008-4737-d8e6-e63b" type="selectionEntry">
+        <entryLink id="4e62-a9c2-d576-5b32" name="New EntryLink" hidden="false" collective="false" import="true" targetId="6008-4737-d8e6-e63b" type="selectionEntry">
           <constraints>
             <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="adb6-9f7d-980b-4eb9" type="max"/>
             <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d5c8-ee6f-27d2-ad57" type="min"/>
           </constraints>
         </entryLink>
-        <entryLink id="5958-aa38-0383-4e91" name="Skorcha" hidden="false" collective="false" targetId="e05b-21b5-8727-ea9d" type="selectionEntry">
+        <entryLink id="5958-aa38-0383-4e91" name="Skorcha" hidden="false" collective="false" import="true" targetId="e05b-21b5-8727-ea9d" type="selectionEntry">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3f4b-4f7e-5e23-c9eb" type="max"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="afca-956f-1bc8-b9c1" type="min"/>
           </constraints>
         </entryLink>
-        <entryLink id="20ff-6794-3482-8822" name="Grot Sponson" hidden="false" collective="false" targetId="2efd-be89-30eb-f182" type="selectionEntry">
+        <entryLink id="20ff-6794-3482-8822" name="Grot Sponson" hidden="false" collective="false" import="true" targetId="2efd-be89-30eb-f182" type="selectionEntry">
           <constraints>
             <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c5d3-4eac-ed3b-c5db" type="max"/>
           </constraints>
         </entryLink>
-        <entryLink id="58ef-3df8-2899-4e7e" name="Stratagem: Field Commander" hidden="false" collective="false" targetId="d043-3847-e963-fb5d" type="selectionEntry">
+        <entryLink id="58ef-3df8-2899-4e7e" name="Stratagem: Field Commander" hidden="false" collective="false" import="true" targetId="d043-3847-e963-fb5d" type="selectionEntry">
           <modifiers>
             <modifier type="set" field="hidden" value="true">
               <conditions>
@@ -9268,7 +9264,7 @@
             </modifier>
           </modifiers>
         </entryLink>
-        <entryLink id="b830-d77d-2b5a-979d" name="Warlord" hidden="false" collective="false" targetId="33f6-60da-7b70-5fee" type="selectionEntry">
+        <entryLink id="b830-d77d-2b5a-979d" name="Warlord" hidden="false" collective="false" import="true" targetId="33f6-60da-7b70-5fee" type="selectionEntry">
           <modifiers>
             <modifier type="set" field="hidden" value="true">
               <conditions>
@@ -9277,9 +9273,9 @@
             </modifier>
           </modifiers>
         </entryLink>
-        <entryLink id="506f-98a6-ae30-cdc0" name="Warlord Traits" hidden="false" collective="false" targetId="c2ce-6759-e009-8c11" type="selectionEntryGroup"/>
-        <entryLink id="7cb4-c4b8-7fd6-0eb0" name="Stompa Mob Character" hidden="false" collective="false" targetId="a2e0-0ff7-462d-bb22" type="selectionEntry"/>
-        <entryLink id="0e5d-de68-4049-0a7e" name="Tezdrek&apos;s Stompa Power Field" hidden="false" collective="false" targetId="e1a7-cfd9-6a33-c529" type="selectionEntry">
+        <entryLink id="506f-98a6-ae30-cdc0" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="c2ce-6759-e009-8c11" type="selectionEntryGroup"/>
+        <entryLink id="7cb4-c4b8-7fd6-0eb0" name="Stompa Mob Character" hidden="false" collective="false" import="true" targetId="a2e0-0ff7-462d-bb22" type="selectionEntry"/>
+        <entryLink id="0e5d-de68-4049-0a7e" name="Tezdrek&apos;s Stompa Power Field" hidden="false" collective="false" import="true" targetId="e1a7-cfd9-6a33-c529" type="selectionEntry">
           <modifiers>
             <modifier type="set" field="hidden" value="true">
               <conditions>
@@ -9298,7 +9294,7 @@
         <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="ea50-a127-aba6-dfc4" name="Lifta-Droppa" hidden="false" collective="false" type="upgrade">
+    <selectionEntry id="ea50-a127-aba6-dfc4" name="Lifta-Droppa" hidden="false" collective="false" import="true" type="upgrade">
       <profiles>
         <profile id="a7b7-1706-14d3-fb1a" name="Lifta-Droppa" hidden="false" typeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" typeName="Weapon">
           <characteristics>
@@ -9317,7 +9313,7 @@
         <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="e8f4-86e5-a97d-2817" name="Gargantuan Squiggoth" hidden="false" collective="false" type="unit">
+    <selectionEntry id="e8f4-86e5-a97d-2817" name="Gargantuan Squiggoth" hidden="false" collective="false" import="true" type="unit">
       <profiles>
         <profile id="c87b-3e02-65ea-6494" name="Gargantuan Squiggoth" hidden="false" typeId="800f-21d0-4387-c943" typeName="Unit">
           <characteristics>
@@ -9385,7 +9381,7 @@
         <categoryLink id="eafc-cbdc-caf3-ad47" name="New CategoryLink" hidden="false" targetId="bdda-36f0-4f32-1639" primary="false"/>
       </categoryLinks>
       <selectionEntries>
-        <selectionEntry id="eff3-8aa5-48de-b074" name="Huge Tusks" hidden="false" collective="false" type="upgrade">
+        <selectionEntry id="eff3-8aa5-48de-b074" name="Huge Tusks" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0ea3-6f73-76ac-77a7" type="min"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="eb4c-88a0-b6bc-23fd" type="max"/>
@@ -9410,23 +9406,23 @@
         </selectionEntry>
       </selectionEntries>
       <selectionEntryGroups>
-        <selectionEntryGroup id="dc77-0287-80bc-fd26" name="Big Gunz" hidden="false" collective="false" defaultSelectionEntryId="4e54-1a6f-e816-bfb8">
+        <selectionEntryGroup id="dc77-0287-80bc-fd26" name="Big Gunz" hidden="false" collective="false" import="true" defaultSelectionEntryId="4e54-1a6f-e816-bfb8">
           <constraints>
             <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="64ad-0fc6-5e5c-ce49" type="min"/>
             <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d405-522e-a094-1aa5" type="max"/>
           </constraints>
           <entryLinks>
-            <entryLink id="cf48-1132-59cd-f579" name="Killkannon" hidden="false" collective="false" targetId="44ac-f70b-3b79-6eb8" type="selectionEntry">
+            <entryLink id="cf48-1132-59cd-f579" name="Killkannon" hidden="false" collective="false" import="true" targetId="44ac-f70b-3b79-6eb8" type="selectionEntry">
               <constraints>
                 <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6fda-50c9-a313-515d" type="max"/>
               </constraints>
             </entryLink>
-            <entryLink id="ed84-a6ec-af1a-83d1" name="Big Zzappa" hidden="false" collective="false" targetId="0ee1-1fff-eb8b-ae31" type="selectionEntry">
+            <entryLink id="ed84-a6ec-af1a-83d1" name="Big Zzappa" hidden="false" collective="false" import="true" targetId="0ee1-1fff-eb8b-ae31" type="selectionEntry">
               <constraints>
                 <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4f87-2089-6515-8d5c" type="max"/>
               </constraints>
             </entryLink>
-            <entryLink id="4e54-1a6f-e816-bfb8" name="Supa-Lobba" hidden="false" collective="false" targetId="7980-7bba-02d7-c7ae" type="selectionEntry">
+            <entryLink id="4e54-1a6f-e816-bfb8" name="Supa-Lobba" hidden="false" collective="false" import="true" targetId="7980-7bba-02d7-c7ae" type="selectionEntry">
               <constraints>
                 <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ae0d-84c4-b5bf-639a" type="max"/>
               </constraints>
@@ -9435,12 +9431,12 @@
         </selectionEntryGroup>
       </selectionEntryGroups>
       <entryLinks>
-        <entryLink id="3a82-6f00-88ef-27ec" name="Big Shoota" hidden="false" collective="false" targetId="6008-4737-d8e6-e63b" type="selectionEntry">
+        <entryLink id="3a82-6f00-88ef-27ec" name="Big Shoota" hidden="false" collective="false" import="true" targetId="6008-4737-d8e6-e63b" type="selectionEntry">
           <constraints>
             <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a30a-e69e-63bd-f47b" type="max"/>
           </constraints>
         </entryLink>
-        <entryLink id="77af-2b9e-08bd-182b" name="Twin Big Shoota" hidden="false" collective="false" targetId="a4f1-6ccb-1c50-405b" type="selectionEntry">
+        <entryLink id="77af-2b9e-08bd-182b" name="Twin Big Shoota" hidden="false" collective="false" import="true" targetId="a4f1-6ccb-1c50-405b" type="selectionEntry">
           <constraints>
             <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="57f4-e6f7-4126-928d" type="max"/>
             <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="798d-4422-386b-9460" type="min"/>
@@ -9453,7 +9449,7 @@
         <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="7980-7bba-02d7-c7ae" name="Supa-Lobba" hidden="false" collective="false" type="upgrade">
+    <selectionEntry id="7980-7bba-02d7-c7ae" name="Supa-Lobba" hidden="false" collective="false" import="true" type="upgrade">
       <profiles>
         <profile id="f433-7d08-f1cd-df92" name="Supa-Lobba" hidden="false" typeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" typeName="Weapon">
           <characteristics>
@@ -9472,7 +9468,7 @@
         <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="c5aa-3d54-aeaa-36ca" name="Grot Riggers" hidden="false" collective="false" type="upgrade">
+    <selectionEntry id="c5aa-3d54-aeaa-36ca" name="Grot Riggers" hidden="false" collective="false" import="true" type="upgrade">
       <infoLinks>
         <infoLink id="ddfc-f5d0-89b6-d358" name="Grot Riggers" hidden="false" targetId="5291-c6ef-63b6-68a0" type="profile"/>
       </infoLinks>
@@ -9482,7 +9478,7 @@
         <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="95b5-fb4b-a7d2-ec1a" name="Reinforced Ram" hidden="false" collective="false" type="upgrade">
+    <selectionEntry id="95b5-fb4b-a7d2-ec1a" name="Reinforced Ram" hidden="false" collective="false" import="true" type="upgrade">
       <profiles>
         <profile id="9ff3-2d85-0254-9a5f" name="Reinforced Ram" hidden="false" typeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" typeName="Abilities">
           <characteristics>
@@ -9496,14 +9492,14 @@
         <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="8703-3b14-9865-d60f" name="Rokkit Bomm Racks" hidden="false" collective="false" type="upgrade">
+    <selectionEntry id="8703-3b14-9865-d60f" name="Rokkit Bomm Racks" hidden="false" collective="false" import="true" type="upgrade">
       <costs>
         <cost name="pts" typeId="points" value="13.0"/>
         <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0"/>
         <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="2efd-be89-30eb-f182" name="Grot Sponson" hidden="false" collective="false" type="upgrade">
+    <selectionEntry id="2efd-be89-30eb-f182" name="Grot Sponson" hidden="false" collective="false" import="true" type="upgrade">
       <profiles>
         <profile id="5a66-860a-d2c7-d0a7" name="Grot Sponson" hidden="false" typeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" typeName="Weapon">
           <characteristics>
@@ -9522,7 +9518,7 @@
         <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="945e-f882-56b2-3f7e" name="Gorin&apos; Horns" hidden="false" collective="false" type="upgrade">
+    <selectionEntry id="945e-f882-56b2-3f7e" name="Gorin&apos; Horns" hidden="false" collective="false" import="true" type="upgrade">
       <profiles>
         <profile id="cced-5445-7426-1a59" name="Gorin&apos; Horns" hidden="false" typeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" typeName="Weapon">
           <characteristics>
@@ -9541,7 +9537,7 @@
         <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="46b2-df57-7c2f-80d7" name="Mega Klaw" hidden="false" collective="false" type="upgrade">
+    <selectionEntry id="46b2-df57-7c2f-80d7" name="Mega Klaw" hidden="false" collective="false" import="true" type="upgrade">
       <profiles>
         <profile id="4d60-0aec-2f6a-59d4" name="Mega-Choppa (Slash)" hidden="false" typeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" typeName="Weapon">
           <characteristics>
@@ -9560,7 +9556,7 @@
         <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="de51-4ce6-1a6b-ca70" name="Grot Bomm Launcha (Open/Narrative)" hidden="true" collective="false" type="unit">
+    <selectionEntry id="de51-4ce6-1a6b-ca70" name="Grot Bomm Launcha (Open/Narrative)" hidden="true" collective="false" import="true" type="unit">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditionGroups>
@@ -9610,8 +9606,8 @@
         <categoryLink id="f973-8e15-1f54-f144" name="New CategoryLink" hidden="false" targetId="c274d0b0-5866-44bc-9810-91c136ae7438" primary="true"/>
       </categoryLinks>
       <entryLinks>
-        <entryLink id="d565-b93c-60d4-5c9e" name="Has Battle Honours" hidden="false" collective="false" targetId="4763-757f-499f-d998" type="selectionEntry"/>
-        <entryLink id="f7ef-bc80-a293-15e3" name="Battle Honours" hidden="false" collective="false" targetId="5518-d0f5-a880-d71c" type="selectionEntryGroup"/>
+        <entryLink id="d565-b93c-60d4-5c9e" name="Has Battle Honours" hidden="false" collective="false" import="true" targetId="4763-757f-499f-d998" type="selectionEntry"/>
+        <entryLink id="f7ef-bc80-a293-15e3" name="Battle Honours" hidden="false" collective="false" import="true" targetId="5518-d0f5-a880-d71c" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
         <cost name=" PL" typeId="e356-c769-5920-6e14" value="4.0"/>
@@ -9619,7 +9615,7 @@
         <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="e3c1-9af9-b021-7b95" name="Attack Fighta (Open/Narrative)" hidden="true" collective="false" type="model">
+    <selectionEntry id="e3c1-9af9-b021-7b95" name="Attack Fighta (Open/Narrative)" hidden="true" collective="false" import="true" type="model">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditionGroups>
@@ -9683,13 +9679,13 @@
         <categoryLink id="8622-46ec-3966-a55f" name="New CategoryLink" hidden="false" targetId="c8fd-783f-3230-493e" primary="false"/>
       </categoryLinks>
       <selectionEntryGroups>
-        <selectionEntryGroup id="0c85-6073-fdfa-3cbe" name="Wing Weapons" hidden="false" collective="false" defaultSelectionEntryId="72c6-bd67-f00d-5055">
+        <selectionEntryGroup id="0c85-6073-fdfa-3cbe" name="Wing Weapons" hidden="false" collective="false" import="true" defaultSelectionEntryId="72c6-bd67-f00d-5055">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4062-ed0a-2b65-54d3" type="max"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9148-de5f-16cb-abad" type="min"/>
           </constraints>
           <selectionEntries>
-            <selectionEntry id="06bb-6dbc-8654-cf1a" name="Wing Rokkits" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="06bb-6dbc-8654-cf1a" name="Wing Rokkits" hidden="false" collective="false" import="true" type="upgrade">
               <profiles>
                 <profile id="dbe4-e07b-3daf-8457" name="Wing Rokkits" hidden="false" typeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" typeName="Weapon">
                   <characteristics>
@@ -9708,7 +9704,7 @@
                 <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
               </costs>
             </selectionEntry>
-            <selectionEntry id="72c6-bd67-f00d-5055" name="Small Bomms" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="72c6-bd67-f00d-5055" name="Small Bomms" hidden="false" collective="false" import="true" type="upgrade">
               <profiles>
                 <profile id="ab7b-1481-feed-80e1" name="Small Bomms" hidden="false" typeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" typeName="Abilities">
                   <characteristics>
@@ -9726,14 +9722,14 @@
         </selectionEntryGroup>
       </selectionEntryGroups>
       <entryLinks>
-        <entryLink id="e9df-a781-d8b9-be33" name="Twin Big Shoota" hidden="false" collective="false" targetId="a4f1-6ccb-1c50-405b" type="selectionEntry">
+        <entryLink id="e9df-a781-d8b9-be33" name="Twin Big Shoota" hidden="false" collective="false" import="true" targetId="a4f1-6ccb-1c50-405b" type="selectionEntry">
           <constraints>
             <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d49b-cb2f-d148-ad08" type="max"/>
             <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="626c-a6a7-7a05-9423" type="min"/>
           </constraints>
         </entryLink>
-        <entryLink id="6c11-3d08-e6f4-aa16" name="Has Battle Honours" hidden="false" collective="false" targetId="4763-757f-499f-d998" type="selectionEntry"/>
-        <entryLink id="e192-6fdb-2e30-2680" name="Battle Honours" hidden="false" collective="false" targetId="5518-d0f5-a880-d71c" type="selectionEntryGroup"/>
+        <entryLink id="6c11-3d08-e6f4-aa16" name="Has Battle Honours" hidden="false" collective="false" import="true" targetId="4763-757f-499f-d998" type="selectionEntry"/>
+        <entryLink id="e192-6fdb-2e30-2680" name="Battle Honours" hidden="false" collective="false" import="true" targetId="5518-d0f5-a880-d71c" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
         <cost name=" PL" typeId="e356-c769-5920-6e14" value="6.0"/>
@@ -9741,7 +9737,7 @@
         <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="ce2e-a0ad-29b2-3eab" name="Fighta-Bommer (Open/Narrative)" hidden="true" collective="false" type="model">
+    <selectionEntry id="ce2e-a0ad-29b2-3eab" name="Fighta-Bommer (Open/Narrative)" hidden="true" collective="false" import="true" type="model">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditionGroups>
@@ -9805,13 +9801,13 @@
         <categoryLink id="620f-9954-16b4-edeb" name="New CategoryLink" hidden="false" targetId="c8fd-783f-3230-493e" primary="false"/>
       </categoryLinks>
       <selectionEntryGroups>
-        <selectionEntryGroup id="f9fb-7093-4d0c-6498" name="Wing Weapons" hidden="false" collective="false">
+        <selectionEntryGroup id="f9fb-7093-4d0c-6498" name="Wing Weapons" hidden="false" collective="false" import="true">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="95be-3858-fc7a-6721" type="max"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f190-190d-df3f-9d5a" type="min"/>
           </constraints>
           <selectionEntries>
-            <selectionEntry id="0f0f-6ad7-8047-07df" name="Wing Rokkits" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="0f0f-6ad7-8047-07df" name="Wing Rokkits" hidden="false" collective="false" import="true" type="upgrade">
               <profiles>
                 <profile id="6f17-d449-cfa5-5c23" name="Wing Rokkits" hidden="false" typeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" typeName="Weapon">
                   <characteristics>
@@ -9830,7 +9826,7 @@
                 <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
               </costs>
             </selectionEntry>
-            <selectionEntry id="257f-1615-d6d3-b9db" name="Small Bomms" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="257f-1615-d6d3-b9db" name="Small Bomms" hidden="false" collective="false" import="true" type="upgrade">
               <profiles>
                 <profile id="cfc1-d911-6a9b-1c40" name="Small Bomms" hidden="false" typeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" typeName="Abilities">
                   <characteristics>
@@ -9844,7 +9840,7 @@
                 <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
               </costs>
             </selectionEntry>
-            <selectionEntry id="de28-5344-933d-8f30" name="Grot-Guided Bomms" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="de28-5344-933d-8f30" name="Grot-Guided Bomms" hidden="false" collective="false" import="true" type="upgrade">
               <profiles>
                 <profile id="14b5-7100-b620-f1d8" name="Grot Guided Bomm" hidden="false" typeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" typeName="Weapon">
                   <characteristics>
@@ -9867,14 +9863,14 @@
         </selectionEntryGroup>
       </selectionEntryGroups>
       <entryLinks>
-        <entryLink id="c06c-888a-8274-24db" name="Twin Big Shoota" hidden="false" collective="false" targetId="a4f1-6ccb-1c50-405b" type="selectionEntry">
+        <entryLink id="c06c-888a-8274-24db" name="Twin Big Shoota" hidden="false" collective="false" import="true" targetId="a4f1-6ccb-1c50-405b" type="selectionEntry">
           <constraints>
             <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="25ee-172d-a84a-ed5a" type="max"/>
             <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4756-bf44-2e24-e31b" type="min"/>
           </constraints>
         </entryLink>
-        <entryLink id="22f9-4da9-ba1b-5530" name="Has Battle Honours" hidden="false" collective="false" targetId="4763-757f-499f-d998" type="selectionEntry"/>
-        <entryLink id="4fba-842f-ccc5-4d1f" name="Battle Honours" hidden="false" collective="false" targetId="5518-d0f5-a880-d71c" type="selectionEntryGroup"/>
+        <entryLink id="22f9-4da9-ba1b-5530" name="Has Battle Honours" hidden="false" collective="false" import="true" targetId="4763-757f-499f-d998" type="selectionEntry"/>
+        <entryLink id="4fba-842f-ccc5-4d1f" name="Battle Honours" hidden="false" collective="false" import="true" targetId="5518-d0f5-a880-d71c" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
         <cost name=" PL" typeId="e356-c769-5920-6e14" value="7.0"/>
@@ -9882,7 +9878,7 @@
         <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="63ac-bded-f230-452a" name="Big Mek W/ Shokk Attack Gun" publicationId="11b5-77b9-pubN65537" page="86" hidden="false" collective="false" type="unit">
+    <selectionEntry id="63ac-bded-f230-452a" name="Big Mek W/ Shokk Attack Gun" publicationId="11b5-77b9-pubN65537" page="86" hidden="false" collective="false" import="true" type="unit">
       <profiles>
         <profile id="5e0d-fb01-cfb7-1369" name="Big Mek" hidden="false" typeId="800f-21d0-4387-c943" typeName="Unit">
           <characteristics>
@@ -9913,42 +9909,42 @@
         <categoryLink id="92f3-ab6d-24ce-6b37" name="New CategoryLink" hidden="false" targetId="3d52-fccf-10c0-3fae" primary="false"/>
       </categoryLinks>
       <selectionEntryGroups>
-        <selectionEntryGroup id="2245-6a70-9f54-ed81" name="Index Wargear" hidden="false" collective="false">
+        <selectionEntryGroup id="2245-6a70-9f54-ed81" name="Index Wargear" hidden="false" collective="false" import="true">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ef27-4186-9517-9442" type="max"/>
           </constraints>
           <entryLinks>
-            <entryLink id="dab4-44c7-8ec1-200f" name="New EntryLink" hidden="false" collective="false" targetId="c4df-c43d-08a6-18ab" type="selectionEntry"/>
-            <entryLink id="d32f-ab05-76a6-f0cf" name="Big Choppa" hidden="false" collective="false" targetId="0470-1b47-489b-14c9" type="selectionEntry"/>
-            <entryLink id="d3f6-d53c-ecd9-8b68" name="New EntryLink" hidden="false" collective="false" targetId="3511-0070-0667-abf2" type="selectionEntry"/>
-            <entryLink id="9f68-28f7-cdba-d7e5" name="New EntryLink" hidden="false" collective="false" targetId="b6c7-06c8-b7fb-05a7" type="selectionEntry"/>
-            <entryLink id="f051-23e3-655b-a5b3" name="New EntryLink" hidden="false" collective="false" targetId="6d70-25a8-b496-2457" type="selectionEntry"/>
-            <entryLink id="e05d-2d41-14ce-141f" name="New EntryLink" hidden="false" collective="false" targetId="bbc2-56ce-67ec-5422" type="selectionEntry"/>
-            <entryLink id="d791-7964-10da-0366" name="New EntryLink" hidden="false" collective="false" targetId="fe00-451f-6735-6fd9" type="selectionEntry"/>
-            <entryLink id="0d1a-0082-ddd5-0803" name="New EntryLink" hidden="false" collective="false" targetId="a8c1-7fb9-7f7b-84c5" type="selectionEntry"/>
-            <entryLink id="8e77-766f-97bd-f0a0" name="New EntryLink" hidden="false" collective="false" targetId="f15a-fc8e-65b1-e4b8" type="selectionEntry"/>
+            <entryLink id="dab4-44c7-8ec1-200f" name="New EntryLink" hidden="false" collective="false" import="true" targetId="c4df-c43d-08a6-18ab" type="selectionEntry"/>
+            <entryLink id="d32f-ab05-76a6-f0cf" name="Big Choppa" hidden="false" collective="false" import="true" targetId="0470-1b47-489b-14c9" type="selectionEntry"/>
+            <entryLink id="d3f6-d53c-ecd9-8b68" name="New EntryLink" hidden="false" collective="false" import="true" targetId="3511-0070-0667-abf2" type="selectionEntry"/>
+            <entryLink id="9f68-28f7-cdba-d7e5" name="New EntryLink" hidden="false" collective="false" import="true" targetId="b6c7-06c8-b7fb-05a7" type="selectionEntry"/>
+            <entryLink id="f051-23e3-655b-a5b3" name="New EntryLink" hidden="false" collective="false" import="true" targetId="6d70-25a8-b496-2457" type="selectionEntry"/>
+            <entryLink id="e05d-2d41-14ce-141f" name="New EntryLink" hidden="false" collective="false" import="true" targetId="bbc2-56ce-67ec-5422" type="selectionEntry"/>
+            <entryLink id="d791-7964-10da-0366" name="New EntryLink" hidden="false" collective="false" import="true" targetId="fe00-451f-6735-6fd9" type="selectionEntry"/>
+            <entryLink id="0d1a-0082-ddd5-0803" name="New EntryLink" hidden="false" collective="false" import="true" targetId="a8c1-7fb9-7f7b-84c5" type="selectionEntry"/>
+            <entryLink id="8e77-766f-97bd-f0a0" name="New EntryLink" hidden="false" collective="false" import="true" targetId="f15a-fc8e-65b1-e4b8" type="selectionEntry"/>
           </entryLinks>
         </selectionEntryGroup>
       </selectionEntryGroups>
       <entryLinks>
-        <entryLink id="64a7-d9a4-2ac0-873d" name="Stikkbombs" hidden="false" collective="false" targetId="6df7-0ee7-7e6d-b182" type="selectionEntry"/>
-        <entryLink id="91d4-2e61-a6b4-75e5" name="Grot Oiler" hidden="false" collective="false" targetId="9459-87f3-a9a1-6840" type="selectionEntry">
+        <entryLink id="64a7-d9a4-2ac0-873d" name="Stikkbombs" hidden="false" collective="false" import="true" targetId="6df7-0ee7-7e6d-b182" type="selectionEntry"/>
+        <entryLink id="91d4-2e61-a6b4-75e5" name="Grot Oiler" hidden="false" collective="false" import="true" targetId="9459-87f3-a9a1-6840" type="selectionEntry">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c152-9b92-166e-d241" type="max"/>
           </constraints>
         </entryLink>
-        <entryLink id="3ec1-e330-7b98-46f8" name="Warlord Traits" hidden="false" collective="false" targetId="c2ce-6759-e009-8c11" type="selectionEntryGroup"/>
-        <entryLink id="9218-9de6-b322-5ac7" name="Warlord" hidden="false" collective="false" targetId="33f6-60da-7b70-5fee" type="selectionEntry"/>
-        <entryLink id="9279-7d0c-556f-7c9c" name="Shokk Attack Gun" hidden="false" collective="false" targetId="fe4b-833c-f74e-cce7" type="selectionEntry">
+        <entryLink id="3ec1-e330-7b98-46f8" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="c2ce-6759-e009-8c11" type="selectionEntryGroup"/>
+        <entryLink id="9218-9de6-b322-5ac7" name="Warlord" hidden="false" collective="false" import="true" targetId="33f6-60da-7b70-5fee" type="selectionEntry"/>
+        <entryLink id="9279-7d0c-556f-7c9c" name="Shokk Attack Gun" hidden="false" collective="false" import="true" targetId="fe4b-833c-f74e-cce7" type="selectionEntry">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7095-0bf6-ad0b-48d8" type="max"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="be8d-6d91-10a4-f3f9" type="min"/>
           </constraints>
         </entryLink>
-        <entryLink id="c5cf-6e2b-99fc-b69f" name="Relic Gubbinz" hidden="false" collective="false" targetId="04b0-dab2-123b-df51" type="selectionEntryGroup"/>
-        <entryLink id="5187-0d50-321c-c9b8" name="Is a Custom Character" hidden="false" collective="false" targetId="43c4-8968-c599-ad5f" type="selectionEntry"/>
-        <entryLink id="eb2d-7f68-b7aa-c30b" name="Custom Character Selections" hidden="false" collective="false" targetId="8774-e003-4a50-56c7" type="selectionEntryGroup"/>
-        <entryLink id="31e0-6405-4f22-9c95" name="Stratagem: Field Commander" hidden="false" collective="false" targetId="d043-3847-e963-fb5d" type="selectionEntry">
+        <entryLink id="c5cf-6e2b-99fc-b69f" name="Relic Gubbinz" hidden="false" collective="false" import="true" targetId="04b0-dab2-123b-df51" type="selectionEntryGroup"/>
+        <entryLink id="5187-0d50-321c-c9b8" name="Is a Custom Character" hidden="false" collective="false" import="true" targetId="43c4-8968-c599-ad5f" type="selectionEntry"/>
+        <entryLink id="eb2d-7f68-b7aa-c30b" name="Custom Character Selections" hidden="false" collective="false" import="true" targetId="8774-e003-4a50-56c7" type="selectionEntryGroup"/>
+        <entryLink id="31e0-6405-4f22-9c95" name="Stratagem: Field Commander" hidden="false" collective="false" import="true" targetId="d043-3847-e963-fb5d" type="selectionEntry">
           <modifiers>
             <modifier type="set" field="hidden" value="true">
               <conditions>
@@ -9964,7 +9960,7 @@
         <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="6322-7945-e129-cc1d" name="Kustom Mega-zappa" hidden="false" collective="false" type="upgrade">
+    <selectionEntry id="6322-7945-e129-cc1d" name="Kustom Mega-zappa" hidden="false" collective="false" import="true" type="upgrade">
       <profiles>
         <profile id="8f63-ff5e-a918-a32d" name="Kustom Mega-zappa" hidden="false" typeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" typeName="Weapon">
           <characteristics>
@@ -9983,7 +9979,7 @@
         <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="02b9-11f4-6969-f8bd" name="Deffkilla Wartrike" publicationId="11b5-77b9-pubN65537" page="89" hidden="false" collective="false" type="unit">
+    <selectionEntry id="02b9-11f4-6969-f8bd" name="Deffkilla Wartrike" publicationId="11b5-77b9-pubN65537" page="89" hidden="false" collective="false" import="true" type="unit">
       <profiles>
         <profile id="4612-e7bd-824d-9374" name="Deffkill Wartrike" hidden="false" typeId="800f-21d0-4387-c943" typeName="Unit">
           <characteristics>
@@ -10026,7 +10022,7 @@
         <categoryLink id="6c06-558c-1a17-1c39" name="Vehicle" hidden="false" targetId="c8fd-783f-3230-493e" primary="false"/>
       </categoryLinks>
       <selectionEntries>
-        <selectionEntry id="f05b-43d6-7be8-17f8" name="Killa Jet" hidden="false" collective="false" type="upgrade">
+        <selectionEntry id="f05b-43d6-7be8-17f8" name="Killa Jet" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d612-34f1-54f1-d9b3" type="max"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="54ac-f9b2-dca5-5ac7" type="min"/>
@@ -10059,7 +10055,7 @@
             <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
           </costs>
         </selectionEntry>
-        <selectionEntry id="e8e1-f188-9cef-91e5" name="Snagga Klaw" hidden="false" collective="false" type="upgrade">
+        <selectionEntry id="e8e1-f188-9cef-91e5" name="Snagga Klaw" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ae70-482e-0314-c7d8" type="min"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1465-05a9-a6fe-143e" type="max"/>
@@ -10092,7 +10088,7 @@
             <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
           </costs>
         </selectionEntry>
-        <selectionEntry id="7f5c-4c2a-b996-3647" name="Twin Boomstick" hidden="false" collective="false" type="upgrade">
+        <selectionEntry id="7f5c-4c2a-b996-3647" name="Twin Boomstick" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
             <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8154-f1cf-ef49-9f08" type="max"/>
             <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="47b7-21ef-8083-d559" type="min"/>
@@ -10117,12 +10113,12 @@
         </selectionEntry>
       </selectionEntries>
       <entryLinks>
-        <entryLink id="a82c-e738-875f-5666" name="Warlord Traits" hidden="false" collective="false" targetId="c2ce-6759-e009-8c11" type="selectionEntryGroup"/>
-        <entryLink id="53ed-7ff4-0c90-fa75" name="Warlord" hidden="false" collective="false" targetId="33f6-60da-7b70-5fee" type="selectionEntry"/>
-        <entryLink id="2a1b-0873-03f3-307d" name="Relic Gubbinz" hidden="false" collective="false" targetId="04b0-dab2-123b-df51" type="selectionEntryGroup"/>
-        <entryLink id="5319-a824-0511-9edd" name="Is a Custom Character" hidden="false" collective="false" targetId="43c4-8968-c599-ad5f" type="selectionEntry"/>
-        <entryLink id="6754-f353-569d-dfc5" name="Custom Character Selections" hidden="false" collective="false" targetId="8774-e003-4a50-56c7" type="selectionEntryGroup"/>
-        <entryLink id="8448-8690-0905-df28" name="Stratagem: Field Commander" hidden="false" collective="false" targetId="d043-3847-e963-fb5d" type="selectionEntry">
+        <entryLink id="a82c-e738-875f-5666" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="c2ce-6759-e009-8c11" type="selectionEntryGroup"/>
+        <entryLink id="53ed-7ff4-0c90-fa75" name="Warlord" hidden="false" collective="false" import="true" targetId="33f6-60da-7b70-5fee" type="selectionEntry"/>
+        <entryLink id="2a1b-0873-03f3-307d" name="Relic Gubbinz" hidden="false" collective="false" import="true" targetId="04b0-dab2-123b-df51" type="selectionEntryGroup"/>
+        <entryLink id="5319-a824-0511-9edd" name="Is a Custom Character" hidden="false" collective="false" import="true" targetId="43c4-8968-c599-ad5f" type="selectionEntry"/>
+        <entryLink id="6754-f353-569d-dfc5" name="Custom Character Selections" hidden="false" collective="false" import="true" targetId="8774-e003-4a50-56c7" type="selectionEntryGroup"/>
+        <entryLink id="8448-8690-0905-df28" name="Stratagem: Field Commander" hidden="false" collective="false" import="true" targetId="d043-3847-e963-fb5d" type="selectionEntry">
           <modifiers>
             <modifier type="set" field="hidden" value="true">
               <conditions>
@@ -10138,7 +10134,7 @@
         <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="3e2b-6a43-cae2-f7ad" name="Shokkjump Dragstas" hidden="false" collective="false" type="unit">
+    <selectionEntry id="3e2b-6a43-cae2-f7ad" name="Shokkjump Dragstas" hidden="false" collective="false" import="true" type="unit">
       <profiles>
         <profile id="b93f-30fb-9d7e-2a40" name="Grot Gunner and Targeting Squig" hidden="false" typeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" typeName="Abilities">
           <characteristics>
@@ -10167,13 +10163,13 @@
         <categoryLink id="daac-4e2c-de7f-827e" name="Shokkjump Dragsta" hidden="false" targetId="ebf5-d421-acf7-e1ae" primary="false"/>
       </categoryLinks>
       <selectionEntryGroups>
-        <selectionEntryGroup id="e4cb-5321-2acc-fccc" name="Mob" hidden="false" collective="false" defaultSelectionEntryId="6b34-a35f-3f36-3c3e">
+        <selectionEntryGroup id="e4cb-5321-2acc-fccc" name="Mob" hidden="false" collective="false" import="true" defaultSelectionEntryId="6b34-a35f-3f36-3c3e">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3cbc-2e8e-d37e-e097" type="min"/>
             <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1ee4-e0af-3a69-d807" type="max"/>
           </constraints>
           <selectionEntries>
-            <selectionEntry id="6b34-a35f-3f36-3c3e" name="Shokkjump Dragstas" hidden="false" collective="false" type="model">
+            <selectionEntry id="6b34-a35f-3f36-3c3e" name="Shokkjump Dragstas" hidden="false" collective="false" import="true" type="model">
               <profiles>
                 <profile id="3a1b-cb1c-7333-deb8" name="Shokkjump Dragstas" hidden="false" typeId="800f-21d0-4387-c943" typeName="Unit">
                   <characteristics>
@@ -10190,7 +10186,7 @@
                 </profile>
               </profiles>
               <selectionEntries>
-                <selectionEntry id="bdcc-078f-a9f7-72bd" name="Kustom Shokk Rifle" hidden="false" collective="false" type="upgrade">
+                <selectionEntry id="bdcc-078f-a9f7-72bd" name="Kustom Shokk Rifle" hidden="false" collective="false" import="true" type="upgrade">
                   <constraints>
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9672-8f54-96db-deaa" type="max"/>
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5123-faf0-5b7b-0cf8" type="min"/>
@@ -10213,7 +10209,7 @@
                     <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
                   </costs>
                 </selectionEntry>
-                <selectionEntry id="2542-5e6d-46c1-21f0" name="Saw Blades" hidden="false" collective="false" type="upgrade">
+                <selectionEntry id="2542-5e6d-46c1-21f0" name="Saw Blades" hidden="false" collective="false" import="true" type="upgrade">
                   <constraints>
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a680-39a4-163e-0133" type="max"/>
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="73c3-0902-68b0-71ba" type="min"/>
@@ -10238,14 +10234,14 @@
                 </selectionEntry>
               </selectionEntries>
               <entryLinks>
-                <entryLink id="f3e0-0acd-4bd8-3112" name="Rokkit Launcha" hidden="false" collective="false" targetId="a8c1-7fb9-7f7b-84c5" type="selectionEntry">
+                <entryLink id="f3e0-0acd-4bd8-3112" name="Rokkit Launcha" hidden="false" collective="false" import="true" targetId="a8c1-7fb9-7f7b-84c5" type="selectionEntry">
                   <constraints>
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c2ef-eab9-2997-2b80" type="max"/>
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6268-78de-bf3a-0f9f" type="min"/>
                   </constraints>
                 </entryLink>
-                <entryLink id="14da-3ec3-c79d-9b25" name="Has Battle Honours" hidden="false" collective="false" targetId="4763-757f-499f-d998" type="selectionEntry"/>
-                <entryLink id="a331-fe95-fb58-3412" name="Battle Honours" hidden="false" collective="false" targetId="5518-d0f5-a880-d71c" type="selectionEntryGroup"/>
+                <entryLink id="14da-3ec3-c79d-9b25" name="Has Battle Honours" hidden="false" collective="false" import="true" targetId="4763-757f-499f-d998" type="selectionEntry"/>
+                <entryLink id="a331-fe95-fb58-3412" name="Battle Honours" hidden="false" collective="false" import="true" targetId="5518-d0f5-a880-d71c" type="selectionEntryGroup"/>
               </entryLinks>
               <costs>
                 <cost name="pts" typeId="points" value="108.0"/>
@@ -10262,7 +10258,7 @@
         <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="9771-81af-630b-74a3" name="Rukkatrukk Squigbuggy" hidden="false" collective="false" type="unit">
+    <selectionEntry id="9771-81af-630b-74a3" name="Rukkatrukk Squigbuggy" hidden="false" collective="false" import="true" type="unit">
       <profiles>
         <profile id="a4a9-f632-d747-3aa7" name="Grot Gunner" hidden="false" typeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" typeName="Abilities">
           <characteristics>
@@ -10290,13 +10286,13 @@
         <categoryLink id="d88c-7d6d-5dc9-078e" name="Rukkatrukk Squigbuggy" hidden="false" targetId="9c5e-7c82-7224-dd28" primary="false"/>
       </categoryLinks>
       <selectionEntryGroups>
-        <selectionEntryGroup id="f34a-fba8-2726-4d8a" name="Mob" hidden="false" collective="false" defaultSelectionEntryId="2fa7-f344-76e7-7fd2">
+        <selectionEntryGroup id="f34a-fba8-2726-4d8a" name="Mob" hidden="false" collective="false" import="true" defaultSelectionEntryId="2fa7-f344-76e7-7fd2">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5101-fafa-4043-6b1a" type="min"/>
             <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5f23-9a0a-daf5-c3f5" type="max"/>
           </constraints>
           <selectionEntries>
-            <selectionEntry id="2fa7-f344-76e7-7fd2" name="Rukkatrukk Squigbuggy" hidden="false" collective="false" type="model">
+            <selectionEntry id="2fa7-f344-76e7-7fd2" name="Rukkatrukk Squigbuggy" hidden="false" collective="false" import="true" type="model">
               <profiles>
                 <profile id="a6ca-5828-a99b-1ae3" name="Rukkatrukk Squigbuggy" hidden="false" typeId="800f-21d0-4387-c943" typeName="Unit">
                   <characteristics>
@@ -10313,7 +10309,7 @@
                 </profile>
               </profiles>
               <selectionEntries>
-                <selectionEntry id="faac-9a74-4db2-cd34" name="Saw Blades" hidden="false" collective="false" type="upgrade">
+                <selectionEntry id="faac-9a74-4db2-cd34" name="Saw Blades" hidden="false" collective="false" import="true" type="upgrade">
                   <constraints>
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c7ab-3374-7864-d3a2" type="max"/>
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="142a-ecb1-bf26-3c32" type="min"/>
@@ -10336,7 +10332,7 @@
                     <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
                   </costs>
                 </selectionEntry>
-                <selectionEntry id="725f-8810-3ef9-da6c" name="Squig Mine" hidden="false" collective="false" type="upgrade">
+                <selectionEntry id="725f-8810-3ef9-da6c" name="Squig Mine" hidden="false" collective="false" import="true" type="upgrade">
                   <constraints>
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f2aa-7504-8cd8-f23b" type="max"/>
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ccf6-b095-9121-e108" type="min"/>
@@ -10354,7 +10350,7 @@
                     <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
                   </costs>
                 </selectionEntry>
-                <selectionEntry id="2882-6917-8d09-f5ae" name="Heavy Squig Launcha" hidden="false" collective="false" type="upgrade">
+                <selectionEntry id="2882-6917-8d09-f5ae" name="Heavy Squig Launcha" hidden="false" collective="false" import="true" type="upgrade">
                   <constraints>
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2883-60bf-7e22-a77e" type="max"/>
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ee68-ecf6-69dc-2e20" type="min"/>
@@ -10397,7 +10393,7 @@
                     <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
                   </costs>
                 </selectionEntry>
-                <selectionEntry id="509e-baf2-f24e-08a1" name="Squig Launcha" hidden="false" collective="false" type="upgrade">
+                <selectionEntry id="509e-baf2-f24e-08a1" name="Squig Launcha" hidden="false" collective="false" import="true" type="upgrade">
                   <constraints>
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1f53-6dc5-3e60-4069" type="max"/>
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5ac7-b3e2-833a-11d4" type="min"/>
@@ -10440,7 +10436,7 @@
                     <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
                   </costs>
                 </selectionEntry>
-                <selectionEntry id="a73a-91dc-58dd-6582" name="Shotgun" hidden="false" collective="false" type="upgrade">
+                <selectionEntry id="a73a-91dc-58dd-6582" name="Shotgun" hidden="false" collective="false" import="true" type="upgrade">
                   <constraints>
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6920-20c4-fc08-807f" type="max"/>
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="364a-ca0f-a1e8-dba7" type="min"/>
@@ -10463,7 +10459,7 @@
                     <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
                   </costs>
                 </selectionEntry>
-                <selectionEntry id="a3f2-4de4-1d72-4111" name="Stikk Squigs" hidden="false" collective="false" type="upgrade">
+                <selectionEntry id="a3f2-4de4-1d72-4111" name="Stikk Squigs" hidden="false" collective="false" import="true" type="upgrade">
                   <constraints>
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b515-3a29-3dcf-0f02" type="max"/>
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bca7-e4fd-b396-ba11" type="min"/>
@@ -10488,8 +10484,8 @@
                 </selectionEntry>
               </selectionEntries>
               <entryLinks>
-                <entryLink id="9645-cf8b-2be5-9ac0" name="Has Battle Honours" hidden="false" collective="false" targetId="4763-757f-499f-d998" type="selectionEntry"/>
-                <entryLink id="c43d-30b6-cb97-d209" name="Battle Honours" hidden="false" collective="false" targetId="5518-d0f5-a880-d71c" type="selectionEntryGroup"/>
+                <entryLink id="9645-cf8b-2be5-9ac0" name="Has Battle Honours" hidden="false" collective="false" import="true" targetId="4763-757f-499f-d998" type="selectionEntry"/>
+                <entryLink id="c43d-30b6-cb97-d209" name="Battle Honours" hidden="false" collective="false" import="true" targetId="5518-d0f5-a880-d71c" type="selectionEntryGroup"/>
               </entryLinks>
               <costs>
                 <cost name="pts" typeId="points" value="140.0"/>
@@ -10506,7 +10502,7 @@
         <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="f81f-4af6-bf20-9655" name="Boomdakka Snazzwagon" hidden="false" collective="false" type="unit">
+    <selectionEntry id="f81f-4af6-bf20-9655" name="Boomdakka Snazzwagon" hidden="false" collective="false" import="true" type="unit">
       <profiles>
         <profile id="8910-6765-b8a3-8b8e" name="Riding Shotgun" hidden="false" typeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" typeName="Abilities">
           <characteristics>
@@ -10540,13 +10536,13 @@
         <categoryLink id="b1ab-fad2-9181-08e2" name="Boomdakka Snazzwagon" hidden="false" targetId="9b2e-bba8-205c-d3a2" primary="false"/>
       </categoryLinks>
       <selectionEntryGroups>
-        <selectionEntryGroup id="a04d-0211-e0b6-677a" name="Mob" hidden="false" collective="false" defaultSelectionEntryId="8aff-96b2-e84f-1f11">
+        <selectionEntryGroup id="a04d-0211-e0b6-677a" name="Mob" hidden="false" collective="false" import="true" defaultSelectionEntryId="8aff-96b2-e84f-1f11">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9588-ff37-e03a-8190" type="min"/>
             <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="54eb-10be-80f9-4251" type="max"/>
           </constraints>
           <selectionEntries>
-            <selectionEntry id="8aff-96b2-e84f-1f11" name="Boomdakka Snazzwagon" hidden="false" collective="false" type="model">
+            <selectionEntry id="8aff-96b2-e84f-1f11" name="Boomdakka Snazzwagon" hidden="false" collective="false" import="true" type="model">
               <profiles>
                 <profile id="be28-6c94-19cf-5d5e" name="Boomdakka Snazzwagon" hidden="false" typeId="800f-21d0-4387-c943" typeName="Unit">
                   <characteristics>
@@ -10563,7 +10559,7 @@
                 </profile>
               </profiles>
               <selectionEntries>
-                <selectionEntry id="933f-08a5-bde3-36f7" name="Mek Speshul" hidden="false" collective="false" type="upgrade">
+                <selectionEntry id="933f-08a5-bde3-36f7" name="Mek Speshul" hidden="false" collective="false" import="true" type="upgrade">
                   <constraints>
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4530-4d55-5f6e-2e4b" type="max"/>
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4a7b-0178-cf4c-8e6a" type="min"/>
@@ -10586,7 +10582,7 @@
                     <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
                   </costs>
                 </selectionEntry>
-                <selectionEntry id="ab2f-7701-4979-aeef" name="Burna Bottles" hidden="false" collective="false" type="upgrade">
+                <selectionEntry id="ab2f-7701-4979-aeef" name="Burna Bottles" hidden="false" collective="false" import="true" type="upgrade">
                   <constraints>
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4b79-99c1-132a-3a0e" type="max"/>
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="715d-561b-69b3-8f26" type="min"/>
@@ -10611,20 +10607,20 @@
                 </selectionEntry>
               </selectionEntries>
               <entryLinks>
-                <entryLink id="1a27-3e48-49ce-7036" name="Big Shoota" hidden="false" collective="false" targetId="6008-4737-d8e6-e63b" type="selectionEntry">
+                <entryLink id="1a27-3e48-49ce-7036" name="Big Shoota" hidden="false" collective="false" import="true" targetId="6008-4737-d8e6-e63b" type="selectionEntry">
                   <constraints>
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="dda7-f779-ddb7-af85" type="max"/>
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d304-d7f4-fe74-568c" type="min"/>
                   </constraints>
                 </entryLink>
-                <entryLink id="e168-cc28-bbdd-cdca" name="Grot Blasta" hidden="false" collective="false" targetId="3aa4-aff7-db5e-4b46" type="selectionEntry">
+                <entryLink id="e168-cc28-bbdd-cdca" name="Grot Blasta" hidden="false" collective="false" import="true" targetId="3aa4-aff7-db5e-4b46" type="selectionEntry">
                   <constraints>
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8230-fb24-f55d-ddd9" type="min"/>
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0d67-b964-3076-c5e2" type="max"/>
                   </constraints>
                 </entryLink>
-                <entryLink id="24df-0f45-abe4-6cf2" name="Has Battle Honours" hidden="false" collective="false" targetId="4763-757f-499f-d998" type="selectionEntry"/>
-                <entryLink id="4b06-2626-26e5-0555" name="Battle Honours" hidden="false" collective="false" targetId="5518-d0f5-a880-d71c" type="selectionEntryGroup"/>
+                <entryLink id="24df-0f45-abe4-6cf2" name="Has Battle Honours" hidden="false" collective="false" import="true" targetId="4763-757f-499f-d998" type="selectionEntry"/>
+                <entryLink id="4b06-2626-26e5-0555" name="Battle Honours" hidden="false" collective="false" import="true" targetId="5518-d0f5-a880-d71c" type="selectionEntryGroup"/>
               </entryLinks>
               <costs>
                 <cost name="pts" typeId="points" value="95.0"/>
@@ -10641,7 +10637,7 @@
         <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="e185-cc94-ec1e-9b84" name="Bonebreaka" hidden="false" collective="false" type="unit">
+    <selectionEntry id="e185-cc94-ec1e-9b84" name="Bonebreaka" hidden="false" collective="false" import="true" type="unit">
       <profiles>
         <profile id="847b-d49b-3025-db8f" name="Bonebreaka" hidden="false" typeId="800f-21d0-4387-c943" typeName="Unit">
           <characteristics>
@@ -10700,7 +10696,7 @@
         <categoryLink id="d0cf-6c5b-1e17-7320" name="Bonebreaker" hidden="false" targetId="1906-fdee-ba81-c889" primary="false"/>
       </categoryLinks>
       <selectionEntries>
-        <selectionEntry id="46a4-f1ac-7494-89bc" name="Bonebreaker Ram" hidden="false" collective="false" type="upgrade">
+        <selectionEntry id="46a4-f1ac-7494-89bc" name="Bonebreaker Ram" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="80f4-2312-47bd-1114" type="max"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e23a-4aa1-3480-3f74" type="min"/>
@@ -10720,35 +10716,35 @@
         </selectionEntry>
       </selectionEntries>
       <selectionEntryGroups>
-        <selectionEntryGroup id="71df-c918-b2f2-ef54" name="Other Guns (0-4)" hidden="false" collective="false">
+        <selectionEntryGroup id="71df-c918-b2f2-ef54" name="Other Guns (0-4)" hidden="false" collective="false" import="true">
           <constraints>
             <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f7db-b954-1b61-d14f" type="min"/>
             <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e60e-49ab-07b6-9292" type="max"/>
           </constraints>
           <entryLinks>
-            <entryLink id="d9cd-c548-68cc-eda2" name="Big Shoota" hidden="false" collective="false" targetId="6008-4737-d8e6-e63b" type="selectionEntry"/>
+            <entryLink id="d9cd-c548-68cc-eda2" name="Big Shoota" hidden="false" collective="false" import="true" targetId="6008-4737-d8e6-e63b" type="selectionEntry"/>
           </entryLinks>
         </selectionEntryGroup>
-        <selectionEntryGroup id="f586-f11a-3e9a-c21e" name="Big Gun" hidden="false" collective="false">
+        <selectionEntryGroup id="f586-f11a-3e9a-c21e" name="Big Gun" hidden="false" collective="false" import="true">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3560-5a95-71f1-1bc0" type="max"/>
           </constraints>
           <entryLinks>
-            <entryLink id="8471-fe17-e7f3-9f6e" name="New EntryLink" hidden="false" collective="false" targetId="b3d8-73ff-d4fc-c2ac" type="selectionEntry"/>
-            <entryLink id="db66-fdb4-97c6-823a" name="Zzap gun" hidden="false" collective="false" targetId="b390-deb9-6d7e-d632" type="selectionEntry"/>
-            <entryLink id="3a81-fb75-adbd-94c4" name="Killkannon" hidden="false" collective="false" targetId="44ac-f70b-3b79-6eb8" type="selectionEntry"/>
+            <entryLink id="8471-fe17-e7f3-9f6e" name="New EntryLink" hidden="false" collective="false" import="true" targetId="b3d8-73ff-d4fc-c2ac" type="selectionEntry"/>
+            <entryLink id="db66-fdb4-97c6-823a" name="Zzap gun" hidden="false" collective="false" import="true" targetId="b390-deb9-6d7e-d632" type="selectionEntry"/>
+            <entryLink id="3a81-fb75-adbd-94c4" name="Killkannon" hidden="false" collective="false" import="true" targetId="44ac-f70b-3b79-6eb8" type="selectionEntry"/>
           </entryLinks>
         </selectionEntryGroup>
       </selectionEntryGroups>
       <entryLinks>
-        <entryLink id="c43a-0500-42ce-d8ce" name="Battlewagon Equipment" hidden="false" collective="false" targetId="51e5-322a-ca81-946b" type="selectionEntryGroup"/>
-        <entryLink id="793d-c1b3-e6a1-bf8b" name="Deff Rolla" hidden="false" collective="false" targetId="a29c-7f2f-9a36-79bb" type="selectionEntry">
+        <entryLink id="c43a-0500-42ce-d8ce" name="Battlewagon Equipment" hidden="false" collective="false" import="true" targetId="51e5-322a-ca81-946b" type="selectionEntryGroup"/>
+        <entryLink id="793d-c1b3-e6a1-bf8b" name="Deff Rolla" hidden="false" collective="false" import="true" targetId="a29c-7f2f-9a36-79bb" type="selectionEntry">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4848-aae7-8c21-88b5" type="min"/>
           </constraints>
         </entryLink>
-        <entryLink id="ddf9-6f54-761f-0910" name="Has Battle Honours" hidden="false" collective="false" targetId="4763-757f-499f-d998" type="selectionEntry"/>
-        <entryLink id="72ed-19de-48f0-e362" name="Battle Honours" hidden="false" collective="false" targetId="5518-d0f5-a880-d71c" type="selectionEntryGroup"/>
+        <entryLink id="ddf9-6f54-761f-0910" name="Has Battle Honours" hidden="false" collective="false" import="true" targetId="4763-757f-499f-d998" type="selectionEntry"/>
+        <entryLink id="72ed-19de-48f0-e362" name="Battle Honours" hidden="false" collective="false" import="true" targetId="5518-d0f5-a880-d71c" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="points" value="140.0"/>
@@ -10756,7 +10752,7 @@
         <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="e7d1-7688-5cbb-557f" name="Gunwagon" hidden="false" collective="false" type="unit">
+    <selectionEntry id="e7d1-7688-5cbb-557f" name="Gunwagon" hidden="false" collective="false" import="true" type="unit">
       <profiles>
         <profile id="4ab3-67c7-07a2-47b9" name="Gunwagon" hidden="false" typeId="800f-21d0-4387-c943" typeName="Unit">
           <characteristics>
@@ -10820,31 +10816,31 @@
         <categoryLink id="5f3a-51fc-0e00-9a41" name="Gunwagon" hidden="false" targetId="e564-c35f-d795-333b" primary="false"/>
       </categoryLinks>
       <selectionEntryGroups>
-        <selectionEntryGroup id="bb40-d086-4cc7-33c0" name="Other Guns (0-4)" hidden="false" collective="false">
+        <selectionEntryGroup id="bb40-d086-4cc7-33c0" name="Other Guns (0-4)" hidden="false" collective="false" import="true">
           <constraints>
             <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9b31-c2dc-c409-5aed" type="min"/>
             <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fd16-cbd7-c4f7-1e80" type="max"/>
           </constraints>
           <entryLinks>
-            <entryLink id="6aa2-a89a-91e3-d7ab" name="Big Shoota" hidden="false" collective="false" targetId="6008-4737-d8e6-e63b" type="selectionEntry"/>
+            <entryLink id="6aa2-a89a-91e3-d7ab" name="Big Shoota" hidden="false" collective="false" import="true" targetId="6008-4737-d8e6-e63b" type="selectionEntry"/>
           </entryLinks>
         </selectionEntryGroup>
-        <selectionEntryGroup id="9486-b278-c867-df4b" name="Big Gun" hidden="false" collective="false" defaultSelectionEntryId="c15e-c546-ce72-0bc4">
+        <selectionEntryGroup id="9486-b278-c867-df4b" name="Big Gun" hidden="false" collective="false" import="true" defaultSelectionEntryId="c15e-c546-ce72-0bc4">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f51d-3880-e413-1140" type="max"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0446-0bae-260e-6c7c" type="min"/>
           </constraints>
           <entryLinks>
-            <entryLink id="c15e-c546-ce72-0bc4" name="Kannon" hidden="false" collective="false" targetId="b3d8-73ff-d4fc-c2ac" type="selectionEntry"/>
-            <entryLink id="5a3e-be88-f072-529d" name="Zzap gun" hidden="false" collective="false" targetId="b390-deb9-6d7e-d632" type="selectionEntry"/>
-            <entryLink id="0721-6914-6cab-67bd" name="Killkannon" hidden="false" collective="false" targetId="44ac-f70b-3b79-6eb8" type="selectionEntry"/>
+            <entryLink id="c15e-c546-ce72-0bc4" name="Kannon" hidden="false" collective="false" import="true" targetId="b3d8-73ff-d4fc-c2ac" type="selectionEntry"/>
+            <entryLink id="5a3e-be88-f072-529d" name="Zzap gun" hidden="false" collective="false" import="true" targetId="b390-deb9-6d7e-d632" type="selectionEntry"/>
+            <entryLink id="0721-6914-6cab-67bd" name="Killkannon" hidden="false" collective="false" import="true" targetId="44ac-f70b-3b79-6eb8" type="selectionEntry"/>
           </entryLinks>
         </selectionEntryGroup>
       </selectionEntryGroups>
       <entryLinks>
-        <entryLink id="175c-4585-295f-25a2" name="Battlewagon Equipment" hidden="false" collective="false" targetId="51e5-322a-ca81-946b" type="selectionEntryGroup"/>
-        <entryLink id="08bc-6bbd-f4aa-2a21" name="Has Battle Honours" hidden="false" collective="false" targetId="4763-757f-499f-d998" type="selectionEntry"/>
-        <entryLink id="2c43-b793-6fba-217b" name="Battle Honours" hidden="false" collective="false" targetId="5518-d0f5-a880-d71c" type="selectionEntryGroup"/>
+        <entryLink id="175c-4585-295f-25a2" name="Battlewagon Equipment" hidden="false" collective="false" import="true" targetId="51e5-322a-ca81-946b" type="selectionEntryGroup"/>
+        <entryLink id="08bc-6bbd-f4aa-2a21" name="Has Battle Honours" hidden="false" collective="false" import="true" targetId="4763-757f-499f-d998" type="selectionEntry"/>
+        <entryLink id="2c43-b793-6fba-217b" name="Battle Honours" hidden="false" collective="false" import="true" targetId="5518-d0f5-a880-d71c" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="points" value="140.0"/>
@@ -10852,7 +10848,7 @@
         <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="437b-75b3-db04-d55d" name="Kustom Boosta Blastas" hidden="false" collective="false" type="unit">
+    <selectionEntry id="437b-75b3-db04-d55d" name="Kustom Boosta Blastas" hidden="false" collective="false" import="true" type="unit">
       <profiles>
         <profile id="a8ed-92d8-672d-fd37" name="Grot Gunner" hidden="false" typeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" typeName="Abilities">
           <characteristics>
@@ -10886,13 +10882,13 @@
         <categoryLink id="28f7-ad35-149d-8921" name="Kustom Boosta-Blasta" hidden="false" targetId="d5c8-73dd-03af-cf29" primary="false"/>
       </categoryLinks>
       <selectionEntryGroups>
-        <selectionEntryGroup id="4b78-519e-d5e4-3b4f" name="Mob" hidden="false" collective="false" defaultSelectionEntryId="ecbd-bcc0-23af-9c85">
+        <selectionEntryGroup id="4b78-519e-d5e4-3b4f" name="Mob" hidden="false" collective="false" import="true" defaultSelectionEntryId="ecbd-bcc0-23af-9c85">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0603-9ca6-ac81-81a9" type="min"/>
             <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="cdcb-9aac-8021-c066" type="max"/>
           </constraints>
           <selectionEntries>
-            <selectionEntry id="ecbd-bcc0-23af-9c85" name="Kustom Boosta Blastas" hidden="false" collective="false" type="model">
+            <selectionEntry id="ecbd-bcc0-23af-9c85" name="Kustom Boosta Blastas" hidden="false" collective="false" import="true" type="model">
               <profiles>
                 <profile id="84b0-9b1a-967e-5c4a" name="Kustom Boosta Blastas" hidden="false" typeId="800f-21d0-4387-c943" typeName="Unit">
                   <characteristics>
@@ -10909,7 +10905,7 @@
                 </profile>
               </profiles>
               <selectionEntries>
-                <selectionEntry id="99fa-8ec9-7113-995d" name="Rivet Cannon" hidden="false" collective="false" type="upgrade">
+                <selectionEntry id="99fa-8ec9-7113-995d" name="Rivet Cannon" hidden="false" collective="false" import="true" type="upgrade">
                   <constraints>
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a340-98d5-7545-cf25" type="max"/>
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9d47-0054-7cec-3b8f" type="min"/>
@@ -10932,7 +10928,7 @@
                     <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
                   </costs>
                 </selectionEntry>
-                <selectionEntry id="b492-5f60-b3ce-99e8" name="Burna Exhaust" hidden="false" collective="false" type="upgrade">
+                <selectionEntry id="b492-5f60-b3ce-99e8" name="Burna Exhaust" hidden="false" collective="false" import="true" type="upgrade">
                   <constraints>
                     <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f91e-ef58-7cad-0525" type="max"/>
                     <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e0e8-05a9-d087-fa40" type="min"/>
@@ -10957,20 +10953,20 @@
                 </selectionEntry>
               </selectionEntries>
               <entryLinks>
-                <entryLink id="b24a-1bf5-2263-eb9a" name="Grot Blasta" hidden="false" collective="false" targetId="3aa4-aff7-db5e-4b46" type="selectionEntry">
+                <entryLink id="b24a-1bf5-2263-eb9a" name="Grot Blasta" hidden="false" collective="false" import="true" targetId="3aa4-aff7-db5e-4b46" type="selectionEntry">
                   <constraints>
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7152-793c-bfc5-3796" type="max"/>
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f880-6ce7-01fb-950d" type="min"/>
                   </constraints>
                 </entryLink>
-                <entryLink id="94cc-7e1b-7e7e-3200" name="Stikkbombs" hidden="false" collective="false" targetId="6df7-0ee7-7e6d-b182" type="selectionEntry">
+                <entryLink id="94cc-7e1b-7e7e-3200" name="Stikkbombs" hidden="false" collective="false" import="true" targetId="6df7-0ee7-7e6d-b182" type="selectionEntry">
                   <constraints>
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="445a-5590-269a-0f10" type="max"/>
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a698-6403-ae62-8233" type="min"/>
                   </constraints>
                 </entryLink>
-                <entryLink id="474b-936f-4b58-7b94" name="Has Battle Honours" hidden="false" collective="false" targetId="4763-757f-499f-d998" type="selectionEntry"/>
-                <entryLink id="9558-cc31-78de-dac9" name="Battle Honours" hidden="false" collective="false" targetId="5518-d0f5-a880-d71c" type="selectionEntryGroup"/>
+                <entryLink id="474b-936f-4b58-7b94" name="Has Battle Honours" hidden="false" collective="false" import="true" targetId="4763-757f-499f-d998" type="selectionEntry"/>
+                <entryLink id="9558-cc31-78de-dac9" name="Battle Honours" hidden="false" collective="false" import="true" targetId="5518-d0f5-a880-d71c" type="selectionEntryGroup"/>
               </entryLinks>
               <costs>
                 <cost name="pts" typeId="points" value="100.0"/>
@@ -10987,7 +10983,7 @@
         <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="365a-9db9-ab7e-0235" name="Megatrakk Scrapjet" hidden="false" collective="false" type="unit">
+    <selectionEntry id="365a-9db9-ab7e-0235" name="Megatrakk Scrapjet" hidden="false" collective="false" import="true" type="unit">
       <modifiers>
         <modifier type="set" field="e356-c769-5920-6e14" value="1">
           <conditions>
@@ -11023,13 +11019,13 @@
         <categoryLink id="cee0-a871-fe3e-b730" name="Megatrakk Scrapjet" hidden="false" targetId="646b-c0f9-8529-7684" primary="false"/>
       </categoryLinks>
       <selectionEntryGroups>
-        <selectionEntryGroup id="f72d-514d-dc1c-2275" name="Mob" hidden="false" collective="false" defaultSelectionEntryId="5b38-1a3c-a4dc-559f">
+        <selectionEntryGroup id="f72d-514d-dc1c-2275" name="Mob" hidden="false" collective="false" import="true" defaultSelectionEntryId="5b38-1a3c-a4dc-559f">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="023b-fc46-ab9d-8ea3" type="min"/>
             <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ae0a-2458-0472-48a2" type="max"/>
           </constraints>
           <selectionEntries>
-            <selectionEntry id="5b38-1a3c-a4dc-559f" name="Megatrakk Scrapjet" hidden="false" collective="false" type="model">
+            <selectionEntry id="5b38-1a3c-a4dc-559f" name="Megatrakk Scrapjet" hidden="false" collective="false" import="true" type="model">
               <profiles>
                 <profile id="3215-2577-6976-8ac2" name="Megatrakk Scrapjet" hidden="false" typeId="800f-21d0-4387-c943" typeName="Unit">
                   <characteristics>
@@ -11046,7 +11042,7 @@
                 </profile>
               </profiles>
               <selectionEntries>
-                <selectionEntry id="fbf2-9140-265c-f464" name="Rokkit Cannon" hidden="false" collective="false" type="upgrade">
+                <selectionEntry id="fbf2-9140-265c-f464" name="Rokkit Cannon" hidden="false" collective="false" import="true" type="upgrade">
                   <constraints>
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0fff-e3bd-3ba9-5a50" type="max"/>
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1f9f-d325-fc31-426e" type="min"/>
@@ -11069,7 +11065,7 @@
                     <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
                   </costs>
                 </selectionEntry>
-                <selectionEntry id="f423-39ea-848c-9f59" name="Wing Missiles" hidden="false" collective="false" type="upgrade">
+                <selectionEntry id="f423-39ea-848c-9f59" name="Wing Missiles" hidden="false" collective="false" import="true" type="upgrade">
                   <constraints>
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4e22-baa4-9443-7111" type="max"/>
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a200-847f-9271-8faa" type="min"/>
@@ -11092,7 +11088,7 @@
                     <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
                   </costs>
                 </selectionEntry>
-                <selectionEntry id="ed8b-4705-9f1c-2789" name="Nose Drill" hidden="false" collective="false" type="upgrade">
+                <selectionEntry id="ed8b-4705-9f1c-2789" name="Nose Drill" hidden="false" collective="false" import="true" type="upgrade">
                   <constraints>
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d1f6-19a1-0cc7-e44b" type="max"/>
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bd97-369e-85d9-9c07" type="min"/>
@@ -11117,14 +11113,14 @@
                 </selectionEntry>
               </selectionEntries>
               <entryLinks>
-                <entryLink id="43a9-da4f-215c-56c6" name="Twin Big Shoota" hidden="false" collective="false" targetId="a4f1-6ccb-1c50-405b" type="selectionEntry">
+                <entryLink id="43a9-da4f-215c-56c6" name="Twin Big Shoota" hidden="false" collective="false" import="true" targetId="a4f1-6ccb-1c50-405b" type="selectionEntry">
                   <constraints>
                     <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0fbe-4db8-75af-0797" type="min"/>
                     <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9ca2-50c1-d05b-43e5" type="max"/>
                   </constraints>
                 </entryLink>
-                <entryLink id="0346-40db-0e55-b424" name="Has Battle Honours" hidden="false" collective="false" targetId="4763-757f-499f-d998" type="selectionEntry"/>
-                <entryLink id="4a8c-6797-3be4-1a39" name="Battle Honours" hidden="false" collective="false" targetId="5518-d0f5-a880-d71c" type="selectionEntryGroup"/>
+                <entryLink id="0346-40db-0e55-b424" name="Has Battle Honours" hidden="false" collective="false" import="true" targetId="4763-757f-499f-d998" type="selectionEntry"/>
+                <entryLink id="4a8c-6797-3be4-1a39" name="Battle Honours" hidden="false" collective="false" import="true" targetId="5518-d0f5-a880-d71c" type="selectionEntryGroup"/>
               </entryLinks>
               <costs>
                 <cost name="pts" typeId="points" value="90.0"/>
@@ -11141,7 +11137,7 @@
         <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="8c9b-9002-d5df-136d" name="Mekboy Workshop" hidden="false" collective="false" type="upgrade">
+    <selectionEntry id="8c9b-9002-d5df-136d" name="Mekboy Workshop" hidden="false" collective="false" import="true" type="upgrade">
       <profiles>
         <profile id="efda-a541-95aa-26b0" name="Ork Structure" hidden="false" typeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" typeName="Abilities">
           <characteristics>
@@ -11171,7 +11167,7 @@
         <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="a8f4-732e-fc64-3577" name="Grot Blaster" hidden="false" collective="true" type="upgrade">
+    <selectionEntry id="a8f4-732e-fc64-3577" name="Grot Blaster" hidden="false" collective="true" import="true" type="upgrade">
       <profiles>
         <profile id="efbc-9d9d-3981-66de" name="Grot Blaster" hidden="false" typeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" typeName="Weapon">
           <characteristics>
@@ -11190,7 +11186,7 @@
         <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="6310-b918-b696-23dc" name="Dread Saw" hidden="false" collective="false" type="upgrade">
+    <selectionEntry id="6310-b918-b696-23dc" name="Dread Saw" hidden="false" collective="false" import="true" type="upgrade">
       <profiles>
         <profile id="8b1e-1c6a-4250-591b" name="Dread Saw" hidden="false" typeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" typeName="Weapon">
           <characteristics>
@@ -11209,7 +11205,7 @@
         <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="fee6-89eb-b8fc-9982" name="Clan Kultur" hidden="false" collective="false" type="upgrade">
+    <selectionEntry id="fee6-89eb-b8fc-9982" name="Clan Kultur" hidden="false" collective="false" import="true" type="upgrade">
       <constraints>
         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4201-2a13-9734-79c0" type="max"/>
       </constraints>
@@ -11217,13 +11213,13 @@
         <categoryLink id="4279-8c6a-f037-e4fe" name="No Force Org Slot" hidden="false" targetId="ff36a6f3-19bf-4f48-8956-adacfd28fe74" primary="true"/>
       </categoryLinks>
       <selectionEntryGroups>
-        <selectionEntryGroup id="f30f-40ff-c530-7b48" name="Clan Kultur" hidden="false" collective="false" defaultSelectionEntryId="84e7-10dc-db59-a1b2">
+        <selectionEntryGroup id="f30f-40ff-c530-7b48" name="Clan Kultur" hidden="false" collective="false" import="true" defaultSelectionEntryId="84e7-10dc-db59-a1b2">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="eea0-75d0-c282-6080" type="min"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5806-d973-1991-aa62" type="max"/>
           </constraints>
           <selectionEntries>
-            <selectionEntry id="ae38-f508-d394-4a6d" name="Blood Axes" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="ae38-f508-d394-4a6d" name="Blood Axes" hidden="false" collective="false" import="true" type="upgrade">
               <profiles>
                 <profile id="bf11-a1b1-4535-4a81" name="Blood Axes" hidden="false" typeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" typeName="Abilities">
                   <characteristics>
@@ -11237,7 +11233,7 @@
                 <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
               </costs>
             </selectionEntry>
-            <selectionEntry id="9e0f-d86a-591a-e26f" name="Deathskulls" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="9e0f-d86a-591a-e26f" name="Deathskulls" hidden="false" collective="false" import="true" type="upgrade">
               <profiles>
                 <profile id="6e8b-c60e-dd19-eb0b" name="Deathskulls" hidden="false" typeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" typeName="Abilities">
                   <characteristics>
@@ -11251,7 +11247,7 @@
                 <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
               </costs>
             </selectionEntry>
-            <selectionEntry id="2eb5-ccdb-f8d3-7cb4" name="Evil Sunz" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="2eb5-ccdb-f8d3-7cb4" name="Evil Sunz" hidden="false" collective="false" import="true" type="upgrade">
               <profiles>
                 <profile id="795a-043f-8d44-3294" name="Evil Sunz" hidden="false" typeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" typeName="Abilities">
                   <characteristics>
@@ -11265,7 +11261,7 @@
                 <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
               </costs>
             </selectionEntry>
-            <selectionEntry id="d90e-57d8-6092-3048" name="Bad Moons" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="d90e-57d8-6092-3048" name="Bad Moons" hidden="false" collective="false" import="true" type="upgrade">
               <profiles>
                 <profile id="8a3b-414a-3cb0-b125" name="Bad Moons" hidden="false" typeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" typeName="Abilities">
                   <characteristics>
@@ -11279,7 +11275,7 @@
                 <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
               </costs>
             </selectionEntry>
-            <selectionEntry id="22bd-c413-33e8-277b" name="Freebooterz" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="22bd-c413-33e8-277b" name="Freebooterz" hidden="false" collective="false" import="true" type="upgrade">
               <profiles>
                 <profile id="6fd4-795b-113d-1b16" name="Freebooterz" hidden="false" typeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" typeName="Abilities">
                   <characteristics>
@@ -11293,7 +11289,7 @@
                 <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
               </costs>
             </selectionEntry>
-            <selectionEntry id="5602-29aa-24d5-612d" name="Goffs" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="5602-29aa-24d5-612d" name="Goffs" hidden="false" collective="false" import="true" type="upgrade">
               <profiles>
                 <profile id="acaf-5e7d-83f9-9113" name="Goffs" hidden="false" typeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" typeName="Abilities">
                   <characteristics>
@@ -11307,7 +11303,7 @@
                 <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
               </costs>
             </selectionEntry>
-            <selectionEntry id="f8db-12ff-f160-e0b4" name="Snakebites" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="f8db-12ff-f160-e0b4" name="Snakebites" hidden="false" collective="false" import="true" type="upgrade">
               <profiles>
                 <profile id="c9a1-f545-c32b-be53" name="Snakebites" hidden="false" typeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" typeName="Abilities">
                   <characteristics>
@@ -11321,7 +11317,7 @@
                 <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
               </costs>
             </selectionEntry>
-            <selectionEntry id="84e7-10dc-db59-a1b2" name="No Clan" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="84e7-10dc-db59-a1b2" name="No Clan" hidden="false" collective="false" import="true" type="upgrade">
               <profiles>
                 <profile id="2588-c7da-7940-ea83" name="No Clan" page="" hidden="false" typeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" typeName="Abilities">
                   <characteristics>
@@ -11344,7 +11340,7 @@
         <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="d4ec-cdd8-004f-a8ab" name="Tankbusta Bombs" hidden="false" collective="false" type="upgrade">
+    <selectionEntry id="d4ec-cdd8-004f-a8ab" name="Tankbusta Bombs" hidden="false" collective="false" import="true" type="upgrade">
       <profiles>
         <profile id="95a6-22fd-84fc-4c28" name="Tankbusta Bombs" hidden="false" typeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" typeName="Weapon">
           <characteristics>
@@ -11363,7 +11359,7 @@
         <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="a29c-7f2f-9a36-79bb" name="Deff Rolla" hidden="false" collective="false" type="upgrade">
+    <selectionEntry id="a29c-7f2f-9a36-79bb" name="Deff Rolla" hidden="false" collective="false" import="true" type="upgrade">
       <constraints>
         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e75f-e7d7-e8a3-f291" type="max"/>
       </constraints>
@@ -11385,7 +11381,7 @@
         <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="3aa4-aff7-db5e-4b46" name="Grot Blasta" hidden="false" collective="false" type="upgrade">
+    <selectionEntry id="3aa4-aff7-db5e-4b46" name="Grot Blasta" hidden="false" collective="false" import="true" type="upgrade">
       <profiles>
         <profile id="8d97-5f06-f4c8-1809" name="Grot Blaster" hidden="false" typeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" typeName="Weapon">
           <characteristics>
@@ -11404,25 +11400,25 @@
         <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="5d56-647b-a086-2ded" name="Extra Gubbins (1/3 CP)" hidden="false" collective="false" type="upgrade">
+    <selectionEntry id="5d56-647b-a086-2ded" name="Extra Gubbins (1/3 CP)" hidden="false" collective="false" import="true" type="upgrade">
       <categoryLinks>
         <categoryLink id="f7fb-145a-7f07-017b" name="No Force Org Slot" hidden="false" targetId="ff36a6f3-19bf-4f48-8956-adacfd28fe74" primary="true"/>
       </categoryLinks>
       <selectionEntryGroups>
-        <selectionEntryGroup id="5158-cf2e-154b-29a1" name="Extra Gubbins" hidden="false" collective="false" defaultSelectionEntryId="5a36-b534-4309-3008">
+        <selectionEntryGroup id="5158-cf2e-154b-29a1" name="Extra Gubbins" hidden="false" collective="false" import="true" defaultSelectionEntryId="5a36-b534-4309-3008">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1c0d-02a8-57df-0db9" type="max"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5e15-b576-9194-c50e" type="min"/>
           </constraints>
           <selectionEntries>
-            <selectionEntry id="5a36-b534-4309-3008" name="1 Extra Shiny Gubbins" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="5a36-b534-4309-3008" name="1 Extra Shiny Gubbins" hidden="false" collective="false" import="true" type="upgrade">
               <costs>
                 <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0"/>
                 <cost name="pts" typeId="points" value="0.0"/>
                 <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="-1.0"/>
               </costs>
             </selectionEntry>
-            <selectionEntry id="40e1-0fc9-41a2-a08b" name="2 Extra Shiny Gubbins" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="40e1-0fc9-41a2-a08b" name="2 Extra Shiny Gubbins" hidden="false" collective="false" import="true" type="upgrade">
               <costs>
                 <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0"/>
                 <cost name="pts" typeId="points" value="0.0"/>
@@ -11438,7 +11434,7 @@
         <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="ca75-94bd-4424-6d4c" name="Headwoppa&apos;s Killchoppa" hidden="false" collective="false" type="upgrade">
+    <selectionEntry id="ca75-94bd-4424-6d4c" name="Headwoppa&apos;s Killchoppa" hidden="false" collective="false" import="true" type="upgrade">
       <modifiers>
         <modifier type="set" field="hidden" value="true">
           <conditions>
@@ -11467,7 +11463,7 @@
         <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="f8cd-d7c6-a72c-7e5b" name="Gitstoppa Shells" hidden="false" collective="false" type="upgrade">
+    <selectionEntry id="f8cd-d7c6-a72c-7e5b" name="Gitstoppa Shells" hidden="false" collective="false" import="true" type="upgrade">
       <modifiers>
         <modifier type="set" field="hidden" value="true">
           <conditionGroups>
@@ -11497,7 +11493,7 @@
         <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="67ae-0581-17b9-4a40" name="Da Dead Shiny Shoota" hidden="false" collective="false" type="upgrade">
+    <selectionEntry id="67ae-0581-17b9-4a40" name="Da Dead Shiny Shoota" hidden="false" collective="false" import="true" type="upgrade">
       <modifiers>
         <modifier type="set" field="hidden" value="true">
           <conditions>
@@ -11526,7 +11522,7 @@
         <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="80f0-e3e9-27b1-d270" name="Da Killa Klaw" hidden="false" collective="false" type="upgrade">
+    <selectionEntry id="80f0-e3e9-27b1-d270" name="Da Killa Klaw" hidden="false" collective="false" import="true" type="upgrade">
       <modifiers>
         <modifier type="set" field="hidden" value="true">
           <conditions>
@@ -11555,7 +11551,7 @@
         <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="8f4c-0968-1720-2088" name="Da Gobshot Blunderbuss" hidden="false" collective="false" type="upgrade">
+    <selectionEntry id="8f4c-0968-1720-2088" name="Da Gobshot Blunderbuss" hidden="false" collective="false" import="true" type="upgrade">
       <modifiers>
         <modifier type="set" field="hidden" value="true">
           <conditionGroups>
@@ -11600,7 +11596,7 @@
         <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="33fd-f9ce-0809-8a9b" name="Shoota (Index)" hidden="false" collective="false" type="upgrade">
+    <selectionEntry id="33fd-f9ce-0809-8a9b" name="Shoota (Index)" hidden="false" collective="false" import="true" type="upgrade">
       <infoLinks>
         <infoLink id="0453-0934-9a26-cb27" name="Shoota" hidden="false" targetId="5a2b-0c64-8aa8-2f3e" type="profile"/>
       </infoLinks>
@@ -11610,7 +11606,7 @@
         <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="5fbe-d76c-183e-3413" name="Rokkit Launcha (Index)" hidden="false" collective="false" type="upgrade">
+    <selectionEntry id="5fbe-d76c-183e-3413" name="Rokkit Launcha (Index)" hidden="false" collective="false" import="true" type="upgrade">
       <infoLinks>
         <infoLink id="36f4-016c-e321-36dd" name="Rokkit Launcha" hidden="false" targetId="fa68-4aa1-f708-5aed" type="profile"/>
       </infoLinks>
@@ -11620,7 +11616,7 @@
         <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="b427-a07f-0027-e062" name="Kombi-Rokkit (Index)" hidden="false" collective="false" type="upgrade">
+    <selectionEntry id="b427-a07f-0027-e062" name="Kombi-Rokkit (Index)" hidden="false" collective="false" import="true" type="upgrade">
       <profiles>
         <profile id="2bb6-c35c-3987-325f" name="Kombi-Rokkit" hidden="false" typeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" typeName="Abilities">
           <characteristics>
@@ -11638,7 +11634,7 @@
         <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="bb1b-00f0-1da0-824c" name="Kombi-Skorcha (Index)" hidden="false" collective="false" type="upgrade">
+    <selectionEntry id="bb1b-00f0-1da0-824c" name="Kombi-Skorcha (Index)" hidden="false" collective="false" import="true" type="upgrade">
       <profiles>
         <profile id="0f1b-0b19-5a38-6fee" name="Kombi-Skorcha" hidden="false" typeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" typeName="Abilities">
           <characteristics>
@@ -11656,7 +11652,7 @@
         <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="6e69-3661-a3ae-a377" name="Kustom Shoota (Index)" hidden="false" collective="false" type="upgrade">
+    <selectionEntry id="6e69-3661-a3ae-a377" name="Kustom Shoota (Index)" hidden="false" collective="false" import="true" type="upgrade">
       <profiles>
         <profile id="ed5f-d47c-5d1f-8d13" name="Kustom Shoota" publicationId="11b5-77b9-pubN69765" hidden="false" typeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" typeName="Weapon">
           <characteristics>
@@ -11675,7 +11671,7 @@
         <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="b618-ec7e-d5cd-56ad" name="Slugga (Index)" hidden="false" collective="false" type="upgrade">
+    <selectionEntry id="b618-ec7e-d5cd-56ad" name="Slugga (Index)" hidden="false" collective="false" import="true" type="upgrade">
       <infoLinks>
         <infoLink id="fae6-8f6d-33bd-220d" name="New InfoLink" hidden="false" targetId="597d-56aa-73c4-88bf" type="profile"/>
       </infoLinks>
@@ -11685,7 +11681,7 @@
         <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="f0cf-1bde-c442-378a" name="Kustom Mega-Slugga (Index)" hidden="false" collective="false" type="upgrade">
+    <selectionEntry id="f0cf-1bde-c442-378a" name="Kustom Mega-Slugga (Index)" hidden="false" collective="false" import="true" type="upgrade">
       <profiles>
         <profile id="21f1-44b5-1151-755c" name="Kustom Mega-Slugga" hidden="false" typeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" typeName="Weapon">
           <characteristics>
@@ -11704,7 +11700,7 @@
         <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="4cb0-1ccc-7926-6c37" name="Kustom Mega-blasta (Index)" hidden="false" collective="false" type="upgrade">
+    <selectionEntry id="4cb0-1ccc-7926-6c37" name="Kustom Mega-blasta (Index)" hidden="false" collective="false" import="true" type="upgrade">
       <infoLinks>
         <infoLink id="3865-fd7b-129d-1f9e" name="Kustom Mega-blasta" hidden="false" targetId="ded2-c077-d596-e294" type="profile"/>
       </infoLinks>
@@ -11714,7 +11710,7 @@
         <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="66cb-c463-e3ee-7e1d" name="Warlord" hidden="false" collective="false" type="upgrade">
+    <selectionEntry id="66cb-c463-e3ee-7e1d" name="Warlord" hidden="false" collective="false" import="true" type="upgrade">
       <constraints>
         <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" id="22ce-62c5-74a2-19d5" type="max"/>
         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" id="496e-2ac8-8015-45f8" type="max"/>
@@ -11728,7 +11724,7 @@
         <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="5ec1-fede-e18a-54de" name="Morgog&apos;s Finkin&apos; Cap" hidden="false" collective="false" type="upgrade">
+    <selectionEntry id="5ec1-fede-e18a-54de" name="Morgog&apos;s Finkin&apos; Cap" hidden="false" collective="false" import="true" type="upgrade">
       <modifiers>
         <modifier type="set" field="hidden" value="true">
           <conditionGroups>
@@ -11752,35 +11748,35 @@
         </profile>
       </profiles>
       <selectionEntryGroups>
-        <selectionEntryGroup id="dd91-058f-84b5-28d3" name="Warlord Traits" hidden="false" collective="false">
+        <selectionEntryGroup id="dd91-058f-84b5-28d3" name="Warlord Traits" hidden="false" collective="false" import="true">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" id="6789-abac-387f-bcdb" type="max"/>
           </constraints>
           <selectionEntryGroups>
-            <selectionEntryGroup id="1dff-66e5-edcd-a3b1" name="Ork Traits" hidden="false" collective="false">
+            <selectionEntryGroup id="1dff-66e5-edcd-a3b1" name="Ork Traits" hidden="false" collective="false" import="true">
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" id="bca6-d9fd-982f-76ef" type="max"/>
               </constraints>
               <entryLinks>
-                <entryLink id="e322-3271-0c64-5ccb" name="Ard as Nails" hidden="false" collective="false" targetId="e940-4535-ae9d-ac2a" type="selectionEntry"/>
-                <entryLink id="a930-48ed-62b0-9e0e" name="Big Killa Boss" hidden="false" collective="false" targetId="04f8-83d1-366e-e472" type="selectionEntry"/>
-                <entryLink id="0dc3-0b8f-5661-92c8" name="Butal but Kunnin" hidden="false" collective="false" targetId="7f12-8f4c-8f99-0a16" type="selectionEntry"/>
-                <entryLink id="008f-809a-a06c-5442" name="Da Best Armour Teef Can Buy" hidden="false" collective="false" targetId="965f-2bc7-8c89-8ab8" type="selectionEntry"/>
-                <entryLink id="b23d-1dc4-8ad9-cd0c" name="Follow me Ladz!" hidden="false" collective="false" targetId="1a3c-6e25-1e6a-f971" type="selectionEntry"/>
-                <entryLink id="9067-480a-03a0-1b7b" name="I&apos;ve Got A Plan, Ladz!" hidden="false" collective="false" targetId="f4f6-066c-7624-6c0b" type="selectionEntry"/>
-                <entryLink id="e6dd-8fe1-092b-8f3f" name="Killa Reputation" hidden="false" collective="false" targetId="18dd-0ed7-7966-85f3" type="selectionEntry"/>
-                <entryLink id="52c5-4870-fe21-e43c" name="Kunnin but Brutal" hidden="false" collective="false" targetId="5bce-ed03-5f6c-6f5f" type="selectionEntry"/>
-                <entryLink id="bd30-f3fc-ee8b-4c1e" name="Might is Right" hidden="false" collective="false" targetId="4829-1f2a-ae41-4ba4" type="selectionEntry"/>
-                <entryLink id="5d07-566f-1333-b0d0" name="Opportunist" hidden="false" collective="false" targetId="5d71-82c4-ac0b-1f28" type="selectionEntry"/>
-                <entryLink id="aabd-df0f-7a93-b51c" name="Proper Killy" hidden="false" collective="false" targetId="f816-d517-7b97-ee2a" type="selectionEntry"/>
-                <entryLink id="4ec6-3628-15ae-f1b2" name="Speed Freek" hidden="false" collective="false" targetId="aba6-84bf-f77d-0fe8" type="selectionEntry"/>
-                <entryLink id="ed08-a926-f4bb-e4b1" name="Surly as a Squiggoth" hidden="false" collective="false" targetId="11b4-5592-2e65-a6ce" type="selectionEntry"/>
+                <entryLink id="e322-3271-0c64-5ccb" name="Ard as Nails" hidden="false" collective="false" import="true" targetId="e940-4535-ae9d-ac2a" type="selectionEntry"/>
+                <entryLink id="a930-48ed-62b0-9e0e" name="Big Killa Boss" hidden="false" collective="false" import="true" targetId="04f8-83d1-366e-e472" type="selectionEntry"/>
+                <entryLink id="0dc3-0b8f-5661-92c8" name="Butal but Kunnin" hidden="false" collective="false" import="true" targetId="7f12-8f4c-8f99-0a16" type="selectionEntry"/>
+                <entryLink id="008f-809a-a06c-5442" name="Da Best Armour Teef Can Buy" hidden="false" collective="false" import="true" targetId="965f-2bc7-8c89-8ab8" type="selectionEntry"/>
+                <entryLink id="b23d-1dc4-8ad9-cd0c" name="Follow me Ladz!" hidden="false" collective="false" import="true" targetId="1a3c-6e25-1e6a-f971" type="selectionEntry"/>
+                <entryLink id="9067-480a-03a0-1b7b" name="I&apos;ve Got A Plan, Ladz!" hidden="false" collective="false" import="true" targetId="f4f6-066c-7624-6c0b" type="selectionEntry"/>
+                <entryLink id="e6dd-8fe1-092b-8f3f" name="Killa Reputation" hidden="false" collective="false" import="true" targetId="18dd-0ed7-7966-85f3" type="selectionEntry"/>
+                <entryLink id="52c5-4870-fe21-e43c" name="Kunnin but Brutal" hidden="false" collective="false" import="true" targetId="5bce-ed03-5f6c-6f5f" type="selectionEntry"/>
+                <entryLink id="bd30-f3fc-ee8b-4c1e" name="Might is Right" hidden="false" collective="false" import="true" targetId="4829-1f2a-ae41-4ba4" type="selectionEntry"/>
+                <entryLink id="5d07-566f-1333-b0d0" name="Opportunist" hidden="false" collective="false" import="true" targetId="5d71-82c4-ac0b-1f28" type="selectionEntry"/>
+                <entryLink id="aabd-df0f-7a93-b51c" name="Proper Killy" hidden="false" collective="false" import="true" targetId="f816-d517-7b97-ee2a" type="selectionEntry"/>
+                <entryLink id="4ec6-3628-15ae-f1b2" name="Speed Freek" hidden="false" collective="false" import="true" targetId="aba6-84bf-f77d-0fe8" type="selectionEntry"/>
+                <entryLink id="ed08-a926-f4bb-e4b1" name="Surly as a Squiggoth" hidden="false" collective="false" import="true" targetId="11b4-5592-2e65-a6ce" type="selectionEntry"/>
               </entryLinks>
             </selectionEntryGroup>
           </selectionEntryGroups>
           <entryLinks>
-            <entryLink id="7f10-a94a-0fe8-e422" name="Warlord Traits (BRB)" hidden="false" collective="false" targetId="d442-1f03-d9da-e77f" type="selectionEntryGroup"/>
-            <entryLink id="63da-b57e-edcd-095f" name="Warlord Traits (CA)" hidden="false" collective="false" targetId="f673-3d9b-bb1b-377f" type="selectionEntryGroup"/>
+            <entryLink id="7f10-a94a-0fe8-e422" name="Warlord Traits (BRB)" hidden="false" collective="false" import="true" targetId="d442-1f03-d9da-e77f" type="selectionEntryGroup"/>
+            <entryLink id="63da-b57e-edcd-095f" name="Warlord Traits (CA)" hidden="false" collective="false" import="true" targetId="f673-3d9b-bb1b-377f" type="selectionEntryGroup"/>
           </entryLinks>
         </selectionEntryGroup>
       </selectionEntryGroups>
@@ -11790,7 +11786,7 @@
         <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="e940-4535-ae9d-ac2a" name="Ard as Nails" hidden="false" collective="false" type="upgrade">
+    <selectionEntry id="e940-4535-ae9d-ac2a" name="Ard as Nails" hidden="false" collective="false" import="true" type="upgrade">
       <constraints>
         <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="51ee-0154-8c1b-26f7" type="max"/>
       </constraints>
@@ -11807,7 +11803,7 @@
         <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="04f8-83d1-366e-e472" name="Big Killa Boss" hidden="false" collective="false" type="upgrade">
+    <selectionEntry id="04f8-83d1-366e-e472" name="Big Killa Boss" hidden="false" collective="false" import="true" type="upgrade">
       <constraints>
         <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="eae2-3477-88a6-09d4" type="max"/>
       </constraints>
@@ -11824,7 +11820,7 @@
         <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="7f12-8f4c-8f99-0a16" name="Brutal but Kunnin" hidden="false" collective="false" type="upgrade">
+    <selectionEntry id="7f12-8f4c-8f99-0a16" name="Brutal but Kunnin" hidden="false" collective="false" import="true" type="upgrade">
       <constraints>
         <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="56ca-b5b0-7c16-b2d4" type="max"/>
       </constraints>
@@ -11841,7 +11837,7 @@
         <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="965f-2bc7-8c89-8ab8" name="Da Best Armour Teef Can Buy" hidden="false" collective="false" type="upgrade">
+    <selectionEntry id="965f-2bc7-8c89-8ab8" name="Da Best Armour Teef Can Buy" hidden="false" collective="false" import="true" type="upgrade">
       <modifiers>
         <modifier type="set" field="hidden" value="true">
           <conditions>
@@ -11865,7 +11861,7 @@
         <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="1a3c-6e25-1e6a-f971" name="Follow Me, Ladz!" hidden="false" collective="false" type="upgrade">
+    <selectionEntry id="1a3c-6e25-1e6a-f971" name="Follow Me, Ladz!" hidden="false" collective="false" import="true" type="upgrade">
       <constraints>
         <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="8fdf-5d6e-b37c-d79c" type="max"/>
       </constraints>
@@ -11883,7 +11879,7 @@ Command Point.</characteristic>
         <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="1.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="f4f6-066c-7624-6c0b" name="I&apos;ve Got A Plan, Ladz!" hidden="false" collective="false" type="upgrade">
+    <selectionEntry id="f4f6-066c-7624-6c0b" name="I&apos;ve Got A Plan, Ladz!" hidden="false" collective="false" import="true" type="upgrade">
       <modifiers>
         <modifier type="set" field="hidden" value="true">
           <conditions>
@@ -11903,7 +11899,7 @@ Command Point.</characteristic>
         <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="18dd-0ed7-7966-85f3" name="Killa Reputation" hidden="false" collective="false" type="upgrade">
+    <selectionEntry id="18dd-0ed7-7966-85f3" name="Killa Reputation" hidden="false" collective="false" import="true" type="upgrade">
       <modifiers>
         <modifier type="set" field="hidden" value="true">
           <conditions>
@@ -11923,7 +11919,7 @@ Command Point.</characteristic>
         <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="5bce-ed03-5f6c-6f5f" name="Kunnin but Brutal" hidden="false" collective="false" type="upgrade">
+    <selectionEntry id="5bce-ed03-5f6c-6f5f" name="Kunnin but Brutal" hidden="false" collective="false" import="true" type="upgrade">
       <constraints>
         <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="2f4e-16e0-bf4f-4abe" type="max"/>
       </constraints>
@@ -11940,7 +11936,7 @@ Command Point.</characteristic>
         <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="4829-1f2a-ae41-4ba4" name="Might is Right" hidden="false" collective="false" type="upgrade">
+    <selectionEntry id="4829-1f2a-ae41-4ba4" name="Might is Right" hidden="false" collective="false" import="true" type="upgrade">
       <constraints>
         <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="2011-5c4f-8158-39fa" type="max"/>
       </constraints>
@@ -11957,7 +11953,7 @@ Command Point.</characteristic>
         <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="5d71-82c4-ac0b-1f28" name="Opportunist" hidden="false" collective="false" type="upgrade">
+    <selectionEntry id="5d71-82c4-ac0b-1f28" name="Opportunist" hidden="false" collective="false" import="true" type="upgrade">
       <modifiers>
         <modifier type="set" field="hidden" value="true">
           <conditions>
@@ -11977,7 +11973,7 @@ Command Point.</characteristic>
         <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="f816-d517-7b97-ee2a" name="Proper Killy" hidden="false" collective="false" type="upgrade">
+    <selectionEntry id="f816-d517-7b97-ee2a" name="Proper Killy" hidden="false" collective="false" import="true" type="upgrade">
       <modifiers>
         <modifier type="set" field="hidden" value="true">
           <conditions>
@@ -11997,7 +11993,7 @@ Command Point.</characteristic>
         <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="aba6-84bf-f77d-0fe8" name="Speed Freek" hidden="false" collective="false" type="upgrade">
+    <selectionEntry id="aba6-84bf-f77d-0fe8" name="Speed Freek" hidden="false" collective="false" import="true" type="upgrade">
       <modifiers>
         <modifier type="set" field="hidden" value="true">
           <conditions>
@@ -12017,7 +12013,7 @@ Command Point.</characteristic>
         <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="11b4-5592-2e65-a6ce" name="Surly as a Squiggoth" hidden="false" collective="false" type="upgrade">
+    <selectionEntry id="11b4-5592-2e65-a6ce" name="Surly as a Squiggoth" hidden="false" collective="false" import="true" type="upgrade">
       <modifiers>
         <modifier type="set" field="hidden" value="true">
           <conditions>
@@ -12041,7 +12037,7 @@ Command Point.</characteristic>
         <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="6e69-5a9b-cfdf-05d5" name="Dread Klaw (Index)" hidden="false" collective="false" type="upgrade">
+    <selectionEntry id="6e69-5a9b-cfdf-05d5" name="Dread Klaw (Index)" hidden="false" collective="false" import="true" type="upgrade">
       <profiles>
         <profile id="6d2c-c13e-d2b2-4666" name="Dread Klaw" hidden="false" typeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" typeName="Weapon">
           <characteristics>
@@ -12060,7 +12056,7 @@ Command Point.</characteristic>
         <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="6758-d594-1ac7-ddb2" name="Dethrolla Battle Fortress" hidden="true" collective="false" type="unit">
+    <selectionEntry id="6758-d594-1ac7-ddb2" name="Dethrolla Battle Fortress" hidden="true" collective="false" import="true" type="unit">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditionGroups>
@@ -12143,7 +12139,7 @@ Command Point.</characteristic>
         <categoryLink id="c9da-f5d7-5c01-8973" name="Lord of War" hidden="false" targetId="c888f08a-6cea-4a01-8126-d374a9231554" primary="true"/>
       </categoryLinks>
       <selectionEntries>
-        <selectionEntry id="5d99-e524-231b-d8f6" name="Dethrolla" hidden="false" collective="false" type="upgrade">
+        <selectionEntry id="5d99-e524-231b-d8f6" name="Dethrolla" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="df33-50da-0a91-5f03" type="max"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4138-0ec5-07f6-0500" type="min"/>
@@ -12168,68 +12164,68 @@ Command Point.</characteristic>
         </selectionEntry>
       </selectionEntries>
       <selectionEntryGroups>
-        <selectionEntryGroup id="e4c4-f374-5bc7-6c0d" name="Big Shootas (0-5)" hidden="false" collective="false">
+        <selectionEntryGroup id="e4c4-f374-5bc7-6c0d" name="Big Shootas (0-5)" hidden="false" collective="false" import="true">
           <constraints>
             <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7117-76e0-9a26-00a5" type="max"/>
           </constraints>
           <entryLinks>
-            <entryLink id="fd70-7122-f10d-47ba" name="Big Shoota" hidden="false" collective="false" targetId="6008-4737-d8e6-e63b" type="selectionEntry">
+            <entryLink id="fd70-7122-f10d-47ba" name="Big Shoota" hidden="false" collective="false" import="true" targetId="6008-4737-d8e6-e63b" type="selectionEntry">
               <constraints>
                 <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="21d4-f81f-9335-7e84" type="max"/>
               </constraints>
             </entryLink>
           </entryLinks>
         </selectionEntryGroup>
-        <selectionEntryGroup id="a02c-13cb-46bb-dd8a" name="Kannon" hidden="false" collective="false" defaultSelectionEntryId="9e6c-44a9-52c9-9857">
+        <selectionEntryGroup id="a02c-13cb-46bb-dd8a" name="Kannon" hidden="false" collective="false" import="true" defaultSelectionEntryId="9e6c-44a9-52c9-9857">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="992e-625d-aa56-8553" type="max"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3bc4-d42c-a479-d31a" type="min"/>
           </constraints>
           <entryLinks>
-            <entryLink id="9e6c-44a9-52c9-9857" name="Kannon" hidden="false" collective="false" targetId="b3d8-73ff-d4fc-c2ac" type="selectionEntry"/>
-            <entryLink id="d14a-7374-8cbe-3979" name="Zzap gun" hidden="false" collective="false" targetId="b390-deb9-6d7e-d632" type="selectionEntry"/>
-            <entryLink id="a297-1f58-9f61-db28" name="Lobba" hidden="false" collective="false" targetId="b25a-5184-36ce-d147" type="selectionEntry"/>
+            <entryLink id="9e6c-44a9-52c9-9857" name="Kannon" hidden="false" collective="false" import="true" targetId="b3d8-73ff-d4fc-c2ac" type="selectionEntry"/>
+            <entryLink id="d14a-7374-8cbe-3979" name="Zzap gun" hidden="false" collective="false" import="true" targetId="b390-deb9-6d7e-d632" type="selectionEntry"/>
+            <entryLink id="a297-1f58-9f61-db28" name="Lobba" hidden="false" collective="false" import="true" targetId="b25a-5184-36ce-d147" type="selectionEntry"/>
           </entryLinks>
         </selectionEntryGroup>
-        <selectionEntryGroup id="6dbc-dbd5-a8c7-d3bf" name="Zzap Guns" hidden="false" collective="false" defaultSelectionEntryId="8cc4-24d0-2632-5055">
+        <selectionEntryGroup id="6dbc-dbd5-a8c7-d3bf" name="Zzap Guns" hidden="false" collective="false" import="true" defaultSelectionEntryId="8cc4-24d0-2632-5055">
           <constraints>
             <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="13a7-f030-a624-ca0e" type="max"/>
             <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8dbf-12f9-0b9f-54fd" type="min"/>
           </constraints>
           <entryLinks>
-            <entryLink id="4efb-bda2-8082-3a2c" name="Kannon" hidden="false" collective="false" targetId="b3d8-73ff-d4fc-c2ac" type="selectionEntry">
+            <entryLink id="4efb-bda2-8082-3a2c" name="Kannon" hidden="false" collective="false" import="true" targetId="b3d8-73ff-d4fc-c2ac" type="selectionEntry">
               <constraints>
                 <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="be9c-7850-8640-5ad9" type="max"/>
               </constraints>
             </entryLink>
-            <entryLink id="8cc4-24d0-2632-5055" name="Zzap gun" hidden="false" collective="false" targetId="b390-deb9-6d7e-d632" type="selectionEntry">
+            <entryLink id="8cc4-24d0-2632-5055" name="Zzap gun" hidden="false" collective="false" import="true" targetId="b390-deb9-6d7e-d632" type="selectionEntry">
               <constraints>
                 <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1297-e7de-a370-6d97" type="max"/>
               </constraints>
             </entryLink>
-            <entryLink id="3e32-2a6d-a5ea-eec1" name="Lobba" hidden="false" collective="false" targetId="b25a-5184-36ce-d147" type="selectionEntry">
+            <entryLink id="3e32-2a6d-a5ea-eec1" name="Lobba" hidden="false" collective="false" import="true" targetId="b25a-5184-36ce-d147" type="selectionEntry">
               <constraints>
                 <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="537d-e81c-da9a-876b" type="max"/>
               </constraints>
             </entryLink>
           </entryLinks>
         </selectionEntryGroup>
-        <selectionEntryGroup id="ebb0-1cc5-835a-e929" name="More Guns" hidden="false" collective="false">
+        <selectionEntryGroup id="ebb0-1cc5-835a-e929" name="More Guns" hidden="false" collective="false" import="true">
           <constraints>
             <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4109-051f-a1ec-74eb" type="max"/>
           </constraints>
           <entryLinks>
-            <entryLink id="f37b-ebe4-f4bc-5189" name="Twin Big Shoota" hidden="false" collective="false" targetId="a4f1-6ccb-1c50-405b" type="selectionEntry">
+            <entryLink id="f37b-ebe4-f4bc-5189" name="Twin Big Shoota" hidden="false" collective="false" import="true" targetId="a4f1-6ccb-1c50-405b" type="selectionEntry">
               <constraints>
                 <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3257-8d13-6b71-6c8f" type="max"/>
               </constraints>
             </entryLink>
-            <entryLink id="4e97-2d68-3646-3020" name="Skorcha" hidden="false" collective="false" targetId="e05b-21b5-8727-ea9d" type="selectionEntry">
+            <entryLink id="4e97-2d68-3646-3020" name="Skorcha" hidden="false" collective="false" import="true" targetId="e05b-21b5-8727-ea9d" type="selectionEntry">
               <constraints>
                 <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="687d-81e5-3b56-10a2" type="max"/>
               </constraints>
             </entryLink>
-            <entryLink id="8512-b789-9e27-1b83" name="Rokkit Launcha" hidden="false" collective="false" targetId="a8c1-7fb9-7f7b-84c5" type="selectionEntry">
+            <entryLink id="8512-b789-9e27-1b83" name="Rokkit Launcha" hidden="false" collective="false" import="true" targetId="a8c1-7fb9-7f7b-84c5" type="selectionEntry">
               <constraints>
                 <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="40de-26d3-1181-5c1c" type="max"/>
               </constraints>
@@ -12243,7 +12239,7 @@ Command Point.</characteristic>
         <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="103b-3e49-086b-dd50" name="Kill Krusha" hidden="true" collective="false" type="unit">
+    <selectionEntry id="103b-3e49-086b-dd50" name="Kill Krusha" hidden="true" collective="false" import="true" type="unit">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditionGroups>
@@ -12325,7 +12321,7 @@ Command Point.</characteristic>
         <categoryLink id="db40-0e52-fd00-6bc5" name="Kill Krusha" hidden="false" targetId="8d96-51c2-f268-42be" primary="false"/>
       </categoryLinks>
       <selectionEntries>
-        <selectionEntry id="c8eb-b0e7-9979-8d5d" name="Krusha Kannon" hidden="false" collective="false" type="upgrade">
+        <selectionEntry id="c8eb-b0e7-9979-8d5d" name="Krusha Kannon" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="61e3-ac6b-e934-67db" type="max"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1cea-c57e-004b-b2e2" type="min"/>
@@ -12378,7 +12374,7 @@ Command Point.</characteristic>
             <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
           </costs>
         </selectionEntry>
-        <selectionEntry id="8189-347c-c84a-9481" name="Reinforced Ram" hidden="false" collective="false" type="upgrade">
+        <selectionEntry id="8189-347c-c84a-9481" name="Reinforced Ram" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b737-dd8a-e4a3-48df" type="max"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1773-7248-c75e-aaa5" type="min"/>
@@ -12398,32 +12394,32 @@ Command Point.</characteristic>
         </selectionEntry>
       </selectionEntries>
       <selectionEntryGroups>
-        <selectionEntryGroup id="6f43-4274-050f-f79b" name="More Guns" hidden="false" collective="false">
+        <selectionEntryGroup id="6f43-4274-050f-f79b" name="More Guns" hidden="false" collective="false" import="true">
           <constraints>
             <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2c5c-b315-afb9-0759" type="max"/>
           </constraints>
           <entryLinks>
-            <entryLink id="afa1-2210-ea1c-a343" name="Twin Big Shoota" hidden="false" collective="false" targetId="a4f1-6ccb-1c50-405b" type="selectionEntry">
+            <entryLink id="afa1-2210-ea1c-a343" name="Twin Big Shoota" hidden="false" collective="false" import="true" targetId="a4f1-6ccb-1c50-405b" type="selectionEntry">
               <constraints>
                 <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1b30-bc21-9b99-c0dd" type="max"/>
               </constraints>
             </entryLink>
-            <entryLink id="2aa9-d635-d6ee-acb5" name="Skorcha" hidden="false" collective="false" targetId="e05b-21b5-8727-ea9d" type="selectionEntry">
+            <entryLink id="2aa9-d635-d6ee-acb5" name="Skorcha" hidden="false" collective="false" import="true" targetId="e05b-21b5-8727-ea9d" type="selectionEntry">
               <constraints>
                 <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7207-3b90-5119-d39b" type="max"/>
               </constraints>
             </entryLink>
-            <entryLink id="6c82-81f3-f242-382a" name="Rokkit Launcha" hidden="false" collective="false" targetId="a8c1-7fb9-7f7b-84c5" type="selectionEntry">
+            <entryLink id="6c82-81f3-f242-382a" name="Rokkit Launcha" hidden="false" collective="false" import="true" targetId="a8c1-7fb9-7f7b-84c5" type="selectionEntry">
               <constraints>
                 <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f63f-c15a-e7f9-7566" type="max"/>
               </constraints>
             </entryLink>
-            <entryLink id="678f-c926-76dc-a64d" name="Big Shoota" hidden="false" collective="false" targetId="6008-4737-d8e6-e63b" type="selectionEntry">
+            <entryLink id="678f-c926-76dc-a64d" name="Big Shoota" hidden="false" collective="false" import="true" targetId="6008-4737-d8e6-e63b" type="selectionEntry">
               <constraints>
                 <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b9a7-9848-df96-d4ee" type="max"/>
               </constraints>
             </entryLink>
-            <entryLink id="576c-bf67-e071-332f" name="Rack of Rokkits" hidden="false" collective="false" targetId="17f9-fccd-55db-b80a" type="selectionEntry">
+            <entryLink id="576c-bf67-e071-332f" name="Rack of Rokkits" hidden="false" collective="false" import="true" targetId="17f9-fccd-55db-b80a" type="selectionEntry">
               <constraints>
                 <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="99ab-7ba5-e22b-c30a" type="max"/>
               </constraints>
@@ -12437,7 +12433,7 @@ Command Point.</characteristic>
         <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="f94f-4950-cc3d-f356" name="Kart" hidden="false" collective="false" type="unit">
+    <selectionEntry id="f94f-4950-cc3d-f356" name="Kart" hidden="false" collective="false" import="true" type="unit">
       <profiles>
         <profile id="ca61-f994-dcf1-bd8c" name="Kart 1" publicationId="11b5-77b9-pubN143628" hidden="false" typeId="1355-1e88-8ca1-9111" typeName="Flier Wound Track">
           <characteristics>
@@ -12499,12 +12495,12 @@ Command Point.</characteristic>
         <categoryLink id="03d8-16b8-1ed2-2643" name="Faction: Ork" hidden="false" targetId="1c58-037f-7b58-1223" primary="false"/>
       </categoryLinks>
       <selectionEntryGroups>
-        <selectionEntryGroup id="e21c-baa1-7577-0ae3" name="Medium Dakka" hidden="false" collective="false">
+        <selectionEntryGroup id="e21c-baa1-7577-0ae3" name="Medium Dakka" hidden="false" collective="false" import="true">
           <constraints>
             <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ecff-6208-6cb7-fbd8" type="max"/>
           </constraints>
           <entryLinks>
-            <entryLink id="f4b8-4aef-3926-e848" name="Big Shoota" hidden="false" collective="false" targetId="6008-4737-d8e6-e63b" type="selectionEntry">
+            <entryLink id="f4b8-4aef-3926-e848" name="Big Shoota" hidden="false" collective="false" import="true" targetId="6008-4737-d8e6-e63b" type="selectionEntry">
               <modifiers>
                 <modifier type="set" field="points" value="0.0"/>
               </modifiers>
@@ -12513,7 +12509,7 @@ Command Point.</characteristic>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4574-839c-456b-f0a8" type="min"/>
               </constraints>
             </entryLink>
-            <entryLink id="9698-d1fa-e473-0e55" name="Skorcha" hidden="false" collective="false" targetId="e05b-21b5-8727-ea9d" type="selectionEntry">
+            <entryLink id="9698-d1fa-e473-0e55" name="Skorcha" hidden="false" collective="false" import="true" targetId="e05b-21b5-8727-ea9d" type="selectionEntry">
               <modifiers>
                 <modifier type="set" field="points" value="0.0"/>
               </modifiers>
@@ -12525,12 +12521,12 @@ Command Point.</characteristic>
         </selectionEntryGroup>
       </selectionEntryGroups>
       <entryLinks>
-        <entryLink id="b8d6-846f-c387-cbe3" name="Shoota" hidden="false" collective="false" targetId="f314-b941-342f-289c" type="selectionEntry">
+        <entryLink id="b8d6-846f-c387-cbe3" name="Shoota" hidden="false" collective="false" import="true" targetId="f314-b941-342f-289c" type="selectionEntry">
           <constraints>
             <constraint field="selections" scope="parent" value="6.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1218-f948-3625-3912" type="max"/>
           </constraints>
         </entryLink>
-        <entryLink id="e167-b164-9fc5-5f2e" name="Stikkbomb Launcha" hidden="false" collective="false" targetId="1956-50a8-c63a-c42e" type="selectionEntry">
+        <entryLink id="e167-b164-9fc5-5f2e" name="Stikkbomb Launcha" hidden="false" collective="false" import="true" targetId="1956-50a8-c63a-c42e" type="selectionEntry">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fb85-8a1b-21dc-0623" type="max"/>
           </constraints>
@@ -12542,7 +12538,7 @@ Command Point.</characteristic>
         <cost name="pts" typeId="points" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="1cc7-17cf-1d6f-7b14" name="Wagon" hidden="false" collective="false" type="unit">
+    <selectionEntry id="1cc7-17cf-1d6f-7b14" name="Wagon" hidden="false" collective="false" import="true" type="unit">
       <profiles>
         <profile id="52d5-0931-5536-c71d" name="Shoot &apos;Em Again!" publicationId="11b5-77b9-pubN143628" hidden="false" typeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" typeName="Abilities">
           <characteristics>
@@ -12603,12 +12599,12 @@ Command Point.</characteristic>
         <categoryLink id="d856-b55e-879a-5768" name="Faction: Ork" hidden="false" targetId="1c58-037f-7b58-1223" primary="false"/>
       </categoryLinks>
       <selectionEntryGroups>
-        <selectionEntryGroup id="3dcd-39ee-99a9-1dd4" name="Medium Dakka" hidden="false" collective="false">
+        <selectionEntryGroup id="3dcd-39ee-99a9-1dd4" name="Medium Dakka" hidden="false" collective="false" import="true">
           <constraints>
             <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="042c-56b3-1639-043d" type="max"/>
           </constraints>
           <entryLinks>
-            <entryLink id="d8c6-6c89-96c3-95dc" name="Big Shoota" hidden="false" collective="false" targetId="6008-4737-d8e6-e63b" type="selectionEntry">
+            <entryLink id="d8c6-6c89-96c3-95dc" name="Big Shoota" hidden="false" collective="false" import="true" targetId="6008-4737-d8e6-e63b" type="selectionEntry">
               <modifiers>
                 <modifier type="set" field="points" value="0.0"/>
               </modifiers>
@@ -12616,7 +12612,7 @@ Command Point.</characteristic>
                 <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="423f-47dc-efdf-92b5" type="max"/>
               </constraints>
             </entryLink>
-            <entryLink id="3d87-0b9f-beb9-a1f1" name="Skorcha" hidden="false" collective="false" targetId="e05b-21b5-8727-ea9d" type="selectionEntry">
+            <entryLink id="3d87-0b9f-beb9-a1f1" name="Skorcha" hidden="false" collective="false" import="true" targetId="e05b-21b5-8727-ea9d" type="selectionEntry">
               <modifiers>
                 <modifier type="set" field="points" value="0.0"/>
               </modifiers>
@@ -12624,7 +12620,7 @@ Command Point.</characteristic>
                 <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="3c94-e74e-eebd-6670" type="max"/>
               </constraints>
             </entryLink>
-            <entryLink id="571a-264d-0182-3a67" name="Rokkit Launcha" hidden="false" collective="false" targetId="a8c1-7fb9-7f7b-84c5" type="selectionEntry">
+            <entryLink id="571a-264d-0182-3a67" name="Rokkit Launcha" hidden="false" collective="false" import="true" targetId="a8c1-7fb9-7f7b-84c5" type="selectionEntry">
               <modifiers>
                 <modifier type="set" field="points" value="0.0"/>
               </modifiers>
@@ -12634,13 +12630,13 @@ Command Point.</characteristic>
             </entryLink>
           </entryLinks>
         </selectionEntryGroup>
-        <selectionEntryGroup id="5aac-3343-21bd-e313" name="Small Dakka" hidden="false" collective="false" defaultSelectionEntryId="9c31-4a74-804a-b854">
+        <selectionEntryGroup id="5aac-3343-21bd-e313" name="Small Dakka" hidden="false" collective="false" import="true" defaultSelectionEntryId="9c31-4a74-804a-b854">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="66bd-df81-fe71-df63" type="max"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b63d-41b2-346f-ac88" type="min"/>
           </constraints>
           <entryLinks>
-            <entryLink id="9c31-4a74-804a-b854" name="Big Shoota" hidden="false" collective="false" targetId="6008-4737-d8e6-e63b" type="selectionEntry">
+            <entryLink id="9c31-4a74-804a-b854" name="Big Shoota" hidden="false" collective="false" import="true" targetId="6008-4737-d8e6-e63b" type="selectionEntry">
               <modifiers>
                 <modifier type="set" field="points" value="0.0"/>
               </modifiers>
@@ -12648,7 +12644,7 @@ Command Point.</characteristic>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="5468-0c56-afda-5120" type="max"/>
               </constraints>
             </entryLink>
-            <entryLink id="78fb-a0fd-fe79-a060" name="Skorcha" hidden="false" collective="false" targetId="e05b-21b5-8727-ea9d" type="selectionEntry">
+            <entryLink id="78fb-a0fd-fe79-a060" name="Skorcha" hidden="false" collective="false" import="true" targetId="e05b-21b5-8727-ea9d" type="selectionEntry">
               <modifiers>
                 <modifier type="set" field="points" value="0.0"/>
               </modifiers>
@@ -12656,7 +12652,7 @@ Command Point.</characteristic>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="ad1b-f94f-2277-7348" type="max"/>
               </constraints>
             </entryLink>
-            <entryLink id="656c-9649-7deb-1ab8" name="Zzap gun" hidden="false" collective="false" targetId="b390-deb9-6d7e-d632" type="selectionEntry">
+            <entryLink id="656c-9649-7deb-1ab8" name="Zzap gun" hidden="false" collective="false" import="true" targetId="b390-deb9-6d7e-d632" type="selectionEntry">
               <modifiers>
                 <modifier type="set" field="points" value="0.0"/>
               </modifiers>
@@ -12666,12 +12662,12 @@ Command Point.</characteristic>
             </entryLink>
           </entryLinks>
         </selectionEntryGroup>
-        <selectionEntryGroup id="bd0c-3f96-3e0c-6f0f" name="Big Dakka" hidden="false" collective="false">
+        <selectionEntryGroup id="bd0c-3f96-3e0c-6f0f" name="Big Dakka" hidden="false" collective="false" import="true">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f292-a27a-4157-74f4" type="max"/>
           </constraints>
           <entryLinks>
-            <entryLink id="158f-f24f-7abf-5a5b" name="Zzap gun" hidden="false" collective="false" targetId="b390-deb9-6d7e-d632" type="selectionEntry">
+            <entryLink id="158f-f24f-7abf-5a5b" name="Zzap gun" hidden="false" collective="false" import="true" targetId="b390-deb9-6d7e-d632" type="selectionEntry">
               <modifiers>
                 <modifier type="set" field="points" value="0.0"/>
               </modifiers>
@@ -12679,7 +12675,7 @@ Command Point.</characteristic>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9665-af46-bff8-4a85" type="max"/>
               </constraints>
             </entryLink>
-            <entryLink id="be8b-6d50-d156-763c" name="Killkannon" hidden="false" collective="false" targetId="44ac-f70b-3b79-6eb8" type="selectionEntry">
+            <entryLink id="be8b-6d50-d156-763c" name="Killkannon" hidden="false" collective="false" import="true" targetId="44ac-f70b-3b79-6eb8" type="selectionEntry">
               <modifiers>
                 <modifier type="set" field="points" value="0.0"/>
               </modifiers>
@@ -12687,7 +12683,7 @@ Command Point.</characteristic>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ee41-f016-096d-b960" type="max"/>
               </constraints>
             </entryLink>
-            <entryLink id="3b68-70ec-6e79-bbea" name="Lobba" hidden="false" collective="false" targetId="b25a-5184-36ce-d147" type="selectionEntry">
+            <entryLink id="3b68-70ec-6e79-bbea" name="Lobba" hidden="false" collective="false" import="true" targetId="b25a-5184-36ce-d147" type="selectionEntry">
               <modifiers>
                 <modifier type="set" field="points" value="0.0"/>
               </modifiers>
@@ -12699,7 +12695,7 @@ Command Point.</characteristic>
         </selectionEntryGroup>
       </selectionEntryGroups>
       <entryLinks>
-        <entryLink id="9f46-240a-83e0-ef4d" name="Stikkbomb Launcha" hidden="false" collective="false" targetId="1956-50a8-c63a-c42e" type="selectionEntry">
+        <entryLink id="9f46-240a-83e0-ef4d" name="Stikkbomb Launcha" hidden="false" collective="false" import="true" targetId="1956-50a8-c63a-c42e" type="selectionEntry">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f1ef-e2f5-a3c7-edf4" type="max"/>
           </constraints>
@@ -12711,7 +12707,7 @@ Command Point.</characteristic>
         <cost name="pts" typeId="points" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="3ad5-6885-e38b-122b" name="Battle Fortress" hidden="false" collective="false" type="unit">
+    <selectionEntry id="3ad5-6885-e38b-122b" name="Battle Fortress" hidden="false" collective="false" import="true" type="unit">
       <profiles>
         <profile id="e74e-b543-f233-e25a" name="Battle Fortress" publicationId="11b5-77b9-pubN143628" hidden="false" typeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" typeName="Abilities">
           <characteristics>
@@ -12773,31 +12769,31 @@ Command Point.</characteristic>
         <categoryLink id="8158-517b-e117-5c5f" name="Faction: Ork" hidden="false" targetId="1c58-037f-7b58-1223" primary="false"/>
       </categoryLinks>
       <selectionEntryGroups>
-        <selectionEntryGroup id="b836-9065-9036-4512" name="Huge Dakka" hidden="false" collective="false" defaultSelectionEntryId="5730-f3d5-8b36-c31b">
+        <selectionEntryGroup id="b836-9065-9036-4512" name="Huge Dakka" hidden="false" collective="false" import="true" defaultSelectionEntryId="5730-f3d5-8b36-c31b">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5075-f23c-4737-f10a" type="max"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0c08-831f-b130-0c76" type="min"/>
           </constraints>
           <entryLinks>
-            <entryLink id="5730-f3d5-8b36-c31b" name="Deffkannon" hidden="false" collective="false" targetId="eca7-f942-4d8f-4cf2" type="selectionEntry">
+            <entryLink id="5730-f3d5-8b36-c31b" name="Deffkannon" hidden="false" collective="false" import="true" targetId="eca7-f942-4d8f-4cf2" type="selectionEntry">
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="cdc3-1a9b-137f-5d06" type="max"/>
               </constraints>
             </entryLink>
-            <entryLink id="5821-2bbf-442f-a3a4" name="Mega-Gatler" hidden="false" collective="false" targetId="e390-f151-0a36-cd6a" type="selectionEntry">
+            <entryLink id="5821-2bbf-442f-a3a4" name="Mega-Gatler" hidden="false" collective="false" import="true" targetId="e390-f151-0a36-cd6a" type="selectionEntry">
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="91a9-3ecb-250b-0894" type="max"/>
               </constraints>
             </entryLink>
           </entryLinks>
         </selectionEntryGroup>
-        <selectionEntryGroup id="afc6-d23f-acce-5d50" name="Big Dakka" hidden="false" collective="false" defaultSelectionEntryId="9ef6-ed4b-cbc2-3915">
+        <selectionEntryGroup id="afc6-d23f-acce-5d50" name="Big Dakka" hidden="false" collective="false" import="true" defaultSelectionEntryId="9ef6-ed4b-cbc2-3915">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5abc-8d2e-bcdc-134e" type="max"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="cd18-5dd2-5359-f353" type="min"/>
           </constraints>
           <entryLinks>
-            <entryLink id="9ef6-ed4b-cbc2-3915" name="Killkannon" hidden="false" collective="false" targetId="44ac-f70b-3b79-6eb8" type="selectionEntry">
+            <entryLink id="9ef6-ed4b-cbc2-3915" name="Killkannon" hidden="false" collective="false" import="true" targetId="44ac-f70b-3b79-6eb8" type="selectionEntry">
               <modifiers>
                 <modifier type="set" field="points" value="0.0"/>
               </modifiers>
@@ -12805,7 +12801,7 @@ Command Point.</characteristic>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e86e-7ed0-a936-487c" type="max"/>
               </constraints>
             </entryLink>
-            <entryLink id="bad1-93a0-6537-9e39" name="Lobba" hidden="false" collective="false" targetId="b25a-5184-36ce-d147" type="selectionEntry">
+            <entryLink id="bad1-93a0-6537-9e39" name="Lobba" hidden="false" collective="false" import="true" targetId="b25a-5184-36ce-d147" type="selectionEntry">
               <modifiers>
                 <modifier type="set" field="points" value="0.0"/>
               </modifiers>
@@ -12813,7 +12809,7 @@ Command Point.</characteristic>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="df44-228e-f520-6ec5" type="max"/>
               </constraints>
             </entryLink>
-            <entryLink id="cfc1-adf3-440a-aa3c" name="Twin Big Shoota" hidden="false" collective="false" targetId="a4f1-6ccb-1c50-405b" type="selectionEntry">
+            <entryLink id="cfc1-adf3-440a-aa3c" name="Twin Big Shoota" hidden="false" collective="false" import="true" targetId="a4f1-6ccb-1c50-405b" type="selectionEntry">
               <modifiers>
                 <modifier type="set" field="points" value="0.0"/>
               </modifiers>
@@ -12821,7 +12817,7 @@ Command Point.</characteristic>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6fb6-8835-fe09-67a9" type="max"/>
               </constraints>
             </entryLink>
-            <entryLink id="70ac-291a-332c-75c1" name="Zzap gun" hidden="false" collective="false" targetId="b390-deb9-6d7e-d632" type="selectionEntry">
+            <entryLink id="70ac-291a-332c-75c1" name="Zzap gun" hidden="false" collective="false" import="true" targetId="b390-deb9-6d7e-d632" type="selectionEntry">
               <modifiers>
                 <modifier type="set" field="points" value="0.0"/>
               </modifiers>
@@ -12831,12 +12827,12 @@ Command Point.</characteristic>
             </entryLink>
           </entryLinks>
         </selectionEntryGroup>
-        <selectionEntryGroup id="d166-7475-7f8d-a15f" name="Medium Dakka" hidden="false" collective="false">
+        <selectionEntryGroup id="d166-7475-7f8d-a15f" name="Medium Dakka" hidden="false" collective="false" import="true">
           <constraints>
             <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0873-70d2-8db3-fe50" type="max"/>
           </constraints>
           <entryLinks>
-            <entryLink id="d483-0ea3-5a0a-d779" name="Big Shoota" hidden="false" collective="false" targetId="6008-4737-d8e6-e63b" type="selectionEntry">
+            <entryLink id="d483-0ea3-5a0a-d779" name="Big Shoota" hidden="false" collective="false" import="true" targetId="6008-4737-d8e6-e63b" type="selectionEntry">
               <modifiers>
                 <modifier type="set" field="points" value="0.0"/>
               </modifiers>
@@ -12844,7 +12840,7 @@ Command Point.</characteristic>
                 <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="56a8-99ec-1a6a-59a1" type="max"/>
               </constraints>
             </entryLink>
-            <entryLink id="b969-5559-42d2-214c" name="Skorcha" hidden="false" collective="false" targetId="e05b-21b5-8727-ea9d" type="selectionEntry">
+            <entryLink id="b969-5559-42d2-214c" name="Skorcha" hidden="false" collective="false" import="true" targetId="e05b-21b5-8727-ea9d" type="selectionEntry">
               <modifiers>
                 <modifier type="set" field="points" value="0.0"/>
               </modifiers>
@@ -12852,7 +12848,7 @@ Command Point.</characteristic>
                 <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="364f-4d08-cd5e-64b6" type="max"/>
               </constraints>
             </entryLink>
-            <entryLink id="d8b2-d56b-aaeb-cf8b" name="Rokkit Launcha" hidden="false" collective="false" targetId="a8c1-7fb9-7f7b-84c5" type="selectionEntry">
+            <entryLink id="d8b2-d56b-aaeb-cf8b" name="Rokkit Launcha" hidden="false" collective="false" import="true" targetId="a8c1-7fb9-7f7b-84c5" type="selectionEntry">
               <modifiers>
                 <modifier type="set" field="points" value="0.0"/>
               </modifiers>
@@ -12862,14 +12858,14 @@ Command Point.</characteristic>
             </entryLink>
           </entryLinks>
         </selectionEntryGroup>
-        <selectionEntryGroup id="01a0-050d-c7b6-c549" name="Dakka Sponsons" hidden="false" collective="false">
+        <selectionEntryGroup id="01a0-050d-c7b6-c549" name="Dakka Sponsons" hidden="false" collective="false" import="true">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="546f-166c-3ad4-a9fa" type="max"/>
           </constraints>
           <selectionEntries>
-            <selectionEntry id="b276-2a61-c990-6d54" name="2 Dakka Sponsons" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="b276-2a61-c990-6d54" name="2 Dakka Sponsons" hidden="false" collective="false" import="true" type="upgrade">
               <entryLinks>
-                <entryLink id="fde0-669a-b80c-3b60" name="Dakka Sponson" hidden="false" collective="false" targetId="07f5-f036-6c76-0faa" type="selectionEntry">
+                <entryLink id="fde0-669a-b80c-3b60" name="Dakka Sponson" hidden="false" collective="false" import="true" targetId="07f5-f036-6c76-0faa" type="selectionEntry">
                   <constraints>
                     <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8282-dbea-4055-7d4f" type="max"/>
                     <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8115-4c49-9b17-2ec0" type="min"/>
@@ -12882,9 +12878,9 @@ Command Point.</characteristic>
                 <cost name="pts" typeId="points" value="0.0"/>
               </costs>
             </selectionEntry>
-            <selectionEntry id="9bbf-2229-40d6-00e2" name="4 Dakka Sponsons" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="9bbf-2229-40d6-00e2" name="4 Dakka Sponsons" hidden="false" collective="false" import="true" type="upgrade">
               <entryLinks>
-                <entryLink id="cd11-71c6-2972-e1b7" name="Dakka Sponson" hidden="false" collective="false" targetId="07f5-f036-6c76-0faa" type="selectionEntry">
+                <entryLink id="cd11-71c6-2972-e1b7" name="Dakka Sponson" hidden="false" collective="false" import="true" targetId="07f5-f036-6c76-0faa" type="selectionEntry">
                   <constraints>
                     <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3159-f92f-3fac-64fa" type="max"/>
                     <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8b0c-f1b2-b22a-46c4" type="min"/>
@@ -12901,12 +12897,12 @@ Command Point.</characteristic>
         </selectionEntryGroup>
       </selectionEntryGroups>
       <entryLinks>
-        <entryLink id="c641-285e-23b8-a12a" name="Stikkbomb Launcha" hidden="false" collective="false" targetId="1956-50a8-c63a-c42e" type="selectionEntry">
+        <entryLink id="c641-285e-23b8-a12a" name="Stikkbomb Launcha" hidden="false" collective="false" import="true" targetId="1956-50a8-c63a-c42e" type="selectionEntry">
           <constraints>
             <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e825-0ba6-2393-a030" type="max"/>
           </constraints>
         </entryLink>
-        <entryLink id="ea6d-b142-4753-3c2c" name="Twin Big Shoota" hidden="false" collective="false" targetId="a4f1-6ccb-1c50-405b" type="selectionEntry">
+        <entryLink id="ea6d-b142-4753-3c2c" name="Twin Big Shoota" hidden="false" collective="false" import="true" targetId="a4f1-6ccb-1c50-405b" type="selectionEntry">
           <modifiers>
             <modifier type="set" field="points" value="0.0"/>
           </modifiers>
@@ -12915,7 +12911,7 @@ Command Point.</characteristic>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="767c-7849-782c-0372" type="min"/>
           </constraints>
         </entryLink>
-        <entryLink id="f472-c0c6-e5f1-e220" name="Krushin&apos; Tracks" hidden="false" collective="false" targetId="e78b-decc-fbe6-3efa" type="selectionEntry">
+        <entryLink id="f472-c0c6-e5f1-e220" name="Krushin&apos; Tracks" hidden="false" collective="false" import="true" targetId="e78b-decc-fbe6-3efa" type="selectionEntry">
           <modifiers>
             <modifier type="set" field="points" value="0.0"/>
           </modifiers>
@@ -12931,7 +12927,7 @@ Command Point.</characteristic>
         <cost name="pts" typeId="points" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="1956-50a8-c63a-c42e" name="Stikkbomb Launcha" hidden="false" collective="false" type="upgrade">
+    <selectionEntry id="1956-50a8-c63a-c42e" name="Stikkbomb Launcha" hidden="false" collective="false" import="true" type="upgrade">
       <profiles>
         <profile id="0f11-f043-987a-2b5e" name="Stikkbomb Launcha" publicationId="11b5-77b9-pubN143628" hidden="false" typeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" typeName="Weapon">
           <characteristics>
@@ -12950,7 +12946,7 @@ Command Point.</characteristic>
         <cost name="pts" typeId="points" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="e390-f151-0a36-cd6a" name="Mega-Gatler" hidden="false" collective="false" type="upgrade">
+    <selectionEntry id="e390-f151-0a36-cd6a" name="Mega-Gatler" hidden="false" collective="false" import="true" type="upgrade">
       <profiles>
         <profile id="50c9-00d5-8a3e-c11f" name="Mega-Gatler" publicationId="11b5-77b9-pubN143628" hidden="false" typeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" typeName="Weapon">
           <characteristics>
@@ -12969,7 +12965,7 @@ Command Point.</characteristic>
         <cost name="pts" typeId="points" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="eca7-f942-4d8f-4cf2" name="Deffkannon" hidden="false" collective="false" type="upgrade">
+    <selectionEntry id="eca7-f942-4d8f-4cf2" name="Deffkannon" hidden="false" collective="false" import="true" type="upgrade">
       <profiles>
         <profile id="183a-6c70-cb9f-ae9a" name="Deffkannon" publicationId="11b5-77b9-pubN143628" hidden="false" typeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" typeName="Weapon">
           <characteristics>
@@ -12988,15 +12984,15 @@ Command Point.</characteristic>
         <cost name="pts" typeId="points" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="07f5-f036-6c76-0faa" name="Dakka Sponson" hidden="false" collective="false" type="upgrade">
+    <selectionEntry id="07f5-f036-6c76-0faa" name="Dakka Sponson" hidden="false" collective="false" import="true" type="upgrade">
       <selectionEntryGroups>
-        <selectionEntryGroup id="caab-272d-3409-ced5" name="Dakka Choice 1" hidden="false" collective="false" defaultSelectionEntryId="c0a5-dd3d-3f72-3d4b">
+        <selectionEntryGroup id="caab-272d-3409-ced5" name="Dakka Choice 1" hidden="false" collective="false" import="true" defaultSelectionEntryId="c0a5-dd3d-3f72-3d4b">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a356-85f7-de0a-0428" type="min"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bbc5-69a3-4d8b-d53f" type="max"/>
           </constraints>
           <entryLinks>
-            <entryLink id="0ba0-5381-4cd3-6110" name="Zzap gun" hidden="false" collective="false" targetId="b390-deb9-6d7e-d632" type="selectionEntry">
+            <entryLink id="0ba0-5381-4cd3-6110" name="Zzap gun" hidden="false" collective="false" import="true" targetId="b390-deb9-6d7e-d632" type="selectionEntry">
               <modifiers>
                 <modifier type="set" field="points" value="0.0"/>
               </modifiers>
@@ -13004,7 +13000,7 @@ Command Point.</characteristic>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ad94-9660-86d2-25c3" type="max"/>
               </constraints>
             </entryLink>
-            <entryLink id="c0a5-dd3d-3f72-3d4b" name="Rokkit Launcha" hidden="false" collective="false" targetId="a8c1-7fb9-7f7b-84c5" type="selectionEntry">
+            <entryLink id="c0a5-dd3d-3f72-3d4b" name="Rokkit Launcha" hidden="false" collective="false" import="true" targetId="a8c1-7fb9-7f7b-84c5" type="selectionEntry">
               <modifiers>
                 <modifier type="set" field="points" value="0.0"/>
               </modifiers>
@@ -13014,13 +13010,13 @@ Command Point.</characteristic>
             </entryLink>
           </entryLinks>
         </selectionEntryGroup>
-        <selectionEntryGroup id="1c9e-3f68-eea7-847c" name="Dakka Choice 2" hidden="false" collective="false" defaultSelectionEntryId="a97b-7332-aede-1f57">
+        <selectionEntryGroup id="1c9e-3f68-eea7-847c" name="Dakka Choice 2" hidden="false" collective="false" import="true" defaultSelectionEntryId="a97b-7332-aede-1f57">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="315c-e294-c842-55ad" type="min"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b0ad-454c-2b6a-de3c" type="max"/>
           </constraints>
           <entryLinks>
-            <entryLink id="a97b-7332-aede-1f57" name="Twin Big Shoota" hidden="false" collective="false" targetId="a4f1-6ccb-1c50-405b" type="selectionEntry">
+            <entryLink id="a97b-7332-aede-1f57" name="Twin Big Shoota" hidden="false" collective="false" import="true" targetId="a4f1-6ccb-1c50-405b" type="selectionEntry">
               <modifiers>
                 <modifier type="set" field="points" value="0.0"/>
               </modifiers>
@@ -13028,7 +13024,7 @@ Command Point.</characteristic>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c6d6-5043-2267-c837" type="max"/>
               </constraints>
             </entryLink>
-            <entryLink id="4a99-fae7-7094-fe66" name="Twin Big Skorcha" hidden="false" collective="false" targetId="9be2-ffd4-acb5-f47e" type="selectionEntry">
+            <entryLink id="4a99-fae7-7094-fe66" name="Twin Big Skorcha" hidden="false" collective="false" import="true" targetId="9be2-ffd4-acb5-f47e" type="selectionEntry">
               <modifiers>
                 <modifier type="set" field="points" value="0.0"/>
               </modifiers>
@@ -13045,7 +13041,7 @@ Command Point.</characteristic>
         <cost name="pts" typeId="points" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="9be2-ffd4-acb5-f47e" name="Twin Big Skorcha" hidden="false" collective="false" type="upgrade">
+    <selectionEntry id="9be2-ffd4-acb5-f47e" name="Twin Big Skorcha" hidden="false" collective="false" import="true" type="upgrade">
       <profiles>
         <profile id="96f2-c915-fa20-3a5d" name="Twin Big Skorcha" publicationId="11b5-77b9-pubN143628" hidden="false" typeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" typeName="Weapon">
           <characteristics>
@@ -13064,7 +13060,7 @@ Command Point.</characteristic>
         <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="e78b-decc-fbe6-3efa" name="Krushin&apos; Tracks" hidden="false" collective="false" type="upgrade">
+    <selectionEntry id="e78b-decc-fbe6-3efa" name="Krushin&apos; Tracks" hidden="false" collective="false" import="true" type="upgrade">
       <profiles>
         <profile id="15b9-6264-86a1-85c7" name="Krushin&apos; Tracks" publicationId="11b5-77b9-pubN143628" hidden="false" typeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" typeName="Weapon">
           <characteristics>
@@ -13083,7 +13079,7 @@ Command Point.</characteristic>
         <cost name="pts" typeId="points" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="fc96-1331-c935-0c46" name="Specialist Detachment" hidden="false" collective="false" type="upgrade">
+    <selectionEntry id="fc96-1331-c935-0c46" name="Specialist Detachment" hidden="false" collective="false" import="true" type="upgrade">
       <constraints>
         <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" id="1e77-3406-317f-05a3" type="max"/>
       </constraints>
@@ -13091,7 +13087,7 @@ Command Point.</characteristic>
         <categoryLink id="1e39-b8a2-cfc3-162b" name="No Force Org Slot" hidden="false" targetId="ff36a6f3-19bf-4f48-8956-adacfd28fe74" primary="true"/>
       </categoryLinks>
       <entryLinks>
-        <entryLink id="e6c5-ef81-d0b0-9c4c" name="Specialist Detachment" hidden="false" collective="false" targetId="47bf-3a7e-3d24-5af2" type="selectionEntryGroup"/>
+        <entryLink id="e6c5-ef81-d0b0-9c4c" name="Specialist Detachment" hidden="false" collective="false" import="true" targetId="47bf-3a7e-3d24-5af2" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
         <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0"/>
@@ -13099,7 +13095,7 @@ Command Point.</characteristic>
         <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="e1a7-cfd9-6a33-c529" name="Tezdrek&apos;s Stompa Power Field" hidden="false" collective="false" type="upgrade">
+    <selectionEntry id="e1a7-cfd9-6a33-c529" name="Tezdrek&apos;s Stompa Power Field" hidden="false" collective="false" import="true" type="upgrade">
       <modifiers>
         <modifier type="set" field="hidden" value="true">
           <conditions>
@@ -13120,7 +13116,7 @@ Command Point.</characteristic>
         <cost name="pts" typeId="points" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="a2e0-0ff7-462d-bb22" name="Stompa Mob Character" hidden="false" collective="false" type="upgrade">
+    <selectionEntry id="a2e0-0ff7-462d-bb22" name="Stompa Mob Character" hidden="false" collective="false" import="true" type="upgrade">
       <modifiers>
         <modifier type="set" field="hidden" value="true">
           <conditions>
@@ -13143,9 +13139,9 @@ Command Point.</characteristic>
     </selectionEntry>
   </sharedSelectionEntries>
   <sharedSelectionEntryGroups>
-    <selectionEntryGroup id="cb1c-c83b-5adb-5663" name="Power of the WAAAGH!" publicationId="11b5-77b9-pubN69765" hidden="false" collective="false">
+    <selectionEntryGroup id="cb1c-c83b-5adb-5663" name="Power of the WAAAGH!" publicationId="11b5-77b9-pubN69765" hidden="false" collective="false" import="true">
       <selectionEntries>
-        <selectionEntry id="fd8d-73b0-e0bf-903a" name="1. &apos;Eadbanger" hidden="false" collective="false" type="upgrade">
+        <selectionEntry id="fd8d-73b0-e0bf-903a" name="1. &apos;Eadbanger" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="63fc-7288-97b4-1007" type="max"/>
           </constraints>
@@ -13164,7 +13160,7 @@ Command Point.</characteristic>
             <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
           </costs>
         </selectionEntry>
-        <selectionEntry id="24e8-a60a-d622-269b" name="2. Warpath" hidden="false" collective="false" type="upgrade">
+        <selectionEntry id="24e8-a60a-d622-269b" name="2. Warpath" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ed9a-48c1-344d-3ac8" type="max"/>
           </constraints>
@@ -13183,7 +13179,7 @@ Command Point.</characteristic>
             <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
           </costs>
         </selectionEntry>
-        <selectionEntry id="3e56-50cf-0d84-dba5" name="3. Da Jump" hidden="false" collective="false" type="upgrade">
+        <selectionEntry id="3e56-50cf-0d84-dba5" name="3. Da Jump" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="cb42-7063-4c14-adfa" type="max"/>
           </constraints>
@@ -13202,7 +13198,7 @@ Command Point.</characteristic>
             <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
           </costs>
         </selectionEntry>
-        <selectionEntry id="a672-5ac7-2e19-e2e8" name="4. Fists of Gork" hidden="false" collective="false" type="upgrade">
+        <selectionEntry id="a672-5ac7-2e19-e2e8" name="4. Fists of Gork" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="34e0-6656-92e6-b9c6" type="max"/>
           </constraints>
@@ -13221,7 +13217,7 @@ Command Point.</characteristic>
             <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
           </costs>
         </selectionEntry>
-        <selectionEntry id="9c77-a148-5ebc-7ddc" name="6. Roar Of Mork" hidden="false" collective="false" type="upgrade">
+        <selectionEntry id="9c77-a148-5ebc-7ddc" name="6. Roar Of Mork" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f0e1-afb7-14ff-4f88" type="max"/>
           </constraints>
@@ -13240,7 +13236,7 @@ Command Point.</characteristic>
             <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
           </costs>
         </selectionEntry>
-        <selectionEntry id="6e41-c100-c880-9f01" name="5. Da Krunch" hidden="false" collective="false" type="upgrade">
+        <selectionEntry id="6e41-c100-c880-9f01" name="5. Da Krunch" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="917b-1c3d-a637-90c4" type="max"/>
           </constraints>
@@ -13261,52 +13257,52 @@ Command Point.</characteristic>
         </selectionEntry>
       </selectionEntries>
     </selectionEntryGroup>
-    <selectionEntryGroup id="d117-f3ce-54e8-75ba" name="Shooty Weapons" publicationId="11b5-77b9-pubN65537" page="83" hidden="false" collective="false">
+    <selectionEntryGroup id="d117-f3ce-54e8-75ba" name="Shooty Weapons" publicationId="11b5-77b9-pubN65537" page="83" hidden="false" collective="false" import="true">
       <constraints>
         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6f4d-cd73-ad14-1b22" type="max"/>
       </constraints>
       <entryLinks>
-        <entryLink id="c598-68c6-36a5-b95c" name="New EntryLink" hidden="false" collective="false" targetId="3511-0070-0667-abf2" type="selectionEntry"/>
-        <entryLink id="86f5-c30a-f98b-c28f" name="Kombi-Skorcha" hidden="false" collective="false" targetId="b6c7-06c8-b7fb-05a7" type="selectionEntry"/>
-        <entryLink id="ca25-0caf-cf60-5685" name="Kustom Shoota" hidden="false" collective="false" targetId="df47-a9ec-a22e-a2b6" type="selectionEntry"/>
-        <entryLink id="f839-3e2f-6476-f386" name="Shoota" hidden="false" collective="false" targetId="f314-b941-342f-289c" type="selectionEntry">
+        <entryLink id="c598-68c6-36a5-b95c" name="New EntryLink" hidden="false" collective="false" import="true" targetId="3511-0070-0667-abf2" type="selectionEntry"/>
+        <entryLink id="86f5-c30a-f98b-c28f" name="Kombi-Skorcha" hidden="false" collective="false" import="true" targetId="b6c7-06c8-b7fb-05a7" type="selectionEntry"/>
+        <entryLink id="ca25-0caf-cf60-5685" name="Kustom Shoota" hidden="false" collective="false" import="true" targetId="df47-a9ec-a22e-a2b6" type="selectionEntry"/>
+        <entryLink id="f839-3e2f-6476-f386" name="Shoota" hidden="false" collective="false" import="true" targetId="f314-b941-342f-289c" type="selectionEntry">
           <modifiers>
             <modifier type="set" field="name" value="Shoota (Index)"/>
           </modifiers>
         </entryLink>
       </entryLinks>
     </selectionEntryGroup>
-    <selectionEntryGroup id="ddcb-e66a-6750-e9de" name="Souped-Up Weapons" hidden="false" collective="false">
+    <selectionEntryGroup id="ddcb-e66a-6750-e9de" name="Souped-Up Weapons" hidden="false" collective="false" import="true">
       <constraints>
         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="63f8-48ee-d7d8-8f43" type="max"/>
       </constraints>
       <entryLinks>
-        <entryLink id="76da-1520-85f8-a4eb" name="Kombi-Rokkit" hidden="false" collective="false" targetId="3511-0070-0667-abf2" type="selectionEntry"/>
-        <entryLink id="fa50-72c4-0b9e-df90" name="New EntryLink" hidden="false" collective="false" targetId="b6c7-06c8-b7fb-05a7" type="selectionEntry"/>
-        <entryLink id="15c6-ceb3-05ad-6eb7" name="New EntryLink" hidden="false" collective="false" targetId="6d70-25a8-b496-2457" type="selectionEntry"/>
-        <entryLink id="f694-51b9-33a6-90b4" name="New EntryLink" hidden="false" collective="false" targetId="bbc2-56ce-67ec-5422" type="selectionEntry"/>
-        <entryLink id="fd24-b4a5-d221-3d4c" name="New EntryLink" hidden="false" collective="false" targetId="a8c1-7fb9-7f7b-84c5" type="selectionEntry"/>
+        <entryLink id="76da-1520-85f8-a4eb" name="Kombi-Rokkit" hidden="false" collective="false" import="true" targetId="3511-0070-0667-abf2" type="selectionEntry"/>
+        <entryLink id="fa50-72c4-0b9e-df90" name="New EntryLink" hidden="false" collective="false" import="true" targetId="b6c7-06c8-b7fb-05a7" type="selectionEntry"/>
+        <entryLink id="15c6-ceb3-05ad-6eb7" name="New EntryLink" hidden="false" collective="false" import="true" targetId="6d70-25a8-b496-2457" type="selectionEntry"/>
+        <entryLink id="f694-51b9-33a6-90b4" name="New EntryLink" hidden="false" collective="false" import="true" targetId="bbc2-56ce-67ec-5422" type="selectionEntry"/>
+        <entryLink id="fd24-b4a5-d221-3d4c" name="New EntryLink" hidden="false" collective="false" import="true" targetId="a8c1-7fb9-7f7b-84c5" type="selectionEntry"/>
       </entryLinks>
     </selectionEntryGroup>
-    <selectionEntryGroup id="41a6-ce08-1467-5bf5" name="&apos;Eavy Weapons" hidden="false" collective="false" defaultSelectionEntryId="fedd-c558-b6a5-6ac4">
+    <selectionEntryGroup id="41a6-ce08-1467-5bf5" name="&apos;Eavy Weapons" hidden="false" collective="false" import="true" defaultSelectionEntryId="fedd-c558-b6a5-6ac4">
       <constraints>
         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3488-8ee2-e770-85b4" type="max"/>
       </constraints>
       <entryLinks>
-        <entryLink id="3614-e62a-74bc-301c" name="New EntryLink" hidden="false" collective="false" targetId="a8c1-7fb9-7f7b-84c5" type="selectionEntry"/>
-        <entryLink id="fedd-c558-b6a5-6ac4" name="New EntryLink" hidden="false" collective="false" targetId="6008-4737-d8e6-e63b" type="selectionEntry"/>
+        <entryLink id="3614-e62a-74bc-301c" name="New EntryLink" hidden="false" collective="false" import="true" targetId="a8c1-7fb9-7f7b-84c5" type="selectionEntry"/>
+        <entryLink id="fedd-c558-b6a5-6ac4" name="New EntryLink" hidden="false" collective="false" import="true" targetId="6008-4737-d8e6-e63b" type="selectionEntry"/>
       </entryLinks>
     </selectionEntryGroup>
-    <selectionEntryGroup id="57f6-c88c-bcaa-1f50" name="Choppy Weapons" hidden="false" collective="false" defaultSelectionEntryId="7bbf-963a-631c-7a00">
+    <selectionEntryGroup id="57f6-c88c-bcaa-1f50" name="Choppy Weapons" hidden="false" collective="false" import="true" defaultSelectionEntryId="7bbf-963a-631c-7a00">
       <constraints>
         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ecc4-55d8-4c32-cba9" type="max"/>
       </constraints>
       <entryLinks>
-        <entryLink id="7bbf-963a-631c-7a00" name="Big Choppa" hidden="false" collective="false" targetId="0470-1b47-489b-14c9" type="selectionEntry"/>
-        <entryLink id="b322-f65a-2207-734a" name="Power Klaw" hidden="false" collective="false" targetId="fe00-451f-6735-6fd9" type="selectionEntry"/>
+        <entryLink id="7bbf-963a-631c-7a00" name="Big Choppa" hidden="false" collective="false" import="true" targetId="0470-1b47-489b-14c9" type="selectionEntry"/>
+        <entryLink id="b322-f65a-2207-734a" name="Power Klaw" hidden="false" collective="false" import="true" targetId="fe00-451f-6735-6fd9" type="selectionEntry"/>
       </entryLinks>
     </selectionEntryGroup>
-    <selectionEntryGroup id="c2ce-6759-e009-8c11" name="Warlord Traits" hidden="false" collective="false">
+    <selectionEntryGroup id="c2ce-6759-e009-8c11" name="Warlord Traits" hidden="false" collective="false" import="true">
       <modifiers>
         <modifier type="set" field="hidden" value="true">
           <conditionGroups>
@@ -13323,7 +13319,7 @@ Command Point.</characteristic>
         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" id="c14a-024c-55a7-1e35" type="max"/>
       </constraints>
       <selectionEntryGroups>
-        <selectionEntryGroup id="b9da-33f9-4b37-d3c8" name="Ork Traits" hidden="false" collective="false">
+        <selectionEntryGroup id="b9da-33f9-4b37-d3c8" name="Ork Traits" hidden="false" collective="false" import="true">
           <modifiers>
             <modifier type="set" field="hidden" value="true">
               <conditionGroups>
@@ -13340,27 +13336,27 @@ Command Point.</characteristic>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" id="f742-0a44-1b4b-1349" type="max"/>
           </constraints>
           <entryLinks>
-            <entryLink id="7806-6bc9-8199-a247" name="Ard as Nails" hidden="false" collective="false" targetId="e940-4535-ae9d-ac2a" type="selectionEntry"/>
-            <entryLink id="f12a-cca7-a5ea-de80" name="Big Killa Boss" hidden="false" collective="false" targetId="04f8-83d1-366e-e472" type="selectionEntry"/>
-            <entryLink id="15c6-bdf3-96fd-53ed" name="Butal but Kunnin" hidden="false" collective="false" targetId="7f12-8f4c-8f99-0a16" type="selectionEntry"/>
-            <entryLink id="94ab-4f18-5afc-aa5e" name="Da Best Armour Teef Can Buy" hidden="false" collective="false" targetId="965f-2bc7-8c89-8ab8" type="selectionEntry"/>
-            <entryLink id="5379-0588-749b-5fd4" name="Follow me Ladz!" hidden="false" collective="false" targetId="1a3c-6e25-1e6a-f971" type="selectionEntry"/>
-            <entryLink id="e3c7-75f0-8fc1-825b" name="I&apos;ve Got A Plan, Ladz!" hidden="false" collective="false" targetId="f4f6-066c-7624-6c0b" type="selectionEntry"/>
-            <entryLink id="3cd8-cc83-f8c1-5b25" name="Killa Reputation" hidden="false" collective="false" targetId="18dd-0ed7-7966-85f3" type="selectionEntry"/>
-            <entryLink id="04df-9bfb-6ade-fa5d" name="Kunnin but Brutal" hidden="false" collective="false" targetId="5bce-ed03-5f6c-6f5f" type="selectionEntry"/>
-            <entryLink id="8524-19ac-36f5-2fe8" name="Might is Right" hidden="false" collective="false" targetId="4829-1f2a-ae41-4ba4" type="selectionEntry"/>
-            <entryLink id="8ca5-b65a-3a3c-8a4a" name="Opportunist" hidden="false" collective="false" targetId="5d71-82c4-ac0b-1f28" type="selectionEntry"/>
-            <entryLink id="c19a-b5fe-f07c-ef8e" name="Proper Killy" hidden="false" collective="false" targetId="f816-d517-7b97-ee2a" type="selectionEntry"/>
-            <entryLink id="2be2-a079-6463-fcb4" name="Speed Freek" hidden="false" collective="false" targetId="aba6-84bf-f77d-0fe8" type="selectionEntry"/>
-            <entryLink id="eb63-94c6-0061-eb1b" name="Surly as a Squiggoth" hidden="false" collective="false" targetId="11b4-5592-2e65-a6ce" type="selectionEntry"/>
+            <entryLink id="7806-6bc9-8199-a247" name="Ard as Nails" hidden="false" collective="false" import="true" targetId="e940-4535-ae9d-ac2a" type="selectionEntry"/>
+            <entryLink id="f12a-cca7-a5ea-de80" name="Big Killa Boss" hidden="false" collective="false" import="true" targetId="04f8-83d1-366e-e472" type="selectionEntry"/>
+            <entryLink id="15c6-bdf3-96fd-53ed" name="Butal but Kunnin" hidden="false" collective="false" import="true" targetId="7f12-8f4c-8f99-0a16" type="selectionEntry"/>
+            <entryLink id="94ab-4f18-5afc-aa5e" name="Da Best Armour Teef Can Buy" hidden="false" collective="false" import="true" targetId="965f-2bc7-8c89-8ab8" type="selectionEntry"/>
+            <entryLink id="5379-0588-749b-5fd4" name="Follow me Ladz!" hidden="false" collective="false" import="true" targetId="1a3c-6e25-1e6a-f971" type="selectionEntry"/>
+            <entryLink id="e3c7-75f0-8fc1-825b" name="I&apos;ve Got A Plan, Ladz!" hidden="false" collective="false" import="true" targetId="f4f6-066c-7624-6c0b" type="selectionEntry"/>
+            <entryLink id="3cd8-cc83-f8c1-5b25" name="Killa Reputation" hidden="false" collective="false" import="true" targetId="18dd-0ed7-7966-85f3" type="selectionEntry"/>
+            <entryLink id="04df-9bfb-6ade-fa5d" name="Kunnin but Brutal" hidden="false" collective="false" import="true" targetId="5bce-ed03-5f6c-6f5f" type="selectionEntry"/>
+            <entryLink id="8524-19ac-36f5-2fe8" name="Might is Right" hidden="false" collective="false" import="true" targetId="4829-1f2a-ae41-4ba4" type="selectionEntry"/>
+            <entryLink id="8ca5-b65a-3a3c-8a4a" name="Opportunist" hidden="false" collective="false" import="true" targetId="5d71-82c4-ac0b-1f28" type="selectionEntry"/>
+            <entryLink id="c19a-b5fe-f07c-ef8e" name="Proper Killy" hidden="false" collective="false" import="true" targetId="f816-d517-7b97-ee2a" type="selectionEntry"/>
+            <entryLink id="2be2-a079-6463-fcb4" name="Speed Freek" hidden="false" collective="false" import="true" targetId="aba6-84bf-f77d-0fe8" type="selectionEntry"/>
+            <entryLink id="eb63-94c6-0061-eb1b" name="Surly as a Squiggoth" hidden="false" collective="false" import="true" targetId="11b4-5592-2e65-a6ce" type="selectionEntry"/>
           </entryLinks>
         </selectionEntryGroup>
-        <selectionEntryGroup id="3d2f-3e62-ff89-61ab" name="Warlord Traits (Specilaist Detachment)" hidden="false" collective="false">
+        <selectionEntryGroup id="3d2f-3e62-ff89-61ab" name="Warlord Traits (Specilaist Detachment)" hidden="false" collective="false" import="true">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" id="5b02-9c78-88bd-33d1" type="max"/>
           </constraints>
           <selectionEntries>
-            <selectionEntry id="4564-8f7e-0e5d-221c" name="Gork&apos;s One" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="4564-8f7e-0e5d-221c" name="Gork&apos;s One" hidden="false" collective="false" import="true" type="upgrade">
               <modifiers>
                 <modifier type="set" field="hidden" value="true">
                   <conditions>
@@ -13384,7 +13380,7 @@ Command Point.</characteristic>
                 <cost name="pts" typeId="points" value="0.0"/>
               </costs>
             </selectionEntry>
-            <selectionEntry id="b817-d77d-1166-3096" name="Mork&apos;s One" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="b817-d77d-1166-3096" name="Mork&apos;s One" hidden="false" collective="false" import="true" type="upgrade">
               <modifiers>
                 <modifier type="set" field="hidden" value="true">
                   <conditions>
@@ -13408,7 +13404,7 @@ Command Point.</characteristic>
                 <cost name="pts" typeId="points" value="0.0"/>
               </costs>
             </selectionEntry>
-            <selectionEntry id="dfe0-97a2-e8fe-ad5c" name="Quick, Ladz!" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="dfe0-97a2-e8fe-ad5c" name="Quick, Ladz!" hidden="false" collective="false" import="true" type="upgrade">
               <modifiers>
                 <modifier type="set" field="hidden" value="true">
                   <conditionGroups>
@@ -13427,7 +13423,7 @@ Command Point.</characteristic>
                 <cost name="pts" typeId="points" value="0.0"/>
               </costs>
             </selectionEntry>
-            <selectionEntry id="e7cd-6220-4ae3-f7a7" name="Dread Mek" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="e7cd-6220-4ae3-f7a7" name="Dread Mek" hidden="false" collective="false" import="true" type="upgrade">
               <modifiers>
                 <modifier type="set" field="hidden" value="true">
                   <conditionGroups>
@@ -13453,7 +13449,7 @@ Command Point.</characteristic>
                 <cost name="pts" typeId="points" value="0.0"/>
               </costs>
             </selectionEntry>
-            <selectionEntry id="ba5e-b55b-7601-cf81" name="Back-seat Driver" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="ba5e-b55b-7601-cf81" name="Back-seat Driver" hidden="false" collective="false" import="true" type="upgrade">
               <modifiers>
                 <modifier type="set" field="hidden" value="true">
                   <conditionGroups>
@@ -13483,7 +13479,7 @@ Command Point.</characteristic>
         </selectionEntryGroup>
       </selectionEntryGroups>
       <entryLinks>
-        <entryLink id="84b5-e7e1-1873-7cb8" name="Warlord Traits (BRB)" hidden="false" collective="false" targetId="d442-1f03-d9da-e77f" type="selectionEntryGroup">
+        <entryLink id="84b5-e7e1-1873-7cb8" name="Warlord Traits (BRB)" hidden="false" collective="false" import="true" targetId="d442-1f03-d9da-e77f" type="selectionEntryGroup">
           <modifiers>
             <modifier type="set" field="hidden" value="true">
               <conditionGroups>
@@ -13497,7 +13493,7 @@ Command Point.</characteristic>
             </modifier>
           </modifiers>
         </entryLink>
-        <entryLink id="a8f3-34c5-1693-8046" name="Warlord Traits (CA)" hidden="false" collective="false" targetId="f673-3d9b-bb1b-377f" type="selectionEntryGroup">
+        <entryLink id="a8f3-34c5-1693-8046" name="Warlord Traits (CA)" hidden="false" collective="false" import="true" targetId="f673-3d9b-bb1b-377f" type="selectionEntryGroup">
           <modifiers>
             <modifier type="set" field="hidden" value="true">
               <conditionGroups>
@@ -13513,9 +13509,9 @@ Command Point.</characteristic>
         </entryLink>
       </entryLinks>
     </selectionEntryGroup>
-    <selectionEntryGroup id="51e5-322a-ca81-946b" name="Battlewagon Equipment" publicationId="11b5-77b9-pubN65537" page="83" hidden="false" collective="false">
+    <selectionEntryGroup id="51e5-322a-ca81-946b" name="Battlewagon Equipment" publicationId="11b5-77b9-pubN65537" page="83" hidden="false" collective="false" import="true">
       <selectionEntries>
-        <selectionEntry id="9cb9-37ff-7250-5011" name="Grabbin&apos; Klaw" hidden="false" collective="false" type="upgrade">
+        <selectionEntry id="9cb9-37ff-7250-5011" name="Grabbin&apos; Klaw" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7432-df1d-929c-2d46" type="max"/>
           </constraints>
@@ -13537,7 +13533,7 @@ Command Point.</characteristic>
             <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
           </costs>
         </selectionEntry>
-        <selectionEntry id="4e54-1b71-dd87-1bee" name="Grot Riggers" hidden="false" collective="false" type="upgrade">
+        <selectionEntry id="4e54-1b71-dd87-1bee" name="Grot Riggers" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bed8-72b9-7edc-c1f3" type="max"/>
           </constraints>
@@ -13554,7 +13550,7 @@ Command Point.</characteristic>
             <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
           </costs>
         </selectionEntry>
-        <selectionEntry id="d717-c78e-04e0-cc0f" name="Stickbomb Chucka" hidden="false" collective="false" type="upgrade">
+        <selectionEntry id="d717-c78e-04e0-cc0f" name="Stickbomb Chucka" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c971-ac26-0931-312c" type="max"/>
           </constraints>
@@ -13578,19 +13574,19 @@ Command Point.</characteristic>
         </selectionEntry>
       </selectionEntries>
       <entryLinks>
-        <entryLink id="d583-7c3a-cc2c-e08a" name="Lobba" hidden="false" collective="false" targetId="b25a-5184-36ce-d147" type="selectionEntry">
+        <entryLink id="d583-7c3a-cc2c-e08a" name="Lobba" hidden="false" collective="false" import="true" targetId="b25a-5184-36ce-d147" type="selectionEntry">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4513-d08f-9f0a-b133" type="max"/>
           </constraints>
         </entryLink>
-        <entryLink id="9368-da91-74e9-5b5d" name="Wreckin&apos; Ball" hidden="false" collective="false" targetId="afdc-8903-044a-a42e" type="selectionEntry">
+        <entryLink id="9368-da91-74e9-5b5d" name="Wreckin&apos; Ball" hidden="false" collective="false" import="true" targetId="afdc-8903-044a-a42e" type="selectionEntry">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f642-56a2-be26-5d45" type="max"/>
           </constraints>
         </entryLink>
       </entryLinks>
     </selectionEntryGroup>
-    <selectionEntryGroup id="04b0-dab2-123b-df51" name="Shiney Gubbinz" hidden="false" collective="false">
+    <selectionEntryGroup id="04b0-dab2-123b-df51" name="Shiney Gubbinz" hidden="false" collective="false" import="true">
       <modifiers>
         <modifier type="increment" field="dc3f-29ec-83fc-36d2" value="1">
           <conditions>
@@ -13624,7 +13620,7 @@ Command Point.</characteristic>
         <constraint field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="dc3f-29ec-83fc-36d2" type="max"/>
       </constraints>
       <selectionEntries>
-        <selectionEntry id="72d8-4997-0e7d-0eff" name="Da Lucky Stikk" hidden="false" collective="false" type="upgrade">
+        <selectionEntry id="72d8-4997-0e7d-0eff" name="Da Lucky Stikk" hidden="false" collective="false" import="true" type="upgrade">
           <modifiers>
             <modifier type="set" field="hidden" value="true">
               <conditionGroups>
@@ -13653,7 +13649,7 @@ Command Point.</characteristic>
             <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
           </costs>
         </selectionEntry>
-        <selectionEntry id="2f41-91a9-f026-5ebc" name="Rezmekka&apos;s Redder Armour" hidden="false" collective="false" type="upgrade">
+        <selectionEntry id="2f41-91a9-f026-5ebc" name="Rezmekka&apos;s Redder Armour" hidden="false" collective="false" import="true" type="upgrade">
           <modifiers>
             <modifier type="set" field="hidden" value="true">
               <conditionGroups>
@@ -13682,7 +13678,7 @@ Command Point.</characteristic>
             <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
           </costs>
         </selectionEntry>
-        <selectionEntry id="6f8a-2270-2bc4-6c50" name="Da Fixer Upperz" hidden="false" collective="false" type="upgrade">
+        <selectionEntry id="6f8a-2270-2bc4-6c50" name="Da Fixer Upperz" hidden="false" collective="false" import="true" type="upgrade">
           <modifiers>
             <modifier type="set" field="hidden" value="true">
               <conditionGroups>
@@ -13711,7 +13707,7 @@ Command Point.</characteristic>
             <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
           </costs>
         </selectionEntry>
-        <selectionEntry id="4e29-f0bb-84b0-5d23" name="Brogs Buzzbomb" hidden="false" collective="false" type="upgrade">
+        <selectionEntry id="4e29-f0bb-84b0-5d23" name="Brogs Buzzbomb" hidden="false" collective="false" import="true" type="upgrade">
           <modifiers>
             <modifier type="set" field="hidden" value="true">
               <conditionGroups>
@@ -13745,7 +13741,7 @@ Command Point.</characteristic>
             <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
           </costs>
         </selectionEntry>
-        <selectionEntry id="1575-7fda-48ef-4311" name="The Badskull Banner" hidden="false" collective="false" type="upgrade">
+        <selectionEntry id="1575-7fda-48ef-4311" name="The Badskull Banner" hidden="false" collective="false" import="true" type="upgrade">
           <modifiers>
             <modifier type="set" field="hidden" value="true">
               <conditionGroups>
@@ -13774,7 +13770,7 @@ Command Point.</characteristic>
             <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
           </costs>
         </selectionEntry>
-        <selectionEntry id="9d83-15d4-56a3-e47e" name="Super Cybork Body" hidden="false" collective="false" type="upgrade">
+        <selectionEntry id="9d83-15d4-56a3-e47e" name="Super Cybork Body" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
             <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="3ec3-72b8-44c7-22b4" type="max"/>
           </constraints>
@@ -13791,7 +13787,7 @@ Command Point.</characteristic>
             <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
           </costs>
         </selectionEntry>
-        <selectionEntry id="e199-889c-af51-7ff2" name="Scorched Gitbonez" hidden="false" collective="false" type="upgrade">
+        <selectionEntry id="e199-889c-af51-7ff2" name="Scorched Gitbonez" hidden="false" collective="false" import="true" type="upgrade">
           <modifiers>
             <modifier type="set" field="hidden" value="true">
               <conditions>
@@ -13815,7 +13811,7 @@ Command Point.</characteristic>
             <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
           </costs>
         </selectionEntry>
-        <selectionEntry id="67b9-12fd-bea8-4c7d" name="Skargrim’s  Snazztrike" hidden="false" collective="false" type="upgrade">
+        <selectionEntry id="67b9-12fd-bea8-4c7d" name="Skargrim’s  Snazztrike" hidden="false" collective="false" import="true" type="upgrade">
           <modifiers>
             <modifier type="set" field="hidden" value="true">
               <conditionGroups>
@@ -13844,7 +13840,7 @@ Command Point.</characteristic>
             <cost name="pts" typeId="points" value="0.0"/>
           </costs>
         </selectionEntry>
-        <selectionEntry id="cf8b-16ff-d9d9-d157" name="Da Souped-up Shokka" hidden="false" collective="false" type="upgrade">
+        <selectionEntry id="cf8b-16ff-d9d9-d157" name="Da Souped-up Shokka" hidden="false" collective="false" import="true" type="upgrade">
           <modifiers>
             <modifier type="set" field="hidden" value="true">
               <conditionGroups>
@@ -13878,7 +13874,7 @@ Command Point.</characteristic>
             <cost name="pts" typeId="points" value="0.0"/>
           </costs>
         </selectionEntry>
-        <selectionEntry id="f86a-6ae3-6619-8e77" name="Da Blitzshouta" hidden="false" collective="false" type="upgrade">
+        <selectionEntry id="f86a-6ae3-6619-8e77" name="Da Blitzshouta" hidden="false" collective="false" import="true" type="upgrade">
           <modifiers>
             <modifier type="set" field="hidden" value="true">
               <conditionGroups>
@@ -13906,27 +13902,27 @@ Command Point.</characteristic>
         </selectionEntry>
       </selectionEntries>
       <entryLinks>
-        <entryLink id="7f02-f190-2ccd-9e6f" name="Headwoppa&apos;s Killchoppa" hidden="false" collective="false" targetId="ca75-94bd-4424-6d4c" type="selectionEntry"/>
-        <entryLink id="d9fc-22a5-32ce-8572" name="Gitstoppa Shells" hidden="false" collective="false" targetId="f8cd-d7c6-a72c-7e5b" type="selectionEntry"/>
-        <entryLink id="a74b-9401-92c7-0f67" name="Da Dead Shiny Shoota" hidden="false" collective="false" targetId="67ae-0581-17b9-4a40" type="selectionEntry"/>
-        <entryLink id="f926-b1b8-5784-17d7" name="Da Killa Klaw" hidden="false" collective="false" targetId="80f0-e3e9-27b1-d270" type="selectionEntry"/>
-        <entryLink id="003d-47d5-a1b0-31bd" name="Da Gobshot Blunderbuss" hidden="false" collective="false" targetId="8f4c-0968-1720-2088" type="selectionEntry"/>
-        <entryLink id="267f-4963-5da0-5038" name="Morgargs Finkin&apos; Cap" hidden="false" collective="false" targetId="5ec1-fede-e18a-54de" type="selectionEntry"/>
+        <entryLink id="7f02-f190-2ccd-9e6f" name="Headwoppa&apos;s Killchoppa" hidden="false" collective="false" import="true" targetId="ca75-94bd-4424-6d4c" type="selectionEntry"/>
+        <entryLink id="d9fc-22a5-32ce-8572" name="Gitstoppa Shells" hidden="false" collective="false" import="true" targetId="f8cd-d7c6-a72c-7e5b" type="selectionEntry"/>
+        <entryLink id="a74b-9401-92c7-0f67" name="Da Dead Shiny Shoota" hidden="false" collective="false" import="true" targetId="67ae-0581-17b9-4a40" type="selectionEntry"/>
+        <entryLink id="f926-b1b8-5784-17d7" name="Da Killa Klaw" hidden="false" collective="false" import="true" targetId="80f0-e3e9-27b1-d270" type="selectionEntry"/>
+        <entryLink id="003d-47d5-a1b0-31bd" name="Da Gobshot Blunderbuss" hidden="false" collective="false" import="true" targetId="8f4c-0968-1720-2088" type="selectionEntry"/>
+        <entryLink id="267f-4963-5da0-5038" name="Morgargs Finkin&apos; Cap" hidden="false" collective="false" import="true" targetId="5ec1-fede-e18a-54de" type="selectionEntry"/>
       </entryLinks>
     </selectionEntryGroup>
-    <selectionEntryGroup id="d4bf-a2d0-e994-1474" name="Nob Arm1" hidden="false" collective="false" defaultSelectionEntryId="70d9-829c-4696-ddb8">
+    <selectionEntryGroup id="d4bf-a2d0-e994-1474" name="Nob Arm1" hidden="false" collective="false" import="true" defaultSelectionEntryId="70d9-829c-4696-ddb8">
       <constraints>
         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3d1b-0985-1f10-ceb3" type="max"/>
         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6659-1c5f-8a39-1a36" type="min"/>
       </constraints>
       <entryLinks>
-        <entryLink id="8e81-bc80-3cbc-1627" name="Big Choppa" hidden="false" collective="false" targetId="0470-1b47-489b-14c9" type="selectionEntry"/>
-        <entryLink id="5d19-15a5-9dd5-3536" name="Power Klaw" hidden="false" collective="false" targetId="fe00-451f-6735-6fd9" type="selectionEntry"/>
-        <entryLink id="8279-314c-08b7-a39f" name="Choppa" hidden="false" collective="false" targetId="c4df-c43d-08a6-18ab" type="selectionEntry"/>
-        <entryLink id="4aeb-b2ee-e701-9ce6" name="Killsaw" hidden="false" collective="false" targetId="f15a-fc8e-65b1-e4b8" type="selectionEntry"/>
-        <entryLink id="ab91-3f95-266d-f041" name="Power Stabba" hidden="false" collective="false" targetId="5a1a-e62f-5896-dca6" type="selectionEntry"/>
-        <entryLink id="70d9-829c-4696-ddb8" name="Slugga" hidden="false" collective="false" targetId="d13b-ad69-e6a2-d485" type="selectionEntry"/>
-        <entryLink id="0ef7-8a12-d863-180b" name="Kombi-Skorcha" hidden="false" collective="false" targetId="b6c7-06c8-b7fb-05a7" type="selectionEntry">
+        <entryLink id="8e81-bc80-3cbc-1627" name="Big Choppa" hidden="false" collective="false" import="true" targetId="0470-1b47-489b-14c9" type="selectionEntry"/>
+        <entryLink id="5d19-15a5-9dd5-3536" name="Power Klaw" hidden="false" collective="false" import="true" targetId="fe00-451f-6735-6fd9" type="selectionEntry"/>
+        <entryLink id="8279-314c-08b7-a39f" name="Choppa" hidden="false" collective="false" import="true" targetId="c4df-c43d-08a6-18ab" type="selectionEntry"/>
+        <entryLink id="4aeb-b2ee-e701-9ce6" name="Killsaw" hidden="false" collective="false" import="true" targetId="f15a-fc8e-65b1-e4b8" type="selectionEntry"/>
+        <entryLink id="ab91-3f95-266d-f041" name="Power Stabba" hidden="false" collective="false" import="true" targetId="5a1a-e62f-5896-dca6" type="selectionEntry"/>
+        <entryLink id="70d9-829c-4696-ddb8" name="Slugga" hidden="false" collective="false" import="true" targetId="d13b-ad69-e6a2-d485" type="selectionEntry"/>
+        <entryLink id="0ef7-8a12-d863-180b" name="Kombi-Skorcha" hidden="false" collective="false" import="true" targetId="b6c7-06c8-b7fb-05a7" type="selectionEntry">
           <modifiers>
             <modifier type="set" field="hidden" value="true">
               <conditions>
@@ -13935,7 +13931,7 @@ Command Point.</characteristic>
             </modifier>
           </modifiers>
         </entryLink>
-        <entryLink id="5f91-7915-029b-bd17" name="Kombi-Rokkit" hidden="false" collective="false" targetId="3511-0070-0667-abf2" type="selectionEntry">
+        <entryLink id="5f91-7915-029b-bd17" name="Kombi-Rokkit" hidden="false" collective="false" import="true" targetId="3511-0070-0667-abf2" type="selectionEntry">
           <modifiers>
             <modifier type="set" field="hidden" value="true">
               <conditions>
@@ -13944,20 +13940,20 @@ Command Point.</characteristic>
             </modifier>
           </modifiers>
         </entryLink>
-        <entryLink id="b326-2805-f245-f449" name="Shoota (Index)" hidden="false" collective="false" targetId="33fd-f9ce-0809-8a9b" type="selectionEntry"/>
-        <entryLink id="d71e-e2b3-b52b-7422" name="Kustom Shoota (Index)" hidden="false" collective="false" targetId="6e69-3661-a3ae-a377" type="selectionEntry"/>
+        <entryLink id="b326-2805-f245-f449" name="Shoota (Index)" hidden="false" collective="false" import="true" targetId="33fd-f9ce-0809-8a9b" type="selectionEntry"/>
+        <entryLink id="d71e-e2b3-b52b-7422" name="Kustom Shoota (Index)" hidden="false" collective="false" import="true" targetId="6e69-3661-a3ae-a377" type="selectionEntry"/>
       </entryLinks>
     </selectionEntryGroup>
-    <selectionEntryGroup id="2fe0-1fb8-9268-f604" name="Nob Arm2" hidden="false" collective="false" defaultSelectionEntryId="7c79-7879-74de-9483">
+    <selectionEntryGroup id="2fe0-1fb8-9268-f604" name="Nob Arm2" hidden="false" collective="false" import="true" defaultSelectionEntryId="7c79-7879-74de-9483">
       <constraints>
         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9656-065f-7e41-880f" type="max"/>
         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="56c7-0e9e-b1fb-b769" type="min"/>
       </constraints>
       <entryLinks>
-        <entryLink id="e322-76ab-827b-a2da" name="Big Choppa" hidden="false" collective="false" targetId="0470-1b47-489b-14c9" type="selectionEntry"/>
-        <entryLink id="b3c2-4565-9aa0-b097" name="Power Klaw" hidden="false" collective="false" targetId="fe00-451f-6735-6fd9" type="selectionEntry"/>
-        <entryLink id="7c79-7879-74de-9483" name="Choppa" hidden="false" collective="false" targetId="c4df-c43d-08a6-18ab" type="selectionEntry"/>
-        <entryLink id="cfa0-a47b-2eeb-2458" name="Killsaw" hidden="false" collective="false" targetId="f15a-fc8e-65b1-e4b8" type="selectionEntry">
+        <entryLink id="e322-76ab-827b-a2da" name="Big Choppa" hidden="false" collective="false" import="true" targetId="0470-1b47-489b-14c9" type="selectionEntry"/>
+        <entryLink id="b3c2-4565-9aa0-b097" name="Power Klaw" hidden="false" collective="false" import="true" targetId="fe00-451f-6735-6fd9" type="selectionEntry"/>
+        <entryLink id="7c79-7879-74de-9483" name="Choppa" hidden="false" collective="false" import="true" targetId="c4df-c43d-08a6-18ab" type="selectionEntry"/>
+        <entryLink id="cfa0-a47b-2eeb-2458" name="Killsaw" hidden="false" collective="false" import="true" targetId="f15a-fc8e-65b1-e4b8" type="selectionEntry">
           <modifiers>
             <modifier type="set" field="points" value="8">
               <conditions>
@@ -13966,16 +13962,16 @@ Command Point.</characteristic>
             </modifier>
           </modifiers>
         </entryLink>
-        <entryLink id="6511-843b-6a0f-70d1" name="Power Stabba" hidden="false" collective="false" targetId="5a1a-e62f-5896-dca6" type="selectionEntry"/>
-        <entryLink id="7944-30dc-6600-69e8" name="Slugga" hidden="false" collective="false" targetId="d13b-ad69-e6a2-d485" type="selectionEntry"/>
+        <entryLink id="6511-843b-6a0f-70d1" name="Power Stabba" hidden="false" collective="false" import="true" targetId="5a1a-e62f-5896-dca6" type="selectionEntry"/>
+        <entryLink id="7944-30dc-6600-69e8" name="Slugga" hidden="false" collective="false" import="true" targetId="d13b-ad69-e6a2-d485" type="selectionEntry"/>
       </entryLinks>
     </selectionEntryGroup>
-    <selectionEntryGroup id="47bf-3a7e-3d24-5af2" name="Specialist Detachment" hidden="false" collective="false">
+    <selectionEntryGroup id="47bf-3a7e-3d24-5af2" name="Specialist Detachment" hidden="false" collective="false" import="true">
       <constraints>
         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4090-8e3a-39d7-c847" type="max"/>
       </constraints>
       <selectionEntries>
-        <selectionEntry id="aa25-f071-b889-36e5" name="Stompa Mob" hidden="false" collective="false" type="upgrade">
+        <selectionEntry id="aa25-f071-b889-36e5" name="Stompa Mob" hidden="false" collective="false" import="true" type="upgrade">
           <modifiers>
             <modifier type="set" field="hidden" value="true">
               <conditions>
@@ -13999,7 +13995,7 @@ Command Point.</characteristic>
             <cost name="pts" typeId="points" value="0.0"/>
           </costs>
         </selectionEntry>
-        <selectionEntry id="2762-1920-61d6-002e" name="Kult of Speed" hidden="false" collective="false" type="upgrade">
+        <selectionEntry id="2762-1920-61d6-002e" name="Kult of Speed" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8bbb-6e84-c8b0-2f4a" type="max"/>
           </constraints>
@@ -14016,7 +14012,7 @@ Command Point.</characteristic>
             <cost name="pts" typeId="points" value="0.0"/>
           </costs>
         </selectionEntry>
-        <selectionEntry id="8f45-9eef-7552-026c" name="Dread Waaaagh!" hidden="false" collective="false" type="upgrade">
+        <selectionEntry id="8f45-9eef-7552-026c" name="Dread Waaaagh!" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ea3c-3b23-fc35-df7e" type="max"/>
           </constraints>
@@ -14033,7 +14029,7 @@ Command Point.</characteristic>
             <cost name="pts" typeId="points" value="0.0"/>
           </costs>
         </selectionEntry>
-        <selectionEntry id="996c-570e-8250-145d" name="Blitz Brigade" hidden="false" collective="false" type="upgrade">
+        <selectionEntry id="996c-570e-8250-145d" name="Blitz Brigade" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5673-71f3-feae-df46" type="max"/>
           </constraints>


### PR DESCRIPTION
Gave Invictor Tactical Warsuit the right weapon
Removed Termite Assault Drill (Has been replaced with Terrax-Pattern Termite Assault Drill)
Adjusted the Eliminators to the August 2019 Errata
Changed the number of attacks on Aggressor
Fixed Wolf Guard in Tartaros Power Level and default choices
Orks - Fixed Warboss seen as uncategorize

Related issues #5498 #5492 #5401 #5496 