### PR TITLE
#5377

### DIFF
--- a/Imperium - Astra Militarum.cat
+++ b/Imperium - Astra Militarum.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="53e9d88f-7463-8c27-fe67-e1a0d1ed0287" name="Imperium - Astra Militarum" revision="221" battleScribeVersion="2.03" authorName="BSData Developers" authorContact="Discord: @Alphalas, @CrusherJoe | Twitter: @kingoverlord, @theawesomesauce" authorUrl="https://discord.gg/KqPVhds" library="false" gameSystemId="28ec-711c-d87f-3aeb" gameSystemRevision="1" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="53e9d88f-7463-8c27-fe67-e1a0d1ed0287" name="Imperium - Astra Militarum" revision="222" battleScribeVersion="2.03" authorName="BSData Developers" authorContact="Discord: @Alphalas, @CrusherJoe | Twitter: @kingoverlord, @theawesomesauce" authorUrl="https://discord.gg/KqPVhds" library="false" gameSystemId="28ec-711c-d87f-3aeb" gameSystemRevision="1" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <publications>
     <publication id="53e9d88f--pubN88319" name="Codex: Astra Militarum"/>
     <publication id="53e9d88f--pubN101602" name="Codex: Imperial Guard"/>
@@ -54,10 +54,10 @@
     <categoryEntry id="b332-b046-7171-5059" name="Cadian" hidden="false"/>
     <categoryEntry id="3263-4233-4344-6228" name="Astra Militarum" hidden="false"/>
     <categoryEntry id="6218-425e-33cf-6ec3" name="Catachan" hidden="false"/>
-    <categoryEntry id="5988-2982-1dde-215b" name="Officio Prefectus" hidden="false"/>
+    <categoryEntry id="5988-2982-1dde-215b" name="Faction: Officio Prefectus" hidden="false"/>
     <categoryEntry id="218e-c8a1-cea3-8377" name="Tempestus Scions" hidden="false"/>
-    <categoryEntry id="fabd-67cb-befb-8f75" name="Militarum Auxilla" hidden="false"/>
-    <categoryEntry id="2135-9abb-5c57-5391" name="Aeronautica Imperialis" hidden="false"/>
+    <categoryEntry id="fabd-67cb-befb-8f75" name="Faction: Militarum Auxilla" hidden="false"/>
+    <categoryEntry id="2135-9abb-5c57-5391" name="Faction: Aeronautica Imperialis" hidden="false"/>
     <categoryEntry id="ab16-2b7a-6dfe-9072" name="Armoured Sentinel" hidden="false"/>
     <categoryEntry id="60e9-5690-bdb9-21cd" name="Baneblade" hidden="false"/>
     <categoryEntry id="8152-8a8e-f1ab-87d3" name="Banehammer" hidden="false"/>
@@ -107,11 +107,11 @@
     <categoryEntry id="286e-aab4-a764-0451" name="Valkyries" hidden="false"/>
     <categoryEntry id="8895-4b63-cbc0-2d8b" name="Veterans" hidden="false"/>
     <categoryEntry id="e12a-0a79-a7e7-3640" name="Wyvern" hidden="false"/>
-    <categoryEntry id="3e01-e6cf-1353-96f4" name="(REGIMENT)" hidden="false"/>
+    <categoryEntry id="3e01-e6cf-1353-96f4" name="Faction: &lt;REGIMENT&gt;" hidden="false"/>
     <categoryEntry id="75f2-f377-6733-6afa" name="Demolisher" hidden="false"/>
     <categoryEntry id="0fc0-4e00-a978-3f55" name="Yarrik" hidden="false"/>
     <categoryEntry id="f0fa-71b1-5ec2-e534" name="Tempestus Command Squad" hidden="false"/>
-    <categoryEntry id="3984-854b-4603-be64" name="Militarum Tempestus" hidden="false"/>
+    <categoryEntry id="3984-854b-4603-be64" name="Faction: Militarum Tempestus" hidden="false"/>
     <categoryEntry id="e035-adc9-4e15-cfc6" name="Atlas Recovery Tank" hidden="false"/>
     <categoryEntry id="3d05-7d74-22dd-f60d" name="Salamander" hidden="false"/>
     <categoryEntry id="dbc8-2e0d-294e-a269" name="Salamander Command Tank" hidden="false"/>
@@ -178,16 +178,16 @@
     <categoryEntry id="e12c-df62-3e71-a108" name="Vendetta Gunship" hidden="false"/>
     <categoryEntry id="db28-2dda-1f4c-ea71" name="Vulture Gunship" hidden="false"/>
     <categoryEntry id="3620-3173-81e8-fde6" name="Medusa" hidden="false"/>
-    <categoryEntry id="fac9-80d5-a022-1805" name="Astra Telepathica" hidden="false"/>
-    <categoryEntry id="e33e-8d7c-5155-72e9" name="Scholastica Psykana" hidden="false"/>
+    <categoryEntry id="fac9-80d5-a022-1805" name="Faction: Astra Telepathica" hidden="false"/>
+    <categoryEntry id="e33e-8d7c-5155-72e9" name="Faction: Scholastica Psykana" hidden="false"/>
     <categoryEntry id="bfe3-76c4-d9dd-688c" name="Astropath" hidden="false"/>
     <categoryEntry id="75a7-e5c7-78de-739b" name="Primaris Psyker" hidden="false"/>
     <categoryEntry id="39c1-fdc2-b915-1f78" name="Wyrdvane Psykers" hidden="false"/>
-    <categoryEntry id="2009-635c-b08f-f825" name="Adeptus Ministorum" hidden="false"/>
+    <categoryEntry id="2009-635c-b08f-f825" name="Faction: Adeptus Ministorum" hidden="false"/>
     <categoryEntry id="8eaa-7ae8-6d29-0db9" name="Ministorum Priest" hidden="false"/>
     <categoryEntry id="c46c-38fc-a485-e1c5" name="Crusaders" hidden="false"/>
