### PR TITLE
Space Wolves - Fixes for Infiltrator comms array and adjustments for points and PL

### DIFF
--- a/Imperium - Space Wolves.cat
+++ b/Imperium - Space Wolves.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="24b6-2b46-0063-2867" name="Imperium - Space Wolves" revision="91" battleScribeVersion="2.03" authorName="CrusherJoe" authorContact="@CrusherJoe" authorUrl="https://discord.gg/KqPVhds" library="false" gameSystemId="28ec-711c-d87f-3aeb" gameSystemRevision="1" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="24b6-2b46-0063-2867" name="Imperium - Space Wolves" revision="92" battleScribeVersion="2.03" authorName="CrusherJoe" authorContact="@CrusherJoe" authorUrl="https://discord.gg/KqPVhds" library="false" gameSystemId="28ec-711c-d87f-3aeb" gameSystemRevision="1" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <publications>
     <publication id="24b6-2b46-pubN65537" name="Codex: Space Wolves"/>
     <publication id="24b6-2b46-pubN166488" name="Chapter Approved 2017"/>
@@ -7944,7 +7944,7 @@
       </profiles>
       <infoLinks>
         <infoLink id="5df9-9d23-2fa7-1b81" name="And They Shall Know No Fear" hidden="false" targetId="4ea8-94d3-ba39-042f" type="rule"/>
-        <infoLink id="3067-8807-e090-de20" name="Huskarl to the Jarl" hidden="false" targetId="ca86-a970-9bab-d29a" type="profile"/>
+        <infoLink id="3067-8807-e090-de20" name="Huskarl to the Jarl" hidden="false" targetId="838b-671f-4a04-4167" type="profile"/>
         <infoLink id="6319-a807-b5b4-d2d4" name="Hunters Unleashed" hidden="false" targetId="05af-49f8-8692-ec9f" type="rule"/>
       </infoLinks>
       <categoryLinks>
@@ -10102,6 +10102,7 @@
       <costs>
         <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0"/>
         <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
+        <cost name="pts" typeId="points" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="51e9-7938-df95-465e" name="Stalker Bolt Rifle" hidden="false" collective="false" import="true" type="upgrade">
@@ -12717,9 +12718,9 @@
         </entryLink>
       </entryLinks>
       <costs>
-        <cost name=" PL" typeId="e356-c769-5920-6e14" value="6.0"/>
+        <cost name=" PL" typeId="e356-c769-5920-6e14" value="5.0"/>
         <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
-        <cost name="pts" typeId="points" value="110.0"/>
+        <cost name="pts" typeId="points" value="90.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="df41-00d7-0eec-bb30" name="Camo cloak" hidden="false" collective="false" import="true" type="upgrade">
@@ -12751,7 +12752,7 @@
           <characteristics>
             <characteristic name="Cast" typeId="5afb-9914-904b-d3b3">2</characteristic>
             <characteristic name="Deny" typeId="b5ac-9c20-5d5a-6f9b">1</characteristic>
-            <characteristic name="Powers Known" typeId="69d7-b45e-00a2-7e46">Smite &amp; 2 Obscuration</characteristic>
+            <characteristic name="Powers Known" typeId="69d7-b45e-00a2-7e46">Smite &amp; 2 Obscuration or Smite &amp; 2  Tempestas</characteristic>
             <characteristic name="Other" typeId="c2e2-f115-0003-5d7b">-</characteristic>
           </characteristics>
         </profile>
@@ -12773,6 +12774,39 @@
         <categoryLink id="bf41-de2b-3ab0-75ec" name="New CategoryLink" hidden="false" targetId="848a6ff2-0def-4c72-8433-ff7da70e6bc7" primary="true"/>
         <categoryLink id="f73f-bdf0-473e-6d84" name="Rune Priest" hidden="false" targetId="4dc6-527c-7af1-df8d" primary="false"/>
       </categoryLinks>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="b0c4-763f-8927-49c6" name="Disciplines" hidden="false" collective="false" import="true">
