### PR TITLE
corrected grot orderly typo

### DIFF
--- a/Orks.cat
+++ b/Orks.cat
@@ -1511,7 +1511,7 @@
         </profile>
         <profile id="1ffd-2d16-f0d9-cc92" name="Grot Orderly" hidden="false" typeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" typeName="Abilities">
           <characteristics>
-            <characteristic name="Description" typeId="21befb24-fc85-4f52-a745-64b2e48f8228">Once per game, when the Painboy is attempting to heal a model using Dok&apos;s Tools, you may re-roll the dice, either when determining if the surgery is successful, or when calculating the number of wounds regained.  When rolling to wound this unit, always use the Painboy&apos;s Toughness (while it is on the battlefield).  The death of a Grot Orderly is ignored for the purposes of morale.  the Grot Oiler is considered to have the CHARACTER keyword for the purposes of shooting attacks.</characteristic>
+            <characteristic name="Description" typeId="21befb24-fc85-4f52-a745-64b2e48f8228">Once per game, when the Painboy is attempting to heal a model using Dok&apos;s Tools, you may re-roll the dice, either when determining if the surgery is successful, or when calculating the number of wounds regained.  When rolling to wound this unit, always use the Painboy&apos;s Toughness (while it is on the battlefield).  The death of a Grot Orderly is ignored for the purposes of morale.  The Grot Orderly is considered to have the CHARACTER keyword for the purposes of shooting attacks.</characteristic>
           </characteristics>
         </profile>
       </profiles>

--- a/Orks.cat
+++ b/Orks.cat
@@ -1511,7 +1511,7 @@
         </profile>
         <profile id="1ffd-2d16-f0d9-cc92" name="Grot Orderly" hidden="false" typeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" typeName="Abilities">
           <characteristics>
-            <characteristic name="Description" typeId="21befb24-fc85-4f52-a745-64b2e48f8228">Once per game, when the Painboy is attempting to heal a model using Dok&apos;s Tools, you may re-roll the dice, either when determining if the surgery is successful, or when calculating the number of wounds regained.  When rolling to wound this unit, always use the Painboy&apos;s Toughness (while it is on the battlefield).  The death of a Grot Orderly is ignored for the purposes of morale.  The Grot Orderly is considered to have the CHARACTER keyword for the purposes of shooting attacks.</characteristic>
+            <characteristic name="Description" typeId="21befb24-fc85-4f52-a745-64b2e48f8228">Once per game, when the Painboy is attempting to heal a model using Dok&apos;s Tools, you may re-roll the dice, either when determining if the surgery is successful, or when calculating the number of wounds regained.  When rolling to wound this unit, always use the Painboy&apos;s Toughness (while it is on the battlefield). The death of a Grot Orderly is ignored for the purposes of morale. The Grot Orderly is considered to have the CHARACTER keyword for the purposes of shooting attacks.</characteristic>
           </characteristics>
         </profile>
       </profiles>


### PR DESCRIPTION
The "grot orderly" was referred to as a "grot oiler" at the end of his blurb