-    <categoryEntry id="107e-7049-a707-a021" name="(FORGEWORLD)" hidden="false"/>
-    <categoryEntry id="a794-f43a-87e6-1693" name="Adeptus Mechanicus" hidden="false"/>
+    <categoryEntry id="107e-7049-a707-a021" name="Faction: &lt;FORGEWORLD&gt;" hidden="false"/>
+    <categoryEntry id="a794-f43a-87e6-1693" name="Faction: Adeptus Mechanicus" hidden="false"/>
     <categoryEntry id="af1f-72e0-b8d0-65c3" name="Cult Mechanicus" hidden="false"/>
     <categoryEntry id="74be-b4fc-4598-9bec" name="Tech-Priest" hidden="false"/>
     <categoryEntry id="8622-427c-c483-290f" name="Enginseer" hidden="false"/>
@@ -2442,11 +2442,7 @@
       </selectionEntryGroups>
       <entryLinks>
         <entryLink id="1cae-6aa8-364b-3464" name="HEIRLOOMS OF CONQUEST" hidden="false" collective="false" import="true" targetId="8ed7-7588-0f06-9b0d" type="selectionEntryGroup"/>
-        <entryLink id="ef81-3bca-f771-a5fe" name="Warlord" hidden="false" collective="false" import="true" targetId="33f6-60da-7b70-5fee" type="selectionEntry">
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="3c1e-d072-7ef2-75c8" type="max"/>
-          </constraints>
-        </entryLink>
+        <entryLink id="ef81-3bca-f771-a5fe" name="Warlord" hidden="false" collective="false" import="true" targetId="1f07-a468-bda8-fd3f" type="selectionEntry"/>
         <entryLink id="9f91-581d-bce7-2861" name="Display Astra Militarum Orders" hidden="false" collective="false" import="true" targetId="7d8c-221c-99c5-97d2" type="selectionEntry">
           <modifiers>
             <modifier type="set" field="hidden" value="true">
@@ -2456,15 +2452,7 @@
             </modifier>
           </modifiers>
         </entryLink>
-        <entryLink id="cd34-6069-1337-9f51" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="d6e2-a400-a8db-d4f2" type="selectionEntryGroup">
-          <modifiers>
-            <modifier type="set" field="hidden" value="true">
-              <conditions>
-                <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="33f6-60da-7b70-5fee" type="equalTo"/>
-              </conditions>
-            </modifier>
-          </modifiers>
-        </entryLink>
+        <entryLink id="cd34-6069-1337-9f51" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="d6e2-a400-a8db-d4f2" type="selectionEntryGroup"/>
         <entryLink id="a603-c341-d5bf-b687" name="Is A Custom Character" hidden="false" collective="false" import="true" targetId="43c4-8968-c599-ad5f" type="selectionEntry"/>
         <entryLink id="f439-b87f-cdde-c31a" name="Custom Character Selections" hidden="false" collective="false" import="true" targetId="8774-e003-4a50-56c7" type="selectionEntryGroup"/>
       </entryLinks>
@@ -2588,21 +2576,17 @@
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="d0cb-400b-9fcc-337c" type="max"/>
           </constraints>
         </entryLink>
-        <entryLink id="71f0-5b07-f016-2fc5" name="Warlord" hidden="false" collective="false" import="true" targetId="33f6-60da-7b70-5fee" type="selectionEntry">
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="3e11-28ab-af84-283f" type="max"/>
-          </constraints>
-        </entryLink>
+        <entryLink id="71f0-5b07-f016-2fc5" name="Warlord" hidden="false" collective="false" import="true" targetId="1f07-a468-bda8-fd3f" type="selectionEntry"/>
         <entryLink id="2eda-fdd2-f7af-51e1" name="Master of Command" hidden="false" collective="false" import="true" targetId="c88e-8828-206c-8e39" type="selectionEntry">
           <modifiers>
             <modifier type="set" field="hidden" value="true">
               <conditions>
-                <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="33f6-60da-7b70-5fee" type="equalTo"/>
+                <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="1f07-a468-bda8-fd3f" type="equalTo"/>
               </conditions>
             </modifier>
             <modifier type="set" field="9b55-96ce-c4ce-ef3d" value="1">
               <conditions>
-                <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="33f6-60da-7b70-5fee" type="equalTo"/>
+                <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="1f07-a468-bda8-fd3f" type="equalTo"/>
               </conditions>
             </modifier>
           </modifiers>
@@ -3421,24 +3405,21 @@
           </constraints>
         </entryLink>
         <entryLink id="dd4e-261c-2af5-660b" name="Astra Militarum Orders" hidden="false" collective="false" import="true" targetId="7d8c-221c-99c5-97d2" type="selectionEntry"/>
-        <entryLink id="6970-ecd5-a140-886a" name="Warlord" hidden="false" collective="false" import="true" targetId="33f6-60da-7b70-5fee" type="selectionEntry">
+        <entryLink id="6970-ecd5-a140-886a" name="Warlord" hidden="false" collective="false" import="true" targetId="1f07-a468-bda8-fd3f" type="selectionEntry">
           <modifiers>
-            <modifier type="set" field="2d3b-b544-ad49-fb75" value="2"/>
+            <modifier type="set" field="2d3b-b544-ad49-fb75" value="2.0"/>
           </modifiers>
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="e5f6-97ff-fb4c-5390" type="max"/>
-          </constraints>
         </entryLink>
         <entryLink id="43d2-8511-f0a8-6b93" name="WT (Cadia): Superior Tactical Training" hidden="false" collective="false" import="true" targetId="8d6d-9c06-8025-de58" type="selectionEntry">
           <modifiers>
             <modifier type="set" field="hidden" value="true">
               <conditions>
-                <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="33f6-60da-7b70-5fee" type="equalTo"/>
+                <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="1f07-a468-bda8-fd3f" type="equalTo"/>
               </conditions>
             </modifier>
-            <modifier type="set" field="369b-c784-afa9-e250" value="1">
+            <modifier type="set" field="369b-c784-afa9-e250" value="1.0">
               <conditions>
-                <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="33f6-60da-7b70-5fee" type="equalTo"/>
+                <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="1f07-a468-bda8-fd3f" type="equalTo"/>
               </conditions>
             </modifier>
           </modifiers>
@@ -3529,11 +3510,7 @@
       </selectionEntryGroups>
       <entryLinks>
         <entryLink id="71da-decd-f98a-9364" name="HEIRLOOMS OF CONQUEST" hidden="false" collective="false" import="true" targetId="8ed7-7588-0f06-9b0d" type="selectionEntryGroup"/>