+          <constraints>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4cd1-dbbd-beaa-9d33" type="max"/>
+          </constraints>
+          <entryLinks>
+            <entryLink id="6bd9-fd81-123f-549d" name="Tempestas Discipline" hidden="false" collective="false" import="true" targetId="8ae5-0b71-8a1b-a889" type="selectionEntryGroup">
+              <modifiers>
+                <modifier type="set" field="4e7b-a10f-a014-c2a2" value="0.0">
+                  <conditions>
+                    <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="6cb7-18e9-ff23-ae93" type="atLeast"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4e7b-a10f-a014-c2a2" type="max"/>
+              </constraints>
+            </entryLink>
+            <entryLink id="6cb7-18e9-ff23-ae93" name="Obscuration Discipline" hidden="false" collective="false" import="true" targetId="afd6-d659-f542-2c72" type="selectionEntryGroup">
+              <modifiers>
+                <modifier type="set" field="6a46-6ef1-fa74-b289" value="0.0">
+                  <conditions>
+                    <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="6bd9-fd81-123f-549d" type="atLeast"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6a46-6ef1-fa74-b289" type="max"/>
+              </constraints>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
       <entryLinks>
         <entryLink id="7586-1535-85e5-38ae" name="Warlord" hidden="false" collective="false" import="true" targetId="c5f7-4fff-b3d9-5c0b" type="selectionEntry"/>
         <entryLink id="0596-51e5-152b-04de" name="Relics of The Fang" hidden="false" collective="false" import="true" targetId="852c-a667-c934-d436" type="selectionEntryGroup"/>
@@ -12800,7 +12834,7 @@
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="39fd-a125-4b4a-dacf" type="max"/>
           </constraints>
         </entryLink>
-        <entryLink id="749d-a7df-6ce3-2caa" name="Force sword" hidden="false" collective="false" import="true" targetId="07e7-1f9b-4c1c-aad9" type="selectionEntry">
+        <entryLink id="749d-a7df-6ce3-2caa" name="Runic sword" hidden="false" collective="false" import="true" targetId="151d-4c4b-60a8-a80f" type="selectionEntry">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="57a6-a516-d852-b416" type="min"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1eb4-2122-6aed-522d" type="max"/>
@@ -12812,11 +12846,6 @@
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d5e0-ac94-073d-7c84" type="max"/>
           </constraints>
         </entryLink>
-        <entryLink id="1cf3-2703-fe4c-ef60" name="Obscuration Discipline" hidden="false" collective="false" import="true" targetId="afd6-d659-f542-2c72" type="selectionEntryGroup">
-          <constraints>
-            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7754-9699-0674-4004" type="max"/>
-          </constraints>
-        </entryLink>
         <entryLink id="9cd8-2862-cc22-ebff" name="Camo cloak" hidden="false" collective="false" import="true" targetId="df41-00d7-0eec-bb30" type="selectionEntry">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="955a-9634-7d84-109b" type="min"/>
@@ -12825,9 +12854,9 @@
         </entryLink>
       </entryLinks>
       <costs>
-        <cost name=" PL" typeId="e356-c769-5920-6e14" value="6.0"/>
+        <cost name=" PL" typeId="e356-c769-5920-6e14" value="5.0"/>
         <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
-        <cost name="pts" typeId="points" value="100.0"/>
+        <cost name="pts" typeId="points" value="90.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="d391-6395-0b97-8587" name="Wolf Guard Battle Leader in Phobos Armour" hidden="false" collective="false" import="true" type="model">
@@ -12858,6 +12887,7 @@
       </profiles>
       <infoLinks>
         <infoLink id="a33c-1bae-1b2d-d701" name="And They Shall Know No Fear" hidden="false" targetId="4ea8-94d3-ba39-042f" type="rule"/>
+        <infoLink id="bdec-59d1-5dfd-528f" name="Huskarl to the Jarl" hidden="false" targetId="838b-671f-4a04-4167" type="profile"/>
       </infoLinks>
       <categoryLinks>
         <categoryLink id="df97-7d68-75f8-16b6" name="Faction: Imperium" hidden="false" targetId="84e2-9fa9-ebe6-1d18" primary="false"/>
@@ -12942,9 +12972,9 @@
         </entryLink>
       </entryLinks>
       <costs>
-        <cost name=" PL" typeId="e356-c769-5920-6e14" value="5.0"/>
+        <cost name=" PL" typeId="e356-c769-5920-6e14" value="4.0"/>
         <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
-        <cost name="pts" typeId="points" value="80.0"/>
+        <cost name="pts" typeId="points" value="75.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="56c8-1afe-4990-1b28" name="Accelerator autocannon" hidden="false" collective="true" import="true" type="upgrade">
@@ -12963,7 +12993,7 @@
       <costs>
         <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0"/>
         <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
