### PR TITLE
Update Aeldari - Craftworlds.cat

### DIFF
--- a/Aeldari - Craftworlds.cat
+++ b/Aeldari - Craftworlds.cat
@@ -14912,7 +14912,7 @@ unit can emerge from the webway – set this unit up anywhere on the battlefield
                   <conditions>
                     <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1409-e740-c7c9-3758" type="greaterThan"/>
                     <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="c0ea-f722-6a2e-6d65" type="greaterThan"/>
-                    <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ff5c-6397-4052-63eb" type="greaterThan"/>
+                    <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="6c95-9f0a-0951-30ab" type="greaterThan"/>
                   </conditions>
                 </conditionGroup>
               </conditionGroups>

--- a/Aeldari - Ynnari.cat
+++ b/Aeldari - Ynnari.cat
@@ -133,7 +133,7 @@
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0365-6f3a-f47c-4a8b" type="max"/>
           </constraints>
         </entryLink>
-        <entryLink id="3180-c2f3-1d21-1418" name="Favoured of Ynnead" hidden="true" collective="false" import="true" targetId="e382-0294-a92d-3a16" type="selectionEntry">
+        <entryLink id="3180-c2f3-1d21-1418" name="Warden of Souls" hidden="true" collective="false" import="true" targetId="b252-9455-6755-4fbd" type="selectionEntry">
           <modifiers>
             <modifier type="set" field="hidden" value="false">
               <conditions>


### PR DESCRIPTION
Update to allow visarch to trigger ynnari options in craftsworld detachments. For some reason Atom added an extra new line at the end of Aeldari - Craftworlds.cat. 