-        <entryLink id="6774-7417-fb25-420a" name="Warlord" hidden="false" collective="false" import="true" targetId="33f6-60da-7b70-5fee" type="selectionEntry">
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="e075-3cd6-2d3e-8af6" type="max"/>
-          </constraints>
-        </entryLink>
+        <entryLink id="6774-7417-fb25-420a" name="Warlord" hidden="false" collective="false" import="true" targetId="1f07-a468-bda8-fd3f" type="selectionEntry"/>
         <entryLink id="56cb-c918-6807-8b78" name="Display Astra Militarum Orders" hidden="false" collective="false" import="true" targetId="7d8c-221c-99c5-97d2" type="selectionEntry">
           <modifiers>
             <modifier type="set" field="hidden" value="true">
@@ -3543,15 +3520,7 @@
             </modifier>
           </modifiers>
         </entryLink>
-        <entryLink id="a323-d10c-6127-5063" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="d6e2-a400-a8db-d4f2" type="selectionEntryGroup">
-          <modifiers>
-            <modifier type="set" field="hidden" value="true">
-              <conditions>
-                <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="33f6-60da-7b70-5fee" type="equalTo"/>
-              </conditions>
-            </modifier>
-          </modifiers>
-        </entryLink>
+        <entryLink id="a323-d10c-6127-5063" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="d6e2-a400-a8db-d4f2" type="selectionEntryGroup"/>
         <entryLink id="f6a4-43d1-932e-3d89" name="Is A Custom Character" hidden="false" collective="false" import="true" targetId="43c4-8968-c599-ad5f" type="selectionEntry"/>
         <entryLink id="f544-828f-b519-11ef" name="Custom Character Selections" hidden="false" collective="false" import="true" targetId="8774-e003-4a50-56c7" type="selectionEntryGroup"/>
       </entryLinks>
@@ -3841,21 +3810,17 @@
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fbfb-4f83-ffed-5fb6" type="max"/>
           </constraints>
         </entryLink>
-        <entryLink id="1ac9-9ca6-ca01-182a" name="Warlord" hidden="false" collective="false" import="true" targetId="33f6-60da-7b70-5fee" type="selectionEntry">
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="3424-742f-ce54-8e43" type="max"/>
-          </constraints>
-        </entryLink>
+        <entryLink id="1ac9-9ca6-ca01-182a" name="Warlord" hidden="false" collective="false" import="true" targetId="1f07-a468-bda8-fd3f" type="selectionEntry"/>
         <entryLink id="0364-5deb-8155-7df1" name="WT (Catachan): Lead From the Front" hidden="false" collective="false" import="true" targetId="1fff-d44f-98e9-609c" type="selectionEntry">
           <modifiers>
             <modifier type="set" field="hidden" value="true">
               <conditions>
-                <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="33f6-60da-7b70-5fee" type="equalTo"/>
+                <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="1f07-a468-bda8-fd3f" type="equalTo"/>
               </conditions>
             </modifier>
             <modifier type="set" field="6a0f-af00-9e70-8f70" value="1">
               <conditions>
-                <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="33f6-60da-7b70-5fee" type="equalTo"/>
+                <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="1f07-a468-bda8-fd3f" type="equalTo"/>
               </conditions>
             </modifier>
           </modifiers>
@@ -4696,20 +4661,8 @@
         </entryLink>
         <entryLink id="52b6-53f6-3ca6-06b1" name="Display Astra Militarum Orders" hidden="false" collective="false" import="true" targetId="7d8c-221c-99c5-97d2" type="selectionEntry"/>
         <entryLink id="85f6-4431-64bc-b9ac" name="Heirlooms of Conquest" hidden="false" collective="false" import="true" targetId="8ed7-7588-0f06-9b0d" type="selectionEntryGroup"/>
-        <entryLink id="69b7-71e1-2fae-4820" name="Warlord" hidden="false" collective="false" import="true" targetId="33f6-60da-7b70-5fee" type="selectionEntry">
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="9d1a-1aa3-b5ce-00da" type="max"/>
-          </constraints>
-        </entryLink>
-        <entryLink id="7559-24f8-47bd-f27a" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="d6e2-a400-a8db-d4f2" type="selectionEntryGroup">
-          <modifiers>
-            <modifier type="set" field="hidden" value="true">
-              <conditions>
-                <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="33f6-60da-7b70-5fee" type="equalTo"/>
-              </conditions>
-            </modifier>
-          </modifiers>
-        </entryLink>
+        <entryLink id="69b7-71e1-2fae-4820" name="Warlord" hidden="false" collective="false" import="true" targetId="1f07-a468-bda8-fd3f" type="selectionEntry"/>
+        <entryLink id="7559-24f8-47bd-f27a" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="d6e2-a400-a8db-d4f2" type="selectionEntryGroup"/>
         <entryLink id="4ed1-5181-69c5-94e2" name="Emperor&apos;s Blade" hidden="true" collective="false" import="true" targetId="0293-3499-c2d4-086e" type="selectionEntry">
           <modifiers>
             <modifier type="set" field="hidden" value="false">
@@ -4806,11 +4759,7 @@
           </constraints>
         </entryLink>
         <entryLink id="1068-cb21-3dab-77ec" name="Heirlooms of Conquest" hidden="false" collective="false" import="true" targetId="8ed7-7588-0f06-9b0d" type="selectionEntryGroup"/>
-        <entryLink id="83cb-0324-349c-c3e6" name="Warlord" hidden="false" collective="false" import="true" targetId="33f6-60da-7b70-5fee" type="selectionEntry">
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="66e1-c887-9699-226c" type="max"/>
-          </constraints>
-        </entryLink>
+        <entryLink id="83cb-0324-349c-c3e6" name="Warlord" hidden="false" collective="false" import="true" targetId="1f07-a468-bda8-fd3f" type="selectionEntry"/>
         <entryLink id="e2fe-3229-5799-39ce" name="Display Astra Militarum Orders" hidden="false" collective="false" import="true" targetId="7d8c-221c-99c5-97d2" type="selectionEntry">
           <modifiers>
             <modifier type="set" field="hidden" value="true">
@@ -4820,15 +4769,7 @@
             </modifier>
           </modifiers>
         </entryLink>
