### PR TITLE
DV Crimson fixes

### DIFF
--- a/Chaos - Chaos Space Marines.cat
+++ b/Chaos - Chaos Space Marines.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="cb54-c035-5759-7697" name="Chaos - Chaos Space Marines" revision="108" battleScribeVersion="2.03" authorName="BSData Developers" authorContact="@Mad_Spy" authorUrl="https://discord.gg/KqPVhds" library="false" gameSystemId="28ec-711c-d87f-3aeb" gameSystemRevision="1" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="cb54-c035-5759-7697" name="Chaos - Chaos Space Marines" revision="109" battleScribeVersion="2.03" authorName="BSData Developers" authorContact="@Mad_Spy" authorUrl="https://discord.gg/KqPVhds" library="false" gameSystemId="28ec-711c-d87f-3aeb" gameSystemRevision="1" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <publications>
     <publication id="cb54-c035-pubN85174" name="Escalation"/>
     <publication id="cb54-c035-pubN125652" name="Codex: Heretic Astartes - Chaos Space Marines"/>
@@ -10206,6 +10206,7 @@ If this unit makes a charge move, is charged or performs a Heroic Intervention, 
               <conditions>
                 <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7049-f86b-e228-bbaf" type="equalTo"/>
                 <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="c4a9-5a33-d824-bcf8" type="equalTo"/>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="99d7-f254-4967-afe4" type="equalTo"/>
               </conditions>
             </conditionGroup>
           </conditionGroups>
@@ -10294,6 +10295,7 @@ If this unit makes a charge move, is charged or performs a Heroic Intervention, 
               <conditions>
                 <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7049-f86b-e228-bbaf" type="equalTo"/>
                 <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="c4a9-5a33-d824-bcf8" type="equalTo"/>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="99d7-f254-4967-afe4" type="equalTo"/>
               </conditions>
             </conditionGroup>
           </conditionGroups>
@@ -10367,9 +10369,15 @@ If this unit makes a charge move, is charged or performs a Heroic Intervention, 
     <selectionEntry id="551b-c441-ba4d-f592" name="Draznicht&apos;s Ravagers" hidden="false" collective="false" import="true" type="unit">
       <modifiers>
         <modifier type="set" field="702a-3b56-7559-60fe" value="0.0">
-          <conditions>
-            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="c4a9-5a33-d824-bcf8" type="equalTo"/>
-          </conditions>
+          <conditionGroups>
+            <conditionGroup type="and">
+              <conditions>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7049-f86b-e228-bbaf" type="equalTo"/>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="c4a9-5a33-d824-bcf8" type="equalTo"/>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="99d7-f254-4967-afe4" type="equalTo"/>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
         </modifier>
       </modifiers>
       <constraints>


### PR DESCRIPTION
Looks like Kranon and Vrosh were allowed in "Renegade" and "No Legion" whereas Ravagers were only allowed in "No Legion"?

This pull request "fixes" the three named units to all be accepted in "Renegade" / "No Legion" / "Crimson" and bumps the Chaos version to v109