-        <cost name="pts" typeId="points" value="15.0"/>
+        <cost name="pts" typeId="points" value="10.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="8d81-b2e4-e4f9-c295" name="Bolt sniper rifle" hidden="false" collective="false" import="true" type="upgrade">
@@ -13238,14 +13268,14 @@
         <entryLink id="ee74-c410-b0c8-e492" name="Battle Honours" hidden="false" collective="false" import="true" targetId="5518-d0f5-a880-d71c" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
-        <cost name=" PL" typeId="e356-c769-5920-6e14" value="3.0"/>
+        <cost name=" PL" typeId="e356-c769-5920-6e14" value="4.0"/>
         <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
         <cost name="pts" typeId="points" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="9372-f06c-dc8c-7706" name="Infiltrator Squad" hidden="false" collective="false" import="true" type="unit">
       <modifiers>
-        <modifier type="increment" field="e356-c769-5920-6e14" value="6.0">
+        <modifier type="increment" field="e356-c769-5920-6e14" value="5.0">
           <conditions>
             <condition field="selections" scope="9372-f06c-dc8c-7706" value="5.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" childId="model" type="greaterThan"/>
           </conditions>
@@ -13320,25 +13350,19 @@
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1b7f-2945-7ffc-f718" type="max"/>
           </constraints>
           <profiles>
-            <profile id="df82-e54a-a987-5fb0" name="Infiltrator Helix Adept" hidden="false" typeId="800f-21d0-4387-c943" typeName="Unit">
+            <profile id="8d04-8439-a137-b55b" name="Helix Adept" hidden="false" typeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" typeName="Abilities">
               <characteristics>
-                <characteristic name="M" typeId="0bdf-a96e-9e38-7779">6&quot;</characteristic>
-                <characteristic name="WS" typeId="e7f0-1278-0250-df0c">3+</characteristic>
-                <characteristic name="BS" typeId="381b-eb28-74c3-df5f">3+</characteristic>
-                <characteristic name="S" typeId="2218-aa3c-265f-2939">4</characteristic>
-                <characteristic name="T" typeId="9c9f-9774-a358-3a39">4</characteristic>
-                <characteristic name="W" typeId="f330-5e6e-4110-0978">2</characteristic>
-                <characteristic name="A" typeId="13fc-b29b-31f2-ab9f">2</characteristic>
-                <characteristic name="Ld" typeId="00ca-f8b8-876d-b705">7</characteristic>
-                <characteristic name="Save" typeId="c0df-df94-abd7-e8d3">3+</characteristic>
-              </characteristics>
-            </profile>
-            <profile id="711f-74ac-a76b-22cf" name="Helix Adept" hidden="false" typeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" typeName="Abilities">
-              <characteristics>
-                <characteristic name="Description" typeId="21befb24-fc85-4f52-a745-64b2e48f8228">At the end of your Movement phase, an Infiltrator Helix Adept can attempt to heal or revive 1 model from its unit. If the Infiltrator Helix Adept&apos;s unit contains a wounded model, that model regains 1 lost wound. If its unit contains no wounded models, bot one or more of its models have been slain during the battle, roll a D6. On a 5+ one slain model is returned to the unit with 1 would remaining. If the Infiltrator Helix Adept fails to revive a model, he cannot shoot in your next Shooting phase as he recovers the gene-seed of the fallen warrior.</characteristic>
+                <characteristic name="Description" typeId="21befb24-fc85-4f52-a745-64b2e48f8228">At the end of your Movement phase, this unit’s Infiltrator Helix Adept can provide medical attention to this unit. If this unit contains a model that has lost any wounds, that model regains 1 lost wound. Otherwise, if any models from this unit have been destroyed, roll one D6; on a 5+ you can return one destroyed model from this unit to the battlefield with 1 wound remaining, placing it within 3&quot; of this unit’s Infiltrator Helix Adept and in unit coherency (if the model cannot be placed in this way, it is not returned to the battlefield). On a 4 or less, this unit’s Infiltrator Helix Adept cannot shoot this turn as it recovers the gene-seed of the fallen warrior. Each unit can only be provided medical attention once per turn.</characteristic>
               </characteristics>
             </profile>
           </profiles>
+          <infoLinks>
+            <infoLink id="20fb-00e3-9a39-d113" name="Infiltrator" hidden="false" targetId="dea5-61af-1e27-7354" type="profile">
+              <modifiers>
+                <modifier type="set" field="name" value="Infiltrator Helix Adept"/>
+              </modifiers>
+            </infoLink>
+          </infoLinks>
           <entryLinks>
             <entryLink id="96c7-c545-8376-0325" name="Bolt pistol" hidden="false" collective="false" import="true" targetId="37d3-7098-d596-9948" type="selectionEntry">
               <constraints>