-        <entryLink id="3a2f-08de-5ab4-9906" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="d6e2-a400-a8db-d4f2" type="selectionEntryGroup">
-          <modifiers>
-            <modifier type="set" field="hidden" value="true">
-              <conditions>
-                <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="33f6-60da-7b70-5fee" type="equalTo"/>
-              </conditions>
-            </modifier>
-          </modifiers>
-        </entryLink>
+        <entryLink id="3a2f-08de-5ab4-9906" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="d6e2-a400-a8db-d4f2" type="selectionEntryGroup"/>
         <entryLink id="da9a-3bbb-2903-568f" name="Emperor&apos;s Wrath" hidden="true" collective="false" import="true" targetId="5340-9a3d-98a2-fc05" type="selectionEntry">
           <modifiers>
             <modifier type="set" field="hidden" value="false">
@@ -4888,22 +4829,10 @@
           </constraints>
         </entryLink>
         <entryLink id="056a-d147-d741-a830" name="Heirlooms of Conquest" hidden="false" collective="false" import="true" targetId="8ed7-7588-0f06-9b0d" type="selectionEntryGroup"/>
-        <entryLink id="372a-3230-f763-ed2c" name="Warlord" hidden="false" collective="false" import="true" targetId="33f6-60da-7b70-5fee" type="selectionEntry">
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="bd13-4390-d59f-3e12" type="max"/>
-          </constraints>
-        </entryLink>
-        <entryLink id="8b98-8f46-a1cb-7ea0" name="Warlord Traits (BRB)" hidden="false" collective="false" import="true" targetId="d442-1f03-d9da-e77f" type="selectionEntryGroup">
-          <modifiers>
-            <modifier type="set" field="hidden" value="true">
-              <conditions>
-                <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="33f6-60da-7b70-5fee" type="equalTo"/>
-              </conditions>
-            </modifier>
-          </modifiers>
-        </entryLink>
+        <entryLink id="372a-3230-f763-ed2c" name="Warlord" hidden="false" collective="false" import="true" targetId="1f07-a468-bda8-fd3f" type="selectionEntry"/>
         <entryLink id="ba26-55a1-4031-459f" name="Is A Custom Character" hidden="false" collective="false" import="true" targetId="43c4-8968-c599-ad5f" type="selectionEntry"/>
         <entryLink id="8c80-aeea-bf41-ea85" name="Custom Character Selections" hidden="false" collective="false" import="true" targetId="8774-e003-4a50-56c7" type="selectionEntryGroup"/>
+        <entryLink id="eef8-5e0d-fb1f-bd9c" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="d6e2-a400-a8db-d4f2" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="points" value="20.0"/>
@@ -5020,20 +4949,12 @@
         </entryLink>
         <entryLink id="ba28-3204-5740-fb2b" name="Display Astra Militarum Orders" hidden="false" collective="false" import="true" targetId="7d8c-221c-99c5-97d2" type="selectionEntry"/>
         <entryLink id="6a1e-9526-8a64-7ea5" name="HEIRLOOMS OF CONQUEST" hidden="false" collective="false" import="true" targetId="8ed7-7588-0f06-9b0d" type="selectionEntryGroup"/>
-        <entryLink id="b3e1-8892-5000-dd59" name="Warlord" hidden="false" collective="false" import="true" targetId="33f6-60da-7b70-5fee" type="selectionEntry">
+        <entryLink id="b3e1-8892-5000-dd59" name="Warlord" hidden="false" collective="false" import="true" targetId="1f07-a468-bda8-fd3f" type="selectionEntry">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="8986-dd41-706d-7e56" type="max"/>
           </constraints>
         </entryLink>
-        <entryLink id="4dbc-e1f9-80c6-9d29" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="d6e2-a400-a8db-d4f2" type="selectionEntryGroup">
-          <modifiers>
-            <modifier type="set" field="hidden" value="true">
-              <conditions>
-                <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="33f6-60da-7b70-5fee" type="equalTo"/>
-              </conditions>
-            </modifier>
-          </modifiers>
-        </entryLink>
+        <entryLink id="4dbc-e1f9-80c6-9d29" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="d6e2-a400-a8db-d4f2" type="selectionEntryGroup"/>
         <entryLink id="cfc3-facb-f499-200b" name="Emperor&apos;s Blade" hidden="true" collective="false" import="true" targetId="0293-3499-c2d4-086e" type="selectionEntry">
           <modifiers>
             <modifier type="set" field="hidden" value="false">
@@ -5161,21 +5082,17 @@
           </constraints>
         </entryLink>
         <entryLink id="f82a-ecde-6a99-7cf4" name="Astra Militarum Orders" hidden="false" collective="false" import="true" targetId="7d8c-221c-99c5-97d2" type="selectionEntry"/>
-        <entryLink id="a914-2557-bdc5-2a8b" name="Warlord" hidden="false" collective="false" import="true" targetId="33f6-60da-7b70-5fee" type="selectionEntry">
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="d3db-a3e9-a061-1056" type="max"/>
-          </constraints>
-        </entryLink>
+        <entryLink id="a914-2557-bdc5-2a8b" name="Warlord" hidden="false" collective="false" import="true" targetId="1f07-a468-bda8-fd3f" type="selectionEntry"/>
         <entryLink id="eb5c-76df-617a-c27b" name="WT (Catachan): Lead From the Front" hidden="false" collective="false" import="true" targetId="1fff-d44f-98e9-609c" type="selectionEntry">
           <modifiers>
             <modifier type="set" field="hidden" value="true">
               <conditions>
-                <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="33f6-60da-7b70-5fee" type="equalTo"/>
+                <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="1f07-a468-bda8-fd3f" type="equalTo"/>
               </conditions>
             </modifier>
-            <modifier type="set" field="3e76-cfbb-40c4-db29" value="1">
+            <modifier type="set" field="3e76-cfbb-40c4-db29" value="1.0">
               <conditions>
-                <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="33f6-60da-7b70-5fee" type="equalTo"/>
+                <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="1f07-a468-bda8-fd3f" type="equalTo"/>
               </conditions>
             </modifier>
           </modifiers>
@@ -5250,21 +5167,17 @@
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3e37-4293-6256-d677" type="max"/>
           </constraints>
         </entryLink>
