### PR TITLE
Blood Angels: Update Aggressors to use the same weapon selection style as Inceptors.

### DIFF
--- a/Imperium - Blood Angels.cat
+++ b/Imperium - Blood Angels.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="eb0f-c144-a282-8bdc" name="Imperium - Blood Angels" revision="150" battleScribeVersion="2.03" authorName="BSData Developers" authorContact="Discord: @Alphalas | Twitter: @_alphalas" authorUrl="https://discord.gg/KqPVhds" library="false" gameSystemId="28ec-711c-d87f-3aeb" gameSystemRevision="128" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="eb0f-c144-a282-8bdc" name="Imperium - Blood Angels" revision="151" battleScribeVersion="2.03" authorName="BSData Developers" authorContact="Discord: @Alphalas | Twitter: @_alphalas" authorUrl="https://discord.gg/KqPVhds" library="false" gameSystemId="28ec-711c-d87f-3aeb" gameSystemRevision="128" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <publications>
     <publication id="eb0f-c144-pubN65537" name="Codex: Blood Angels"/>
     <publication id="eb0f-c144-pubN68947" name="Index: Imperium 1"/>
@@ -11219,9 +11219,7 @@
         </profile>
       </profiles>
       <infoLinks>
-        <infoLink id="599e-0455-1758-00cf" name="And They Shall Know No Fear" hidden="false" targetId="4ea8-94d3-ba39-042f" type="rule"/>
         <infoLink id="5b5a-0198-e6a8-d022" name="Fire Storm" hidden="false" targetId="756c-a18b-4533-1e7f" type="profile"/>
-        <infoLink id="6744-7011-7103-cdfb" name="Shock Assault" hidden="false" targetId="9267-1813-3c68-416d" type="profile"/>
         <infoLink id="5e20-79d8-a4b3-f83d" name="Relentless Advance" hidden="false" targetId="b53a-b90c-47a1-cf73" type="profile"/>
         <infoLink id="3e06-e8d1-9f89-4466" name="Savage Echoes" hidden="false" targetId="3006-d1b9-c324-c9be" type="rule"/>
         <infoLink id="e9ba-63b2-86c5-71be" name="Angels of Death" hidden="false" targetId="9106-b297-021a-4d72" type="rule"/>
@@ -11249,47 +11247,6 @@
           <infoLinks>
             <infoLink id="5c0c-03fa-ee9e-594f" name="Aggressor" hidden="false" targetId="7f68-38f5-efb4-16c1" type="profile"/>
           </infoLinks>
-          <selectionEntryGroups>
-            <selectionEntryGroup id="f68f-d2d2-5bc5-c242" name="Weapons" hidden="false" collective="true" import="true" defaultSelectionEntryId="5fbc-9176-bfb5-0dc6">
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a659-a042-ca53-d746" type="min"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3a8c-50f3-c866-5e8b" type="max"/>
-              </constraints>
-              <selectionEntries>
-                <selectionEntry id="5fbc-9176-bfb5-0dc6" name="Auto boltstorm gauntlets and fragstorm grenade launcher" hidden="false" collective="true" import="true" type="upgrade">
-                  <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="668a-4e64-af1d-dc6f" type="max"/>
-                  </constraints>
-                  <entryLinks>
-                    <entryLink id="edb6-4ca7-50f6-850b" name="Auto boltstorm gauntlets" hidden="false" collective="false" import="true" targetId="99d2-d806-5ba5-fac9" type="selectionEntry">
-                      <constraints>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8ba3-2d08-e2d4-03bb" type="min"/>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="dd5a-4ec1-c159-82bb" type="max"/>
-                      </constraints>
-                    </entryLink>
-                    <entryLink id="90bd-5f1a-cbae-3e4e" name="Fragstorm grenade launcher" hidden="false" collective="false" import="true" targetId="e4c9-be77-2c22-f2f1" type="selectionEntry">
-                      <constraints>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="41fc-6d1d-f6d9-0b53" type="min"/>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e14a-1022-f622-eacd" type="max"/>
-                      </constraints>
-                    </entryLink>
-                  </entryLinks>
-                  <costs>
-                    <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0"/>
-                    <cost name="pts" typeId="points" value="0.0"/>
-                    <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
-                  </costs>
-                </selectionEntry>
-              </selectionEntries>
-              <entryLinks>
-                <entryLink id="517a-3d46-6f23-6058" name="Flamestorm gauntlets" hidden="false" collective="false" import="true" targetId="7b54-8090-d351-0252" type="selectionEntry">
-                  <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1acd-4947-8558-180d" type="max"/>
-                  </constraints>
-                </entryLink>
-              </entryLinks>
-            </selectionEntryGroup>
-          </selectionEntryGroups>
           <costs>
             <cost name="pts" typeId="points" value="21.0"/>
             <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0"/>
@@ -11304,61 +11261,6 @@
           <infoLinks>
             <infoLink id="b2ef-5eee-5aac-7bc2" name="Aggressor Sergeant" hidden="false" targetId="d670-dd1d-c576-2e94" type="profile"/>
           </infoLinks>