@@ -13366,9 +13390,16 @@
           </costs>
         </selectionEntry>
         <selectionEntry id="5150-c83f-ca03-63a8" name="Infilltrator" hidden="false" collective="false" import="true" type="model">
+          <modifiers>
+            <modifier type="set" field="075f-6490-9cf3-9f3a" value="8.0">
+              <conditions>
+                <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="476a-aea5-71fe-805c" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
           <constraints>
             <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2b3e-db51-2eb6-0e89" type="min"/>
-            <constraint field="selections" scope="parent" value="8.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="075f-6490-9cf3-9f3a" type="max"/>
+            <constraint field="selections" scope="parent" value="9.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="075f-6490-9cf3-9f3a" type="max"/>
           </constraints>
           <profiles>
             <profile id="dea5-61af-1e27-7354" name="Infiltrator" hidden="false" typeId="800f-21d0-4387-c943" typeName="Unit">
@@ -13409,6 +13440,30 @@
             <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0"/>
             <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
             <cost name="pts" typeId="points" value="22.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="605b-23ca-731a-9eb8" name=" Infiltrator comms array" hidden="false" collective="false" import="true" type="upgrade">
+          <modifiers>
+            <modifier type="set" field="044d-8a23-fdb7-fe02" value="0.0">
+              <conditions>
+                <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="476a-aea5-71fe-805c" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="044d-8a23-fdb7-fe02" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="eea9-dca5-dc3d-dbcf" name=" Infiltrator comms array" hidden="false" typeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" typeName="Abilities">
+              <characteristics>
+                <characteristic name="Description" typeId="21befb24-fc85-4f52-a745-64b2e48f8228">Whilst this unit contains a model with an Infiltrator comms array, if there are any friendly &lt;Chapter&gt; Phobos Captain or &lt;Chapter&gt; Phobos Lieutenant models on the battlefield, this unit is always treated as being within range of those models&apos; Jarl of Fenris&apos; and Huskarl to the Jarl abilities.</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="points" value="10.0"/>
+            <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0"/>
+            <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
           </costs>
         </selectionEntry>
       </selectionEntries>
@@ -13607,7 +13662,7 @@
         <entryLink id="1744-2f46-7086-32ed" name="Battle Honours" hidden="false" collective="false" import="true" targetId="5518-d0f5-a880-d71c" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
-        <cost name=" PL" typeId="e356-c769-5920-6e14" value="5.0"/>
+        <cost name=" PL" typeId="e356-c769-5920-6e14" value="4.0"/>
         <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
         <cost name="pts" typeId="points" value="0.0"/>
       </costs>
@@ -17703,11 +17758,6 @@ Matched Play: This model and any units embarked aboard it are exempt from the Ta
     <profile id="b6ba-39af-6402-3665" name="Company Heroes" hidden="false" typeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" typeName="Abilities">
       <characteristics>
         <characteristic name="Description" typeId="21befb24-fc85-4f52-a745-64b2e48f8228">During deployment, all models in this unit must be set up at the same time, though they do not need to be set up in unit coherency. From that point onwards, each Primaris Lieutenant is treated as a separate unit.</characteristic>
-      </characteristics>
-    </profile>
-    <profile id="ca86-a970-9bab-d29a" name="Huskarl to the Jarl" hidden="false" typeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" typeName="Abilities">
-      <characteristics>
-        <characteristic name="Description" typeId="21befb24-fc85-4f52-a745-64b2e48f8228">You can re-roll wound rolls of 1 for friendly SPACE WOLVES units that are within 6&quot; of this model.</characteristic>
       </characteristics>
     </profile>
     <profile id="4010-66d8-1e19-352d" name="Razorback (1)" hidden="false" typeId="29af-65db-c2dc-cfa1" typeName="Stat Damage - M/BS/A">


### PR DESCRIPTION
Added the Infiltrator comms array to the Infiniltrators, fixed PL and added Infiltrator Helix Adept will take the place of an Infiltrator when he is added.
Rune Priest in Phobos Armour - Fixed it's PL and Points value,  changed it's force sword to Runic Sword and Added the Tempestas Discipline to it
Fixed PL and points for Wolf Lord in Phobos armor
Fixed PL for Eliminators
Fixed PL and points for Wolf Guard Battle Leader in Phobos armor
Fixed PL and points for Suppressor Squad

In this version I've remembered to  increment  revision number