-        <entryLink id="e1e2-a2fa-735d-d19e" name="Warlord" hidden="false" collective="false" import="true" targetId="33f6-60da-7b70-5fee" type="selectionEntry">
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="ea72-3660-567d-015c" type="max"/>
-          </constraints>
-        </entryLink>
+        <entryLink id="e1e2-a2fa-735d-d19e" name="Warlord" hidden="false" collective="false" import="true" targetId="1f07-a468-bda8-fd3f" type="selectionEntry"/>
         <entryLink id="1c5a-f44f-2f70-b9d3" name="WT: Superior Tactical Training" hidden="false" collective="false" import="true" targetId="8d6d-9c06-8025-de58" type="selectionEntry">
           <modifiers>
             <modifier type="set" field="hidden" value="true">
               <conditions>
-                <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="33f6-60da-7b70-5fee" type="equalTo"/>
+                <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="1f07-a468-bda8-fd3f" type="equalTo"/>
               </conditions>
             </modifier>
             <modifier type="set" field="b22a-3765-9e14-fb22" value="1">
               <conditions>
-                <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="33f6-60da-7b70-5fee" type="equalTo"/>
+                <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="1f07-a468-bda8-fd3f" type="equalTo"/>
               </conditions>
             </modifier>
           </modifiers>
@@ -6093,21 +6006,9 @@
           </constraints>
         </entryLink>
         <entryLink id="5004-39f9-d15e-5f6e" name="Display Astra Militarum Orders" hidden="false" collective="false" import="true" targetId="7d8c-221c-99c5-97d2" type="selectionEntry"/>
-        <entryLink id="144e-6efe-9f92-ad71" name="Warlord" hidden="false" collective="false" import="true" targetId="33f6-60da-7b70-5fee" type="selectionEntry">
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="bc28-9a9c-e246-b191" type="max"/>
-          </constraints>
-        </entryLink>
+        <entryLink id="144e-6efe-9f92-ad71" name="Warlord" hidden="false" collective="false" import="true" targetId="1f07-a468-bda8-fd3f" type="selectionEntry"/>
         <entryLink id="56f2-3637-22e9-b1c0" name="Heirlooms of Conquest" hidden="false" collective="false" import="true" targetId="8ed7-7588-0f06-9b0d" type="selectionEntryGroup"/>
-        <entryLink id="dfad-4604-447d-c0d0" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="d6e2-a400-a8db-d4f2" type="selectionEntryGroup">
-          <modifiers>
-            <modifier type="set" field="hidden" value="true">
-              <conditions>
-                <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="33f6-60da-7b70-5fee" type="equalTo"/>
-              </conditions>
-            </modifier>
-          </modifiers>
-        </entryLink>
+        <entryLink id="dfad-4604-447d-c0d0" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="d6e2-a400-a8db-d4f2" type="selectionEntryGroup"/>
         <entryLink id="e761-8109-2404-44d1" name="Tempestus Drop Force" hidden="true" collective="false" import="true" targetId="2109-f06d-a289-8dfb" type="selectionEntry">
           <modifiers>
             <modifier type="set" field="hidden" value="false">
@@ -6455,22 +6356,14 @@
         <entryLink id="a11f-39be-c0fe-6dd9" name="Russ Hull Weapon" hidden="false" collective="false" import="true" targetId="5bed-1f36-dd00-bd20" type="selectionEntryGroup"/>
         <entryLink id="708b-6c98-d20e-378e" name="Turret Cannon" hidden="false" collective="false" import="true" targetId="033c-c12e-bdf2-bc9e" type="selectionEntryGroup"/>
         <entryLink id="22ba-efc8-5212-e585" name="Display Tank Orders" hidden="false" collective="false" import="true" targetId="61ed-ee78-e2e8-556c" type="selectionEntry"/>
-        <entryLink id="c9f8-5189-343e-a73c" name="Warlord" hidden="false" collective="false" import="true" targetId="33f6-60da-7b70-5fee" type="selectionEntry">
+        <entryLink id="c9f8-5189-343e-a73c" name="Warlord" hidden="false" collective="false" import="true" targetId="1f07-a468-bda8-fd3f" type="selectionEntry">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="c218-f41e-58b7-a50d" type="max"/>
           </constraints>
         </entryLink>
         <entryLink id="2f48-9469-77ab-8a36" name="Heirlooms of Conquest" hidden="false" collective="false" import="true" targetId="8ed7-7588-0f06-9b0d" type="selectionEntryGroup"/>
         <entryLink id="9ebd-26ba-bcdd-6e38" name="Vehicle Equipment List" hidden="false" collective="false" import="true" targetId="d9f1-0505-984e-c749" type="selectionEntryGroup"/>
-        <entryLink id="68ce-2664-95dd-95ad" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="d6e2-a400-a8db-d4f2" type="selectionEntryGroup">
-          <modifiers>
-            <modifier type="set" field="hidden" value="true">
-              <conditions>
-                <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="33f6-60da-7b70-5fee" type="equalTo"/>
-              </conditions>
-            </modifier>
-          </modifiers>
-        </entryLink>
+        <entryLink id="68ce-2664-95dd-95ad" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="d6e2-a400-a8db-d4f2" type="selectionEntryGroup"/>
         <entryLink id="74b0-b9b7-a340-88b0" name="Emperor&apos;s Fist" hidden="true" collective="false" import="true" targetId="d20c-3e6b-56ab-2664" type="selectionEntry">
           <modifiers>
             <modifier type="set" field="hidden" value="false">
@@ -7885,21 +7778,17 @@
         <entryLink id="f878-d6c4-ca11-7a3f" name="Pintle Mount" hidden="false" collective="false" import="true" targetId="ebb9-dadc-c98d-9b62" type="selectionEntryGroup"/>
         <entryLink id="766b-8fa5-004b-993b" name="Turret Cannon" hidden="false" collective="false" import="true" targetId="033c-c12e-bdf2-bc9e" type="selectionEntryGroup"/>
         <entryLink id="d4f4-54cf-0e83-ee61" name="Tank Orders" hidden="false" collective="false" import="true" targetId="61ed-ee78-e2e8-556c" type="selectionEntry"/>