-          <selectionEntryGroups>
-            <selectionEntryGroup id="cea0-b554-4aee-66b0" name="Weapons (same as the rest of unit)" hidden="false" collective="true" import="true" defaultSelectionEntryId="2fcd-607e-eb1e-0214">
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4caf-d1a8-35b3-2ce2" type="min"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f2eb-18d0-ac1a-6798" type="max"/>
-              </constraints>
-              <selectionEntries>
-                <selectionEntry id="2fcd-607e-eb1e-0214" name="Auto boltstorm gauntlets and fragstorm grenade launcher" hidden="false" collective="true" import="true" type="upgrade">
-                  <modifiers>
-                    <modifier type="set" field="092b-9293-9fa9-80ef" value="1">
-                      <conditions>
-                        <condition field="selections" scope="c13b-c189-2dad-99e5" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="5fbc-9176-bfb5-0dc6" type="greaterThan"/>
-                      </conditions>
-                    </modifier>
-                  </modifiers>
-                  <constraints>
-                    <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="092b-9293-9fa9-80ef" type="max"/>
-                  </constraints>
-                  <entryLinks>
-                    <entryLink id="6e6f-3b1b-ac64-6928" name="Auto boltstorm gauntlets" hidden="false" collective="false" import="true" targetId="99d2-d806-5ba5-fac9" type="selectionEntry">
-                      <constraints>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d628-b939-4625-8cab" type="min"/>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="30c5-b266-ac8e-4fb3" type="max"/>
-                      </constraints>
-                    </entryLink>
-                    <entryLink id="836e-374d-f479-8b49" name="Fragstorm grenade launcher" hidden="false" collective="false" import="true" targetId="e4c9-be77-2c22-f2f1" type="selectionEntry">
-                      <constraints>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="db6e-2bd5-db81-5b2b" type="min"/>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4b75-7660-afc0-3018" type="max"/>
-                      </constraints>
-                    </entryLink>
-                  </entryLinks>
-                  <costs>
-                    <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0"/>
-                    <cost name="pts" typeId="points" value="0.0"/>
-                    <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
-                  </costs>
-                </selectionEntry>
-              </selectionEntries>
-              <entryLinks>
-                <entryLink id="8b80-5f86-1308-77a7" name="Flamestorm gauntlets" hidden="false" collective="false" import="true" targetId="7b54-8090-d351-0252" type="selectionEntry">
-                  <modifiers>
-                    <modifier type="set" field="d9e3-69a8-eda7-2072" value="1">
-                      <conditions>
-                        <condition field="selections" scope="c13b-c189-2dad-99e5" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7b54-8090-d351-0252" type="greaterThan"/>
-                      </conditions>
-                    </modifier>
-                  </modifiers>
-                  <constraints>
-                    <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d9e3-69a8-eda7-2072" type="max"/>
-                  </constraints>
-                </entryLink>
-              </entryLinks>
-            </selectionEntryGroup>
-          </selectionEntryGroups>
           <costs>
             <cost name="pts" typeId="points" value="21.0"/>
             <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0"/>
@@ -11366,6 +11268,57 @@
           </costs>
         </selectionEntry>
       </selectionEntries>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="218b-9012-5e87-dbb1" name="Weapons" hidden="false" collective="false" import="true" defaultSelectionEntryId="8d54-2b32-bbf6-1317">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" id="1db5-faa8-059a-a903" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" id="b778-4d92-18be-85a0" type="max"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="8d54-2b32-bbf6-1317" name="Auto Boltstorm Gauntlets/Fragstorm Grenade Launcher" hidden="false" collective="false" import="true" type="upgrade">
+              <modifiers>
+                <modifier type="increment" field="points" value="16.0">
+                  <repeats>
+                    <repeat field="selections" scope="c13b-c189-2dad-99e5" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="model" repeats="1" roundUp="false"/>
+                  </repeats>
+                </modifier>
+                <modifier type="decrement" field="points" value="16.0"/>
+              </modifiers>
+              <entryLinks>
+                <entryLink id="b857-a75e-64d9-9a73" name="Auto boltstorm gauntlets" hidden="false" collective="false" import="true" targetId="99d2-d806-5ba5-fac9" type="selectionEntry">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bbaf-05bc-4e44-42cd" type="min"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="02eb-25dd-5c87-0ad7" type="max"/>
+                  </constraints>
+                </entryLink>
+                <entryLink id="b835-615c-c0be-e2ec" name="Fragstorm grenade launcher" hidden="false" collective="false" import="true" targetId="e4c9-be77-2c22-f2f1" type="selectionEntry">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b7d9-8bd3-0eaa-b172" type="min"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5060-3aa1-3f02-fda3" type="max"/>
+                  </constraints>
+                </entryLink>
+              </entryLinks>
+              <costs>
+                <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0"/>
+                <cost name="pts" typeId="points" value="0.0"/>
+                <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+          <entryLinks>
+            <entryLink id="776c-b725-fb25-426c" name="Flamestorm gauntlets" hidden="false" collective="false" import="true" targetId="7b54-8090-d351-0252" type="selectionEntry">
+              <modifiers>
+                <modifier type="increment" field="points" value="14.0">
+                  <repeats>
+                    <repeat field="selections" scope="c13b-c189-2dad-99e5" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="model" repeats="1" roundUp="false"/>
+                  </repeats>
+                </modifier>
+                <modifier type="decrement" field="points" value="14.0"/>
+              </modifiers>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
       <entryLinks>
         <entryLink id="93d0-36d4-2f74-86b0" name="Has Battle Honours" hidden="false" collective="false" import="true" targetId="4763-757f-499f-d998" type="selectionEntry"/>
         <entryLink id="d9ed-0b92-8325-db27" name="Battle Honours" hidden="false" collective="false" import="true" targetId="5518-d0f5-a880-d71c" type="selectionEntryGroup"/>


### PR DESCRIPTION
Fixes https://github.com/BSData/wh40k/issues/7208

This change updates aggressors to use the same weapon selection style as inceptors. Weapons are selected for the unit as a whole, rather than per model. Also removed Shock Assault and ATSKNF from the Aggressor profile, since that's covered by Angels of Death.