-        <entryLink id="5127-7da2-5e08-59b8" name="Warlord" hidden="false" collective="false" import="true" targetId="33f6-60da-7b70-5fee" type="selectionEntry">
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="191e-188d-39a8-9d21" type="max"/>
-          </constraints>
-        </entryLink>
+        <entryLink id="5127-7da2-5e08-59b8" name="Warlord" hidden="false" collective="false" import="true" targetId="1f07-a468-bda8-fd3f" type="selectionEntry"/>
         <entryLink id="bba1-a6d6-1a5d-77fb" name="WT: Superior Tactical Training" hidden="false" collective="false" import="true" targetId="8d6d-9c06-8025-de58" type="selectionEntry">
           <modifiers>
             <modifier type="set" field="hidden" value="true">
               <conditions>
-                <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="33f6-60da-7b70-5fee" type="equalTo"/>
+                <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="1f07-a468-bda8-fd3f" type="equalTo"/>
               </conditions>
             </modifier>
             <modifier type="set" field="1007-d3f8-6b94-d5d9" value="1">
               <conditions>
-                <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="33f6-60da-7b70-5fee" type="equalTo"/>
+                <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="1f07-a468-bda8-fd3f" type="equalTo"/>
               </conditions>
             </modifier>
           </modifiers>
@@ -15864,22 +15753,10 @@
           </constraints>
         </entryLink>
         <entryLink id="900b-eaf3-be7f-d4cc" name="Heirlooms of Conquest" hidden="false" collective="false" import="true" targetId="8ed7-7588-0f06-9b0d" type="selectionEntryGroup"/>
-        <entryLink id="e9df-43d2-1bd9-0ef3" name="Warlord Traits (BRB)" hidden="false" collective="false" import="true" targetId="d442-1f03-d9da-e77f" type="selectionEntryGroup">
-          <modifiers>
-            <modifier type="set" field="hidden" value="true">
-              <conditions>
-                <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="33f6-60da-7b70-5fee" type="equalTo"/>
-              </conditions>
-            </modifier>
-          </modifiers>
-        </entryLink>
-        <entryLink id="db57-5bf4-857d-dd99" name="Warlord" hidden="false" collective="false" import="true" targetId="33f6-60da-7b70-5fee" type="selectionEntry">
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="de71-fcde-b972-107f" type="max"/>
-          </constraints>
-        </entryLink>
+        <entryLink id="db57-5bf4-857d-dd99" name="Warlord" hidden="false" collective="false" import="true" targetId="1f07-a468-bda8-fd3f" type="selectionEntry"/>
         <entryLink id="4791-8f48-fb53-5ca9" name="Is A Custom Character" hidden="false" collective="false" import="true" targetId="43c4-8968-c599-ad5f" type="selectionEntry"/>
         <entryLink id="aa28-1d3e-7cce-9ca5" name="Custom Character Selections" hidden="false" collective="false" import="true" targetId="8774-e003-4a50-56c7" type="selectionEntryGroup"/>
+        <entryLink id="3323-4fed-d5e6-6e8f" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="d6e2-a400-a8db-d4f2" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="points" value="26.0"/>
@@ -15981,22 +15858,10 @@
           </constraints>
         </entryLink>
         <entryLink id="3c0f-e785-850c-4ad7" name="HEIRLOOMS OF CONQUEST" hidden="false" collective="false" import="true" targetId="8ed7-7588-0f06-9b0d" type="selectionEntryGroup"/>
-        <entryLink id="65fb-6d22-868b-2019" name="Warlord Traits (BRB)" hidden="false" collective="false" import="true" targetId="d442-1f03-d9da-e77f" type="selectionEntryGroup">
-          <modifiers>
-            <modifier type="set" field="hidden" value="true">
-              <conditions>
-                <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="33f6-60da-7b70-5fee" type="equalTo"/>
-              </conditions>
-            </modifier>
-          </modifiers>
-        </entryLink>
-        <entryLink id="7665-5e94-692a-e041" name="Warlord" hidden="false" collective="false" import="true" targetId="33f6-60da-7b70-5fee" type="selectionEntry">
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="c863-88a3-fd96-04ac" type="max"/>
-          </constraints>
-        </entryLink>
+        <entryLink id="7665-5e94-692a-e041" name="Warlord" hidden="false" collective="false" import="true" targetId="1f07-a468-bda8-fd3f" type="selectionEntry"/>
         <entryLink id="13b1-9906-89a4-9a7f" name="Is A Custom Character" hidden="false" collective="false" import="true" targetId="43c4-8968-c599-ad5f" type="selectionEntry"/>
         <entryLink id="aadb-103c-e86c-396b" name="Custom Character Selections" hidden="false" collective="false" import="true" targetId="8774-e003-4a50-56c7" type="selectionEntryGroup"/>
+        <entryLink id="a773-2d8d-c244-05cb" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="d6e2-a400-a8db-d4f2" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="points" value="38.0"/>
@@ -16219,39 +16084,6 @@
             </entryLink>
           </entryLinks>
         </selectionEntryGroup>
-        <selectionEntryGroup id="a8da-f0ab-3693-6281" name="Warlord Traits" hidden="false" collective="false" import="true">
-          <modifiers>
-            <modifier type="set" field="hidden" value="true">
-              <conditions>
-                <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="33f6-60da-7b70-5fee" type="equalTo"/>
-              </conditions>
-            </modifier>
-          </modifiers>
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="d810-8f37-4fc3-393f" type="max"/>
-          </constraints>
-          <selectionEntryGroups>
-            <selectionEntryGroup id="eb64-e839-f1dd-e969" name="Warlord Traits" hidden="false" collective="false" import="true">
-              <modifiers>
-                <modifier type="set" field="hidden" value="true">
-                  <conditions>
-                    <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="33f6-60da-7b70-5fee" type="equalTo"/>
-                  </conditions>
-                </modifier>
-              </modifiers>
-              <constraints>
-                <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="f662-2c39-d225-2a43" type="max"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5758-8d4d-9d1f-6b80" type="max"/>
-              </constraints>
-              <entryLinks>
-                <entryLink id="957b-baf1-a4a8-63a5" name="WT (Emperor&apos;s Conclave): Fiery Denouncer" hidden="false" collective="false" import="true" targetId="0221-1c21-bf8a-e8dd" type="selectionEntry"/>
-              </entryLinks>
-            </selectionEntryGroup>
-          </selectionEntryGroups>
-          <entryLinks>
-            <entryLink id="377a-d853-f5ab-93e1" name="Warlord Traits (BRB)" hidden="false" collective="false" import="true" targetId="d442-1f03-d9da-e77f" type="selectionEntryGroup"/>
-          </entryLinks>
-        </selectionEntryGroup>
       </selectionEntryGroups>
       <entryLinks>
         <entryLink id="625b-5649-8169-146a" name="Frag &amp; Krak grenades" hidden="false" collective="false" import="true" targetId="cddf-945e-1335-e681" type="selectionEntry">
@@ -16261,11 +16093,6 @@
           </constraints>
         </entryLink>
         <entryLink id="c0c7-00c6-0e99-53b7" name="HEIRLOOMS OF CONQUEST" hidden="false" collective="false" import="true" targetId="8ed7-7588-0f06-9b0d" type="selectionEntryGroup"/>
-        <entryLink id="d7d0-437e-937f-738b" name="Warlord" hidden="false" collective="false" import="true" targetId="33f6-60da-7b70-5fee" type="selectionEntry">
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="9644-a419-121c-91ee" type="max"/>
-          </constraints>
-        </entryLink>
         <entryLink id="4271-c89c-45ac-3a0d" name="Emperor&apos;s Conclave" hidden="true" collective="false" import="true" targetId="83c4-09e6-455b-3b77" type="selectionEntry">
           <modifiers>
             <modifier type="set" field="hidden" value="false">
@@ -16281,6 +16108,8 @@
         <entryLink id="d7c8-9061-7a2b-1c48" name="Vigilus Field Commander WLT" hidden="true" collective="false" import="true" targetId="a636-ec69-8616-b2b4" type="selectionEntryGroup"/>
         <entryLink id="ee1f-a831-cd36-1006" name="Is A Custom Character" hidden="false" collective="false" import="true" targetId="43c4-8968-c599-ad5f" type="selectionEntry"/>
         <entryLink id="ad17-67e3-b8e6-8a50" name="Custom Character Selections" hidden="false" collective="false" import="true" targetId="8774-e003-4a50-56c7" type="selectionEntryGroup"/>
+        <entryLink id="5a0d-6d6a-1bbe-47ec" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="d6e2-a400-a8db-d4f2" type="selectionEntryGroup"/>
+        <entryLink id="9e5e-1145-223a-7617" name="Warlord" hidden="false" collective="false" import="true" targetId="1f07-a468-bda8-fd3f" type="selectionEntry"/>
       </entryLinks>
       <costs>
         <cost name=" PL" typeId="e356-c769-5920-6e14" value="2.0"/>
@@ -16483,20 +16312,8 @@
           </constraints>
         </entryLink>
         <entryLink id="ec2e-e746-c1a9-f7ef" name="HEIRLOOMS OF CONQUEST" hidden="false" collective="false" import="true" targetId="8ed7-7588-0f06-9b0d" type="selectionEntryGroup"/>
-        <entryLink id="5ae7-6d2d-8543-5245" name="Warlord" hidden="false" collective="false" import="true" targetId="33f6-60da-7b70-5fee" type="selectionEntry">
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="29ca-3e22-e082-e5b7" type="max"/>
-          </constraints>
-        </entryLink>
-        <entryLink id="a022-066a-c6bf-89b6" name="Warlord Traits (BRB)" hidden="false" collective="false" import="true" targetId="d442-1f03-d9da-e77f" type="selectionEntryGroup">
-          <modifiers>
-            <modifier type="set" field="hidden" value="true">
-              <conditions>
-                <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="33f6-60da-7b70-5fee" type="equalTo"/>
-              </conditions>
-            </modifier>
-          </modifiers>
-        </entryLink>
+        <entryLink id="5ae7-6d2d-8543-5245" name="Warlord" hidden="false" collective="false" import="true" targetId="1f07-a468-bda8-fd3f" type="selectionEntry"/>
+        <entryLink id="a022-066a-c6bf-89b6" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="d6e2-a400-a8db-d4f2" type="selectionEntryGroup"/>
         <entryLink id="b650-6ddd-6511-4adb" name="Is A Custom Character" hidden="false" collective="false" import="true" targetId="43c4-8968-c599-ad5f" type="selectionEntry"/>
         <entryLink id="c13b-4e0f-aa7f-ba61" name="Custom Character Selections" hidden="false" collective="false" import="true" targetId="8774-e003-4a50-56c7" type="selectionEntryGroup"/>
       </entryLinks>
@@ -17790,6 +17607,7 @@
               <conditions>
                 <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="6e6d-3f5b-3aac-ac75" type="lessThan"/>
                 <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="bc9e-551d-9afb-78d5" type="lessThan"/>
+                <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="3e01-e6cf-1353-96f4" type="notInstanceOf"/>
               </conditions>
             </conditionGroup>
           </conditionGroups>
@@ -17853,6 +17671,7 @@
               <conditions>
                 <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="35a8-2621-55f2-062d" type="lessThan"/>
                 <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="bc9e-551d-9afb-78d5" type="lessThan"/>
+                <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="3e01-e6cf-1353-96f4" type="notInstanceOf"/>
               </conditions>
             </conditionGroup>
           </conditionGroups>
@@ -17892,6 +17711,7 @@
               <conditions>
                 <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a8ba-5296-cc59-3ab6" type="lessThan"/>
                 <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0334-f487-8229-0c1a" type="lessThan"/>
+                <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="3e01-e6cf-1353-96f4" type="notInstanceOf"/>
               </conditions>
             </conditionGroup>
           </conditionGroups>
@@ -17931,6 +17751,7 @@
               <conditions>
                 <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="712b-372f-76c3-ebe8" type="lessThan"/>
                 <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3d52-fccf-10c0-3fae" type="notInstanceOf"/>
+                <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="3e01-e6cf-1353-96f4" type="notInstanceOf"/>
               </conditions>
             </conditionGroup>
           </conditionGroups>
@@ -17955,9 +17776,14 @@
     <selectionEntry id="5ae2-c4d2-05bc-a16f" name="Relic (Militarum Tempestus): The Tactical Auto-Reliquary of Tyberius" hidden="false" collective="false" import="true" type="upgrade">
       <modifiers>
         <modifier type="set" field="hidden" value="true">
-          <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="91ce-e3b2-1f66-8690" type="lessThan"/>
-          </conditions>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <conditions>
+                <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="3e01-e6cf-1353-96f4" type="notInstanceOf"/>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="91ce-e3b2-1f66-8690" type="lessThan"/>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
         </modifier>
       </modifiers>
       <constraints>
@@ -17979,9 +17805,14 @@
     <selectionEntry id="0cbc-fba4-2e32-1813" name="Relic (Cadia): Relic of Lost Cadia" hidden="false" collective="false" import="true" type="upgrade">
       <modifiers>
         <modifier type="set" field="hidden" value="true">
-          <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ef96-6f0e-04be-8b2c" type="lessThan"/>
-          </conditions>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ef96-6f0e-04be-8b2c" type="lessThan"/>
+                <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="3e01-e6cf-1353-96f4" type="notInstanceOf"/>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
         </modifier>
       </modifiers>
       <constraints>
@@ -18069,6 +17900,7 @@
               <conditions>
                 <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7b6d-9d03-763e-4d41" type="lessThan"/>
                 <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3d52-fccf-10c0-3fae" type="notInstanceOf"/>
+                <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="3e01-e6cf-1353-96f4" type="notInstanceOf"/>
               </conditions>
             </conditionGroup>
           </conditionGroups>
@@ -19146,25 +18978,27 @@
         </selectionEntry>
       </selectionEntries>
       <entryLinks>
-        <entryLink id="d36a-1ea4-4647-a178" name="Warlord" hidden="false" collective="false" import="true" targetId="33f6-60da-7b70-5fee" type="selectionEntry">
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2df6-7d28-9901-666c" type="max"/>
-          </constraints>
-        </entryLink>
-        <entryLink id="c9eb-ae26-a51e-04a1" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="d6e2-a400-a8db-d4f2" type="selectionEntryGroup">
-          <modifiers>
-            <modifier type="set" field="hidden" value="true">
-              <conditions>
-                <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="33f6-60da-7b70-5fee" type="equalTo"/>
-              </conditions>
-            </modifier>
-          </modifiers>
-        </entryLink>
+        <entryLink id="d36a-1ea4-4647-a178" name="Warlord" hidden="false" collective="false" import="true" targetId="1f07-a468-bda8-fd3f" type="selectionEntry"/>
+        <entryLink id="c9eb-ae26-a51e-04a1" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="d6e2-a400-a8db-d4f2" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
         <cost name=" PL" typeId="e356-c769-5920-6e14" value="3.0"/>
         <cost name="pts" typeId="points" value="36.0"/>
         <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="1f07-a468-bda8-fd3f" name="Warlord" hidden="false" collective="false" import="true" type="upgrade">
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="000a-cf6d-4c86-a749" type="max"/>
+        <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="010b-c4e3-7372-fcb7" type="max"/>
+      </constraints>
+      <categoryLinks>
+        <categoryLink id="d1f8-9bee-7113-7338" name="Warlord" hidden="false" targetId="ae09-117e-a6fa-316b" primary="false"/>
+      </categoryLinks>
+      <costs>
+        <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0"/>
+        <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
+        <cost name="pts" typeId="points" value="0.0"/>
       </costs>
     </selectionEntry>
   </sharedSelectionEntries>
@@ -20139,7 +19973,7 @@
           <conditionGroups>
             <conditionGroup type="and">
               <conditions>
-                <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="ae09-117e-a6fa-316b" type="lessThan"/>
+                <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="1f07-a468-bda8-fd3f" type="lessThan"/>
                 <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="d7be-7049-0cc9-dcf3" type="lessThan"/>
               </conditions>
             </conditionGroup>
@@ -20160,7 +19994,7 @@
             <conditionGroup type="and">
               <conditions>
                 <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="d7be-7049-0cc9-dcf3" type="lessThan"/>
-                <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="ae09-117e-a6fa-316b" type="lessThan"/>
+                <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="1f07-a468-bda8-fd3f" type="lessThan"/>
               </conditions>
             </conditionGroup>
           </conditionGroups>
@@ -20389,7 +20223,14 @@
         </entryLink>
       </entryLinks>
     </selectionEntryGroup>
-    <selectionEntryGroup id="d6e2-a400-a8db-d4f2" name="Warlord Traits" hidden="false" collective="false" import="true">
+    <selectionEntryGroup id="d6e2-a400-a8db-d4f2" name="Warlord Traits" hidden="true" collective="false" import="true">
+      <modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <conditions>
+            <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1f07-a468-bda8-fd3f" type="equalTo"/>
+          </conditions>
+        </modifier>
+      </modifiers>
       <constraints>
         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="bed7-65c6-5ef5-566f" type="max"/>
       </constraints>
@@ -20397,9 +20238,15 @@
         <selectionEntryGroup id="c22c-df46-53a4-6177" name="Warlord Traits" hidden="false" collective="false" import="true">
           <modifiers>
             <modifier type="set" field="hidden" value="true">
-              <conditions>
-                <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="33f6-60da-7b70-5fee" type="equalTo"/>
-              </conditions>
+              <conditionGroups>
+                <conditionGroup type="and">
+                  <conditions>
+                    <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="5988-2982-1dde-215b" type="notInstanceOf"/>
+                    <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="3e01-e6cf-1353-96f4" type="notInstanceOf"/>
+                    <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="3984-854b-4603-be64" type="notInstanceOf"/>
+                  </conditions>
+                </conditionGroup>
+              </conditionGroups>
             </modifier>
           </modifiers>
           <constraints>
@@ -20588,7 +20435,7 @@
           <conditionGroups>
             <conditionGroup type="and">
               <conditions>
-                <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="33f6-60da-7b70-5fee" type="equalTo"/>
+                <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="1f07-a468-bda8-fd3f" type="equalTo"/>
                 <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="9961-bfca-b70f-a303" type="equalTo"/>
               </conditions>
               <conditionGroups>


### PR DESCRIPTION
Rework of AM Relics and WLTs to trigger off a local "Warlord" entry to prevent cross-faction Warlords unlocking Relics.

All eligible characters have been updated to use the new entry, as has all validation.